### PR TITLE
Add template for go table

### DIFF
--- a/vizro-core/changelog.d/20230906_093501_huong_li_nguyen_add_table_template.md
+++ b/vizro-core/changelog.d/20230906_093501_huong_li_nguyen_add_table_template.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/vizro-core/src/vizro/_themes/_templates/template_dark.py
+++ b/vizro-core/src/vizro/_themes/_templates/template_dark.py
@@ -73,6 +73,25 @@ def create_template_dark() -> Template:
         )
     ]
 
+    template_dark.data.table = [
+        go.Table(
+            header={
+                "fill_color": COLORS["DARK_BG03"],
+                "line_color": COLORS["WHITE_12"],
+                "height": 32,
+                "font": {"color": COLORS["WHITE_85"], "size": 14},
+                "align": "left",
+            },
+            cells={
+                "line_color": COLORS["WHITE_12"],
+                "fill_color": COLORS["DARK_BG03"],
+                "height": 32,
+                "font": {"color": COLORS["WHITE_55"], "size": 14},
+                "align": "left",
+            },
+        )
+    ]
+
     return template_dark
 
 

--- a/vizro-core/src/vizro/_themes/_templates/template_light.py
+++ b/vizro-core/src/vizro/_themes/_templates/template_light.py
@@ -67,9 +67,27 @@ def create_template_light() -> Template:
     }
 
     # CHART TYPES
-
     template_light.data.bar = [
         go.Bar(marker={"line": {"color": template_light["layout"]["paper_bgcolor"], "width": 1}})
+    ]
+
+    template_light.data.table = [
+        go.Table(
+            header={
+                "fill_color": COLORS["Light_BG01"],
+                "line_color": COLORS["BLACK_12"],
+                "height": 32,
+                "font": {"color": COLORS["BLACK_85"], "size": 14},
+                "align": "left",
+            },
+            cells={
+                "line_color": COLORS["BLACK_12"],
+                "fill_color": COLORS["Light_BG01"],
+                "height": 32,
+                "font": {"color": COLORS["BLACK_55"], "size": 14},
+                "align": "left",
+            },
+        )
     ]
 
     return template_light


### PR DESCRIPTION
## Description
- Add template for go table if someone were to use a custom go table (otherwise table will be white on dark theme etc.)

## Screenshot
```
@capture("graph")
def table(data_frame):
    fig = go.Figure(data=[go.Table(header=dict(values=['A Scores', 'B Scores']),
                 cells=dict(values=[[100, 90, 80, 90], [95, 85, 75, 95]]))
                     ])
    return fig
```

![Screenshot 2023-09-05 at 18 10 25](https://github.com/mckinsey/vizro/assets/90609403/b3b55c88-ac1a-42e3-a781-603b5213781e)

## Checklist

- [x] I have not referenced individuals, products or companies in any commits, directly or indirectly
- [x] I have not added data or restricted code in any commits, directly or indirectly
- [x] I have updated the docstring of any public function/class/model changed
- [x] I have added the PR number to the change description in the changelog fragment, e.g. `Enable feature XXX (#123)` (if applicable)

## Types of changes

- [ ] Docs/refactoring (non-breaking change which improves codebase)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
