### PR TITLE
Move model ID to outer component to enable CSS customization

### DIFF
--- a/vizro-core/src/vizro/models/_components/_form.py
+++ b/vizro-core/src/vizro/models/_components/_form.py
@@ -86,6 +86,7 @@ class Form(VizroBaseModel):
                 "gridTemplateRows": f"repeat({len(self.layout.grid)}, minmax({self.layout.row_min_height}, 1fr))",  # type: ignore[union-attr]  # noqa: E501
             },
             className="component_container_grid",
+            id=self.id,
         )
 
 

--- a/vizro-core/src/vizro/models/_components/button.py
+++ b/vizro-core/src/vizro/models/_components/button.py
@@ -31,9 +31,9 @@ class Button(VizroBaseModel):
             [
                 dbc.Button(
                     children=self.text,
-                    id=self.id,
                     className="button_primary",
                 ),
             ],
             className="button_container",
+            id=self.id,
         )

--- a/vizro-core/src/vizro/models/_components/card.py
+++ b/vizro-core/src/vizro/models/_components/card.py
@@ -29,7 +29,7 @@ class Card(VizroBaseModel):
 
     @_log_call
     def build(self):
-        text = dcc.Markdown(self.text, className="card_text", dangerously_allow_html=False)
+        text = dcc.Markdown(self.text, className="card_text", dangerously_allow_html=False, id=f"{self.id}_text")
         button = (
             html.Div(
                 dbc.Button(

--- a/vizro-core/src/vizro/models/_components/card.py
+++ b/vizro-core/src/vizro/models/_components/card.py
@@ -29,12 +29,11 @@ class Card(VizroBaseModel):
 
     @_log_call
     def build(self):
-        text = dcc.Markdown(self.text, id=f"{self.id}_text", className="card_text", dangerously_allow_html=False)
+        text = dcc.Markdown(self.text, className="card_text", dangerously_allow_html=False)
         button = (
             html.Div(
                 dbc.Button(
                     href=get_relative_path(self.href) if self.href.startswith("/") else self.href,
-                    id=f"{self.id}_button",
                     className="card_button",
                 ),
                 className="button_container",
@@ -44,4 +43,4 @@ class Card(VizroBaseModel):
         )
         card_container = "nav_card_container" if self.href else "card_container"
 
-        return html.Div([text, button], className=card_container)
+        return html.Div([text, button], className=card_container, id=self.id)

--- a/vizro-core/src/vizro/models/_components/form/_user_input.py
+++ b/vizro-core/src/vizro/models/_components/form/_user_input.py
@@ -36,16 +36,15 @@ class UserInput(VizroBaseModel):
     def build(self):
         return html.Div(
             [
-                html.P(self.title, id="user_input_title") if self.title else None,
+                html.P(self.title) if self.title else None,
                 dbc.Input(
-                    id=self.id,
                     placeholder=self.placeholder,
                     type=self.input_type,
-                    className="user_input",
                     persistence=True,
                     debounce=True,
+                    className="user_input",
                 ),
-                html.Div(id="placeholder-for-testing"),
             ],
+            id=self.id,
             className="selector_container",
         )

--- a/vizro-core/src/vizro/models/_components/form/checklist.py
+++ b/vizro-core/src/vizro/models/_components/form/checklist.py
@@ -38,14 +38,14 @@ class Checklist(VizroBaseModel):
 
         return html.Div(
             [
-                html.P(self.title, id="checklist_title") if self.title else None,
+                html.P(self.title) if self.title else None,
                 dcc.Checklist(
-                    id=self.id,
                     options=full_options,
                     value=self.value if self.value is not None else [default_value],
-                    className="selector_body_checklist",
                     persistence=True,
+                    className="selector_body_checklist",
                 ),
             ],
             className="selector_container",
+            id=self.id,
         )

--- a/vizro-core/src/vizro/models/_components/form/dropdown.py
+++ b/vizro-core/src/vizro/models/_components/form/dropdown.py
@@ -51,15 +51,16 @@ class Dropdown(VizroBaseModel):
 
         return html.Div(
             [
-                html.P(self.title, id="dropdown_title") if self.title else None,
+                html.P(self.title) if self.title else None,
                 dcc.Dropdown(
-                    id=self.id,
                     options=full_options,
                     value=self.value if self.value is not None else default_value,
                     multi=self.multi,
                     persistence=True,
                     clearable=False,
+                    className="selector_body_dropdown",
                 ),
             ],
             className="selector_dropdown_container",
+            id=self.id,
         )

--- a/vizro-core/src/vizro/models/_components/form/radio_items.py
+++ b/vizro-core/src/vizro/models/_components/form/radio_items.py
@@ -39,14 +39,14 @@ class RadioItems(VizroBaseModel):
 
         return html.Div(
             [
-                html.P(self.title, id="radio_items_title") if self.title else None,
+                html.P(self.title) if self.title else None,
                 dcc.RadioItems(
-                    id=self.id,
                     options=full_options,
                     value=self.value if self.value is not None else default_value,
-                    className="selector_body_radio_items",
                     persistence=True,
+                    className="selector_body_radio_items",
                 ),
             ],
             className="selector_container",
+            id=self.id,
         )

--- a/vizro-core/src/vizro/models/_components/form/range_slider.py
+++ b/vizro-core/src/vizro/models/_components/form/range_slider.py
@@ -80,45 +80,42 @@ class RangeSlider(VizroBaseModel):
 
         return html.Div(
             [
-                html.P(self.title, id="range_slider_title") if self.title else None,
+                html.P(self.title) if self.title else None,
                 html.Div(
                     [
                         dcc.RangeSlider(
-                            id=self.id,
                             min=self.min,
                             max=self.max,
                             step=self.step,
                             marks=self.marks,
-                            className="range_slider_control" if self.step else "range_slider_control_no_space",
                             value=value,
                             persistence=True,
+                            className="range_slider_control" if self.step else "range_slider_control_no_space",
                         ),
                         html.Div(
                             [
                                 dcc.Input(
-                                    id=f"{self.id}_start_value",
                                     type="number",
                                     placeholder="start",
                                     min=self.min,
                                     max=self.max,
-                                    className="slider_input_field_left"
-                                    if self.step
-                                    else "slider_input_field_no_space_left",
                                     value=value[0],
                                     size="24px",
                                     persistence=True,
+                                    className="slider_input_field_left"
+                                    if self.step
+                                    else "slider_input_field_no_space_left",
                                 ),
                                 dcc.Input(
-                                    id=f"{self.id}_end_value",
                                     type="number",
                                     placeholder="end",
                                     min=self.min,
                                     max=self.max,
+                                    value=value[1],
+                                    persistence=True,
                                     className="slider_input_field_right"
                                     if self.step
                                     else "slider_input_field_no_space_right",
-                                    value=value[1],
-                                    persistence=True,
                                 ),
                                 dcc.Store(id=f"temp-store-range_slider-{self.id}", storage_type="local"),
                             ],
@@ -129,4 +126,5 @@ class RangeSlider(VizroBaseModel):
                 ),
             ],
             className="selector_container",
+            id=self.id,
         )

--- a/vizro-core/src/vizro/models/_components/form/slider.py
+++ b/vizro-core/src/vizro/models/_components/form/slider.py
@@ -70,11 +70,10 @@ class Slider(VizroBaseModel):
 
         return html.Div(
             [
-                html.P(self.title, id="slider_title") if self.title else None,
+                html.P(self.title) if self.title else None,
                 html.Div(
                     [
                         dcc.Slider(
-                            id=self.id,
                             min=self.min,
                             max=self.max,
                             step=self.step,
@@ -85,14 +84,13 @@ class Slider(VizroBaseModel):
                             className="slider_control" if self.step else "slider_control_no_space",
                         ),
                         dcc.Input(
-                            id=f"{self.id}_text_value",
                             type="number",
                             placeholder="end",
                             min=self.min,
                             max=self.max,
-                            className="slider_input_field_right" if self.step else "slider_input_field_no_space_right",
                             value=self.value or self.min,
                             persistence=True,
+                            className="slider_input_field_right" if self.step else "slider_input_field_no_space_right",
                         ),
                         dcc.Store(id=f"temp-store-slider-{self.id}", storage_type="local"),
                     ],
@@ -100,4 +98,5 @@ class Slider(VizroBaseModel):
                 ),
             ],
             className="selector_container",
+            id=self.id,
         )

--- a/vizro-core/src/vizro/models/_navigation/_accordion.py
+++ b/vizro-core/src/vizro/models/_navigation/_accordion.py
@@ -67,13 +67,13 @@ class Accordion(VizroBaseModel):
 
         return html.Div(
             children=dbc.Accordion(
-                id=self.id,
                 children=accordion_items,
                 class_name="accordion",
                 persistence=True,
                 persistence_type="session",
             ),
             className="nav_panel",
+            id=self.id,
         )
 
     def _create_accordion(self):
@@ -90,11 +90,11 @@ class Accordion(VizroBaseModel):
 
         return html.Div(
             children=dbc.Accordion(
-                id=self.id,
                 children=accordion_items,
                 class_name="accordion",
                 persistence=True,
                 persistence_type="session",
             ),
             className="nav_panel",
+            id=self.id,
         )

--- a/vizro-core/src/vizro/models/_page.py
+++ b/vizro-core/src/vizro/models/_page.py
@@ -219,7 +219,7 @@ class Page(VizroBaseModel):
 
     def _make_page_layout(self, controls_content, components_content):
         # Create dashboard containers/elements
-        page_title = html.H2(id="page_title", children=self.title)
+        page_title = html.H2(children=self.title)
         theme_switch = self._create_theme_switch()
         nav_panel = self._create_nav_panel()
         control_panel = self._create_control_panel(controls_content)
@@ -235,7 +235,7 @@ class Page(VizroBaseModel):
         )
 
         return dbc.Container(
-            id=f"page_container_{self.id}",
+            id=self.id,
             children=[dcc.Store(id=f"{ON_PAGE_LOAD_ACTION_PREFIX}_trigger_{self.id}"), left_side, right_side],
             className="page_container",
         )

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_checklist.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_checklist.py
@@ -14,9 +14,8 @@ from vizro.models._components.form import Checklist
 def expected_checklist():
     return html.Div(
         [
-            html.P("Title", id="checklist_title"),
+            html.P("Title"),
             dcc.Checklist(
-                id="checklist_id",
                 options=["ALL", "A", "B", "C"],
                 value=["ALL"],
                 className="selector_body_checklist",
@@ -24,6 +23,7 @@ def expected_checklist():
             ),
         ],
         className="selector_container",
+        id="checklist_id",
     )
 
 

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_dropdown.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_dropdown.py
@@ -14,17 +14,18 @@ from vizro.models._components.form import Dropdown
 def expected_dropdown_with_all():
     return html.Div(
         [
-            html.P("Title", id="dropdown_title"),
+            html.P("Title"),
             dcc.Dropdown(
-                id="dropdown_id",
                 options=["ALL", "A", "B", "C"],
                 value="ALL",
                 multi=True,
                 persistence=True,
                 clearable=False,
+                className="selector_body_dropdown",
             ),
         ],
         className="selector_dropdown_container",
+        id="dropdown_id",
     )
 
 
@@ -32,17 +33,18 @@ def expected_dropdown_with_all():
 def expected_dropdown_without_all():
     return html.Div(
         [
-            html.P("Title", id="dropdown_title"),
+            html.P("Title"),
             dcc.Dropdown(
-                id="dropdown_id",
                 options=["A", "B", "C"],
                 value="A",
                 multi=False,
                 persistence=True,
                 clearable=False,
+                className="selector_body_dropdown",
             ),
         ],
         className="selector_dropdown_container",
+        id="dropdown_id",
     )
 
 

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_radioitems.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_radioitems.py
@@ -14,9 +14,8 @@ from vizro.models._components.form import RadioItems
 def expected_radio_items():
     return html.Div(
         [
-            html.P("Title", id="radio_items_title"),
+            html.P("Title"),
             dcc.RadioItems(
-                id="radio_items_id",
                 options=["A", "B", "C"],
                 value="A",
                 className="selector_body_radio_items",
@@ -24,6 +23,7 @@ def expected_radio_items():
             ),
         ],
         className="selector_container",
+        id="radio_items_id",
     )
 
 

--- a/vizro-core/tests/unit/vizro/models/_components/test_button.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_button.py
@@ -1,9 +1,27 @@
 """Unit tests for vizro.models.Button."""
+import json
+
 import dash_bootstrap_components as dbc
+import plotly
 import pytest
+from dash import html
 
 import vizro.models as vm
 from vizro.actions import export_data
+
+
+@pytest.fixture
+def expected_button():
+    return html.Div(
+        [
+            dbc.Button(
+                children="Click me!",
+                className="button_primary",
+            ),
+        ],
+        className="button_container",
+        id="button-id",
+    )
 
 
 class TestButtonInstantiation:
@@ -34,9 +52,9 @@ class TestButtonInstantiation:
 
 
 class TestBuildMethod:
-    def test_button_build(self):
-        button = vm.Button(id="button_id")
-        component = button.build()
+    def test_button_build(self, expected_button):
+        button = vm.Button(id="button-id", text="Click me!").build()
+        result = json.loads(json.dumps(button, cls=plotly.utils.PlotlyJSONEncoder))
+        expected = json.loads(json.dumps(expected_button, cls=plotly.utils.PlotlyJSONEncoder))
 
-        assert isinstance(component["button_id"], dbc.Button)
-        assert hasattr(component["button_id"], "id")
+        assert result == expected

--- a/vizro-core/tests/unit/vizro/models/_components/test_card.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_card.py
@@ -1,10 +1,27 @@
 """Unit tests for vizro.models.Card."""
+import json
+
 import dash_bootstrap_components as dbc
+import plotly
 import pytest
-from dash import dcc
+from dash import dcc, html
 from pydantic import ValidationError
 
 import vizro.models as vm
+
+
+@pytest.fixture
+def expected_card():
+    text = dcc.Markdown("Hello", className="card_text", dangerously_allow_html=False, id="card_id_text")
+    button = html.Div(
+        dbc.Button(
+            href="https://www.google.com",
+            className="card_button",
+        ),
+        className="button_container",
+    )
+
+    return html.Div([text, button], className="nav_card_container", id="card_id")
 
 
 class TestCardInstantiation:
@@ -39,6 +56,13 @@ class TestCardInstantiation:
 class TestBuildMethod:
     """Tests build method."""
 
+    def test_card_build(self, expected_card):
+        card = vm.Card(text="Hello", id="card_id", href="https://www.google.com")
+        card = card.build()
+        result = json.loads(json.dumps(card, cls=plotly.utils.PlotlyJSONEncoder))
+        expected = json.loads(json.dumps(expected_card, cls=plotly.utils.PlotlyJSONEncoder))
+        assert result == expected
+
     @pytest.mark.parametrize(
         "test_text, expected",
         [
@@ -56,7 +80,7 @@ class TestBuildMethod:
             ("""[Example page](/test_page)""", "[Example page](/test_page)"),
         ],
     )
-    def test_markdown_creation_build(self, test_text, expected):
+    def test_markdown_setting(self, test_text, expected):
         card = vm.Card(text=test_text, id="id_valid")
         card = card.build()
         card_markdown = card["id_valid_text"]
@@ -64,14 +88,6 @@ class TestBuildMethod:
         assert isinstance(card_markdown, dcc.Markdown)
         assert card_markdown.dangerously_allow_html is False
         assert card_markdown.children == expected
-
-    def test_button_creation_build(self, href="https://www.google.de/"):
-        card = vm.Card(text="Test", href=href, id="test_href")
-        card = card.build()
-        button = card["test_href_button"]
-
-        assert isinstance(button, dbc.Button)
-        assert button.href == href
 
     @pytest.mark.parametrize(
         "test_text, expected",

--- a/vizro-core/tests/unit/vizro/models/_navigation/conftest.py
+++ b/vizro-core/tests/unit/vizro/models/_navigation/conftest.py
@@ -46,13 +46,13 @@ def accordion_from_page_as_list():
     ]
     accordion = html.Div(
         children=dbc.Accordion(
-            id="accordion_list",
             children=accordion_items,
             class_name="accordion",
             persistence=True,
             persistence_type="session",
         ),
         className="nav_panel",
+        id="accordion_list",
     )
     return accordion
 
@@ -73,12 +73,12 @@ def accordion_from_pages_as_dict():
     ]
     accordion = html.Div(
         children=dbc.Accordion(
-            id="accordion_dict",
             children=accordion_items,
             class_name="accordion",
             persistence=True,
             persistence_type="session",
         ),
         className="nav_panel",
+        id="accordion_dict",
     )
     return accordion

--- a/vizro-core/tests/unit/vizro/models/_navigation/test_accordion.py
+++ b/vizro-core/tests/unit/vizro/models/_navigation/test_accordion.py
@@ -86,7 +86,7 @@ class TestAccordionBuild:
         expected_navigation = accordion_from_page_as_list
 
         # setting accordion id to fix the random id generation
-        expected_navigation.children.id = id_accordion
+        expected_navigation.id = id_accordion
 
         result = json.loads(json.dumps(result_navigation.build(), cls=plotly.utils.PlotlyJSONEncoder))
         expected = json.loads(json.dumps(expected_navigation, cls=plotly.utils.PlotlyJSONEncoder))

--- a/vizro-core/tests/unit/vizro/models/_navigation/test_navigation.py
+++ b/vizro-core/tests/unit/vizro/models/_navigation/test_navigation.py
@@ -76,7 +76,7 @@ class TestNavigationBuild:
 
         # setting accordion id to fix the random id generation
         result_navigation._selector.id = id_accordion
-        accordion_from_page_as_list.children.id = id_accordion
+        accordion_from_page_as_list.id = id_accordion
 
         result = json.loads(json.dumps(result_navigation.build(), cls=plotly.utils.PlotlyJSONEncoder))
         expected = json.loads(json.dumps(accordion_from_page_as_list, cls=plotly.utils.PlotlyJSONEncoder))


### PR DESCRIPTION
## Description
- Move Model ID to outer component such that we can enable customising CSS of all inner components via CSS selectors

In general we should aim to have the self.id of the relevant model only on the outer component, such that we can target the CSS of all the inner components e.g. to customise the CSS of the `Card(id="my_first_card", ..)`, one could do:

```
#my_first_card.nav_card_container {
  background-color: blue;
}

#my_first_card .card_text h3 {
  color: green;
```

Sometimes it's necessary to deviate from that rule though and provide an ID to one of the inner components as well e.g. when one of the inner components is the output/input of a callback e.g. the Markdown component of the Card currently has its own ID `id=f"{self.id}_text"` to enable updating the Card text via a callback in the future. We shouldn't add the ID in all of the inner components though, let's just do it selectively for now where it makes sense. 

## Screenshot

## Checklist

- [ ] I have not referenced individuals, products or companies in any commits, directly or indirectly
- [ ] I have not added data or restricted code in any commits, directly or indirectly
- [ ] I have updated the docstring of any public function/class/model changed
- [ ] I have added the PR number to the change description in the changelog fragment, e.g. `Enable feature XXX (#123)` (if applicable)

## Types of changes

- [ ] Docs/refactoring (non-breaking change which improves codebase)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
