### PR TITLE
Consolidate tests for action_validator_factory

### DIFF
--- a/vizro-core/changelog.d/20230908_110632_huong_li_nguyen_add_test_action_validator_factory.md
+++ b/vizro-core/changelog.d/20230908_110632_huong_li_nguyen_add_test_action_validator_factory.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/vizro-core/tests/unit/vizro/models/_components/conftest.py
+++ b/vizro-core/tests/unit/vizro/models/_components/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+from vizro.models.types import capture
+
+
+@pytest.fixture
+@capture("action")
+def test_action_function():
+    pass

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_checklist.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_checklist.py
@@ -6,7 +6,10 @@ import pytest
 from dash import dcc, html
 from pydantic import ValidationError
 
+from vizro.models._action._action import Action
+from vizro.models._action._actions_chain import ActionsChain
 from vizro.models._components.form import Checklist
+from vizro.models.types import CapturedCallable
 
 
 @pytest.fixture()
@@ -131,6 +134,19 @@ class TestChecklistInstantiation:
     def test_create_checklist_invalid_value_format(self):
         with pytest.raises(ValidationError, match="value is not a valid list"):
             Checklist(value="A", options=["A", "B", "C"])
+
+    def test_set_action_via_validator(self, test_action_function):
+        checklist = Checklist(actions=[Action(function=test_action_function)])
+        actions_chain = checklist.actions[0]
+        action = actions_chain.actions[0]
+
+        assert len(checklist.actions) == 1
+        assert isinstance(actions_chain, ActionsChain)
+        assert actions_chain.trigger.component_property == "value"
+        assert isinstance(action, Action)
+        assert isinstance(action.function, CapturedCallable)
+        assert action.inputs == []
+        assert action.outputs == []
 
 
 class TestChecklistBuild:

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_dropdown.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_dropdown.py
@@ -6,7 +6,10 @@ import pytest
 from dash import dcc, html
 from pydantic import ValidationError
 
+from vizro.models._action._action import Action
+from vizro.models._action._actions_chain import ActionsChain
 from vizro.models._components.form import Dropdown
+from vizro.models.types import CapturedCallable
 
 
 @pytest.fixture()
@@ -169,6 +172,19 @@ class TestDropdownInstantiation:
     def test_create_dropdown_invalid_multi(self):
         with pytest.raises(ValidationError, match="Please set multi=True if providing a list of default values."):
             Dropdown(value=[1, 2], multi=False, options=[1, 2, 3, 4, 5])
+
+    def test_set_action_via_validator(self, test_action_function):
+        dropdown = Dropdown(actions=[Action(function=test_action_function)])
+        actions_chain = dropdown.actions[0]
+        action = actions_chain.actions[0]
+
+        assert len(dropdown.actions) == 1
+        assert isinstance(actions_chain, ActionsChain)
+        assert actions_chain.trigger.component_property == "value"
+        assert isinstance(action, Action)
+        assert isinstance(action.function, CapturedCallable)
+        assert action.inputs == []
+        assert action.outputs == []
 
 
 class TestDropdownBuild:

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_radioitems.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_radioitems.py
@@ -6,7 +6,10 @@ import pytest
 from dash import dcc, html
 from pydantic import ValidationError
 
+from vizro.models._action._action import Action
+from vizro.models._action._actions_chain import ActionsChain
 from vizro.models._components.form import RadioItems
+from vizro.models.types import CapturedCallable
 
 
 @pytest.fixture()
@@ -131,6 +134,19 @@ class TestRadioItemsInstantiation:
     def test_create_radio_items_invalid_value_format(self):
         with pytest.raises(ValidationError, match="3 validation errors for RadioItems"):
             RadioItems(value=[1], options=[1, 2, 3, 4, 5])
+
+    def test_set_action_via_validator(self, test_action_function):
+        radio_items = RadioItems(actions=[Action(function=test_action_function)])
+        actions_chain = radio_items.actions[0]
+        action = actions_chain.actions[0]
+
+        assert len(radio_items.actions) == 1
+        assert isinstance(actions_chain, ActionsChain)
+        assert actions_chain.trigger.component_property == "value"
+        assert isinstance(action, Action)
+        assert isinstance(action.function, CapturedCallable)
+        assert action.inputs == []
+        assert action.outputs == []
 
 
 class TestRadioItemsBuild:

--- a/vizro-core/tests/unit/vizro/models/_components/test_button.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_button.py
@@ -4,7 +4,9 @@ import pytest
 
 import vizro.models as vm
 from vizro.actions import export_data
+from vizro.models._action._action import Action
 from vizro.models._action._actions_chain import ActionsChain
+from vizro.models.types import CapturedCallable
 
 
 class TestButtonInstantiation:
@@ -28,15 +30,18 @@ class TestButtonInstantiation:
         assert button.text == str(text)
         assert button.actions == []
 
-    def test_create_button_with_one_valid_action(self):
+    def test_set_action_via_validator(self):
         button = vm.Button(actions=[vm.Action(function=export_data())])
-        button_actions_chain = button.actions[0]
-        assert hasattr(button, "id")
-        assert button.type == "button"
-        assert button.text == "Click me!"
+        actions_chain = button.actions[0]
+        action = actions_chain.actions[0]
+
         assert len(button.actions) == 1
-        assert isinstance(button_actions_chain, ActionsChain)
-        assert button_actions_chain.trigger.component_property == "n_clicks"
+        assert isinstance(actions_chain, ActionsChain)
+        assert actions_chain.trigger.component_property == "n_clicks"
+        assert isinstance(action, Action)
+        assert isinstance(action.function, CapturedCallable)
+        assert action.inputs == []
+        assert action.outputs == []
 
 
 class TestBuildMethod:


### PR DESCRIPTION
## Description
- Consolidate tests for `action_validator_factory` after several duplications, see this thread: https://github.com/mckinsey/vizro/pull/14#discussion_r1319517169
- Rewrote already existing test for `Button` to follow same test

Essentially, we shouldn't configure the components with an action function, that doesn't make much sense to be used in that component. It's safer to use a test function such that we can still replicate the behaviour.

## Screenshot

## Checklist

- [x] I have not referenced individuals, products or companies in any commits, directly or indirectly
- [x] I have not added data or restricted code in any commits, directly or indirectly
- [x] I have updated the docstring of any public function/class/model changed
- [ ] I have added the PR number to the change description in the changelog fragment, e.g. `Enable feature XXX (#123)` (if applicable)

## Types of changes

- [x] Docs/refactoring (non-breaking change which improves codebase)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
