### PR TITLE
Remove `left_side` container by default if no content present

### DIFF
--- a/vizro-core/changelog.d/20230926_173346_huong_li_nguyen_remove_left_side.md
+++ b/vizro-core/changelog.d/20230926_173346_huong_li_nguyen_remove_left_side.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+
+### Changed
+
+- Remove `left_side` container by default if there are no elements present ([#68](https://github.com/mckinsey/vizro/pull/68))
+
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/vizro-core/changelog.d/20230926_173346_huong_li_nguyen_remove_left_side.md
+++ b/vizro-core/changelog.d/20230926_173346_huong_li_nguyen_remove_left_side.md
@@ -21,7 +21,6 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 - Remove `left_side` container by default if there are no elements present ([#68](https://github.com/mckinsey/vizro/pull/68))
 
-
 <!--
 ### Deprecated
 

--- a/vizro-core/docs/pages/development/authors.md
+++ b/vizro-core/docs/pages/development/authors.md
@@ -1,19 +1,21 @@
 ## Current team members
 
-[Joseph Perkins](https://github.com/Joseph-Perkins),
-[Dan Dumitriu](https://github.com/dandumitriu1),
-[Antony Milne](https://github.com/antonymilne),
-[Huong Li Nguyen](https://github.com/huong-li-nguyen),
-[Maximilian Schulz](https://github.com/maxschulz-COL),
-[Lingyi Zhang](https://github.com/lingyielia),
-[Alexey Snigir](https://github.com/l0uden),
-[Nadija Graca](https://github.com/nadijagraca),
 [Chiara Pullem](https://github.com/chiara-sophie),
+[Antony Milne](https://github.com/antonymilne),
 [Anna Xiong](https://github.com/AnnaXiongQB),
+[Lingyi Zhang](https://github.com/lingyielia),
+[Nadija Graca](https://github.com/nadijagraca),
 [Petar Pejovic](https://github.com/petar-qb)
+[Alexey Snigir](https://github.com/l0uden),
+[Maximilian Schulz](https://github.com/maxschulz-COL),
+[Huong Li Nguyen](https://github.com/huong-li-nguyen),
+[Dan Dumitriu](https://github.com/dandumitriu1),
+[Joseph Perkins](https://github.com/Joseph-Perkins),
 
 ## Previous team members and code contributors
 
+[Jo Stichbury](https://github.com/stichbury)
+[Juan Luis Cano Rodríguez](https://github.com/astrojuanlu)
 [Denis Lebedev](https://github.com/DenisLebedevMcK),
 [Qiuyi Chen](https://github.com/Qiuyi-Chen),
 [Elena Fridman](https://github.com/EllenWie),

--- a/vizro-core/src/vizro/models/_page.py
+++ b/vizro-core/src/vizro/models/_page.py
@@ -215,10 +215,7 @@ class Page(VizroBaseModel):
             children=header_elements,
             className="header",
         )
-        left_side = html.Div(
-            children=left_side_elements,
-            className="left_side",
-        )
+        left_side = html.Div(children=left_side_elements, className="left_side") if any(left_side_elements) else None
         right_side_elements = [header, component_container]
         right_side = html.Div(
             children=right_side_elements,

--- a/vizro-core/tests/unit/vizro/models/test_page.py
+++ b/vizro-core/tests/unit/vizro/models/test_page.py
@@ -98,6 +98,7 @@ class TestPagePreBuildMethod:
         assert page.actions[0].id == f"{ON_PAGE_LOAD_ACTION_PREFIX}_Page 1"
 
 
+# TODO: Add unit tests for private methods in page build
 class TestPageBuild:
     def test_no_left_side_container(self):
         dashboard_title, nav_panel, control_panel = None, None, None

--- a/vizro-core/tests/unit/vizro/models/test_page.py
+++ b/vizro-core/tests/unit/vizro/models/test_page.py
@@ -1,5 +1,4 @@
 import pytest
-from dash import html
 from pydantic import ValidationError
 
 import vizro.models as vm
@@ -99,9 +98,3 @@ class TestPagePreBuildMethod:
 
 
 # TODO: Add unit tests for private methods in page build
-class TestPageBuild:
-    def test_no_left_side_container(self):
-        dashboard_title, nav_panel, control_panel = None, None, None
-        left_side_elements = [dashboard_title, nav_panel, control_panel]
-        left_side = html.Div(children=left_side_elements, className="left_side") if any(left_side_elements) else None
-        assert left_side is None

--- a/vizro-core/tests/unit/vizro/models/test_page.py
+++ b/vizro-core/tests/unit/vizro/models/test_page.py
@@ -1,4 +1,5 @@
 import pytest
+from dash import html
 from pydantic import ValidationError
 
 import vizro.models as vm
@@ -95,3 +96,11 @@ class TestPagePreBuildMethod:
         assert len(page.actions) == 1
         assert isinstance(page.actions[0], ActionsChain)
         assert page.actions[0].id == f"{ON_PAGE_LOAD_ACTION_PREFIX}_Page 1"
+
+
+class TestPageBuild:
+    def test_no_left_side_container(self):
+        dashboard_title, nav_panel, control_panel = None, None, None
+        left_side_elements = [dashboard_title, nav_panel, control_panel]
+        left_side = html.Div(children=left_side_elements, className="left_side") if any(left_side_elements) else None
+        assert left_side is None


### PR DESCRIPTION
## Description
- Remove left_side container by default if no content present (no dashboard_title, controls, single page)

## Screenshot
Example Code:

```
import os
import vizro.plotly.express as px
from vizro import Vizro
import vizro.models as vm

df = px.data.iris()

page = vm.Page(
    title="My first dashboard",
    components=[
        vm.Graph(id="scatter_chart", figure=px.scatter(df, x="sepal_length", y="petal_width", color="species")),
        vm.Graph(id="hist_chart", figure=px.histogram(df, x="sepal_width", color="species")),
    ],
)

dashboard = vm.Dashboard(pages=[page])

if __name__ == "__main__":
    Vizro._user_assets_folder = os.path.abspath("../assets")
    Vizro().build(dashboard).run()

```
![Screenshot 2023-09-26 at 15 09 44](https://github.com/mckinsey/vizro/assets/90609403/d5d1ef69-dc5d-4597-bf30-ba8d72c22f46)


## Checklist

- [x] I have not referenced individuals, products or companies in any commits, directly or indirectly
- [x] I have not added data or restricted code in any commits, directly or indirectly
- [x] I have updated the docstring of any public function/class/model changed
- [x] I have added the PR number to the change description in the changelog fragment, e.g. `Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))` (if applicable)
- [x] I have added tests to cover my changes (if applicable)

## Types of changes

- [ ] Docs/refactoring (non-breaking change which improves codebase)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
