### PR TITLE
Introduce coverage settings and failure threshold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,22 +12,6 @@ exclude_dirs = ["tests"]
 line-length = 120
 target-version = ["py38"]
 
-[tool.coverage.paths]
-tests = ["tests"]
-vizro = ["src/vizro"]
-
-[tool.coverage.report]
-exclude_lines = [
-  "no cov",
-  "if __name__ == .__main__.:",
-  "if TYPE_CHECKING:"
-]
-
-[tool.coverage.run]
-branch = true
-parallel = true
-source_pkgs = ["vizro", "tests"]
-
 [tool.mypy]
 # strict checks : strict = true
 check_untyped_defs = true

--- a/vizro-core/changelog.d/20230926_113052_maximilian_schulz_introduce_coverage.md
+++ b/vizro-core/changelog.d/20230926_113052_maximilian_schulz_introduce_coverage.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/vizro-core/pyproject.toml
+++ b/vizro-core/pyproject.toml
@@ -48,7 +48,7 @@ Issues = "https://github.com/mckinsey/vizro/issues"
 Source = "https://github.com/mckinsey/vizro"
 
 [tool.coverage.paths]
-source = ["src/vizro"]  # omit tests for clarity, although this can be useful to see what test lines DID NOT run
+vizro = ["src/vizro"]  # omit tests for clarity, although this can be useful to see what test lines DID NOT run
 
 [tool.coverage.report]
 exclude_lines = [

--- a/vizro-core/pyproject.toml
+++ b/vizro-core/pyproject.toml
@@ -46,3 +46,21 @@ kedro = [
 Documentation = "https://github.com/mckinsey/vizro#readme"
 Issues = "https://github.com/mckinsey/vizro/issues"
 Source = "https://github.com/mckinsey/vizro"
+
+[tool.coverage.paths]
+source = ["src/vizro"]  # omit tests for clarity, although this can be useful to see what test lines DID NOT run
+
+[tool.coverage.report]
+exclude_lines = [
+  "no cov",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:"
+]
+fail_under = 90
+show_missing = true
+skip_covered = true
+
+[tool.coverage.run]
+branch = true
+parallel = true
+source_pkgs = ["vizro"]

--- a/vizro-core/pyproject.toml
+++ b/vizro-core/pyproject.toml
@@ -56,7 +56,7 @@ exclude_lines = [
   "if __name__ == .__main__.:",
   "if TYPE_CHECKING:"
 ]
-fail_under = 90
+fail_under = 82
 show_missing = true
 skip_covered = true
 


### PR DESCRIPTION
## Description
- move coverage settings to package `pyproject.toml` (they weren't doing anything before)
- slight adjustments and introduction of minimum coverage
- set minimum coverage to **82%**

**Note**
- Took out tests from coverage, as I personally find it more misleading than helpful, it dilutes the true coverage (83% without tests vs 97% with tests)
However, it was interesting to see that some tests seem to not be executed (when running coverage on test files as well), this needs further investigation (created a ticket)

## Screenshot

## Checklist

- [x] I have not referenced individuals, products or companies in any commits, directly or indirectly
- [x] I have not added data or restricted code in any commits, directly or indirectly
- [x] I have updated the docstring of any public function/class/model changed
- [ ] I have added the PR number to the change description in the changelog fragment, e.g. `Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))` (if applicable)
- [x] I have added tests to cover my changes (if applicable)

## Types of changes

- [x] Docs/refactoring (non-breaking change which improves codebase)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
