### PR TITLE
Fix CapturedCallable to work better with kwargs

### DIFF
--- a/vizro-core/changelog.d/20231024_101744_antony.milne_captured_callable.md
+++ b/vizro-core/changelog.d/20231024_101744_antony.milne_captured_callable.md
@@ -31,7 +31,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Fixed
 
-- `CapturedCallable` now handles variadic keywords arguments (`**kwargs`) correctly ([#120](https://github.com/mckinsey/vizro/pull/120))
+- `CapturedCallable` now handles variadic keywords arguments (`**kwargs`) correctly ([#121](https://github.com/mckinsey/vizro/pull/121))
 
 <!--
 ### Security

--- a/vizro-core/changelog.d/20231024_101744_antony.milne_captured_callable.md
+++ b/vizro-core/changelog.d/20231024_101744_antony.milne_captured_callable.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- `CapturedCallable` now handles variadic keywords arguments (`**kwargs`) correctly ([#120](https://github.com/mckinsey/vizro/pull/120))
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/vizro-core/src/vizro/models/types.py
+++ b/vizro-core/src/vizro/models/types.py
@@ -39,6 +39,9 @@ class CapturedCallable:
         """Creates a new CapturedCallable object that will be able to re-run `function`.
 
         Partially binds *args and **kwargs to the function call.
+
+        Raises:
+            ValueError if `function` contains positional-only or variadic positional parameters (*args).
         """
         # It is difficult to get positional-only and variadic positional arguments working at the same time as
         # variadic keyword arguments. Ideally we would do the __call__ as
@@ -201,6 +204,8 @@ class capture:
             # The more difficult case, where we need to still have a valid plotly figure that renders in a notebook.
             # Hence we attach the CapturedCallable as a property instead of returning it directly.
             # TODO: move point of checking that data_frame argument exists earlier on.
+            # TODO: also would be nice to raise errors in CapturedCallable.__init__ at point of function definition
+            #  rather than point of calling if possible.
             @functools.wraps(func)
             def wrapped(*args, **kwargs) -> _DashboardReadyFigure:
                 if "data_frame" not in inspect.signature(func).parameters:

--- a/vizro-core/src/vizro/models/types.py
+++ b/vizro-core/src/vizro/models/types.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import functools
 import inspect
-from copy import deepcopy
 from typing import Any, Dict, List, Literal, Protocol, Union, runtime_checkable
 
 from pydantic import Field, StrictBool
@@ -41,36 +40,68 @@ class CapturedCallable:
 
         Partially binds *args and **kwargs to the function call.
         """
+        # It is difficult to get positional-only and variadic positional arguments working at the same time as
+        # variadic keyword arguments. Ideally we would do the __call__ as
+        # self.__function(*bound_arguments.args, **bound_arguments.kwargs) as in the
+        # Python documentation. This would handle positional-only and variadic positional arguments better but makes
+        # it more difficult to handle variadic keyword arguments due to https://bugs.python.org/issue41745.
+        # Hence we abandon bound_arguments.args and bound_arguments.kwargs in favor of just using
+        # self.__function(**bound_arguments.arguments).
+        parameters = inspect.signature(function).parameters
+        invalid_params = {
+            param.name
+            for param in parameters.values()
+            if param.kind in [inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.VAR_POSITIONAL]
+        }
+
+        if invalid_params:
+            raise ValueError(
+                f"Invalid parameter {', '.join(invalid_params)}. CapturedCallable does not accept functions with "
+                f"positional-only or variadic positional parameters (*args)."
+            )
+
         self.__function = function
-        self.__bound_arguments = inspect.signature(function).bind_partial(*args, **kwargs)
+        self.__arguments = inspect.signature(function).bind_partial(*args, **kwargs).arguments
+
+        # A function can only ever have one variadic keyword parameter. {""} is just here so that var_keyword_param
+        # is always unpacking a one element set.
+        (var_keyword_param,) = {
+            param.name for param in parameters.values() if param.kind == inspect.Parameter.VAR_KEYWORD
+        } or {""}
+
+        # Since we do __call__ as self.__function(**bound_arguments.arguments), we need to restructure the arguments
+        # a bit to put the kwargs in the right place.
+        # For a function with parameter **kwargs this converts self.__arguments = {"kwargs": {"a": 1}} into
+        # self.__arguments = {"a": 1}.
+        if var_keyword_param in self.__arguments:
+            self.__arguments.update(self.__arguments[var_keyword_param])
+            del self.__arguments[var_keyword_param]
 
     def __call__(self, **kwargs):
         """Run the `function` with the initial arguments overridden by **kwargs.
 
         Note *args are not possible here, but you can still override positional arguments using argument name.
         """
-        if not kwargs:
-            return self.__function(*self.__bound_arguments.args, **self.__bound_arguments.kwargs)
-
-        bound_arguments = deepcopy(self.__bound_arguments)
-        bound_arguments.arguments.update(kwargs)
-        # This looks like it should be self.__function(*bound_arguments.args, **bound_arguments.kwargs) as in the
-        # Python documentation, but that leads to problems due to https://bugs.python.org/issue41745.
-        return self.__function(**bound_arguments.arguments)
+        return self.__function(**{**self.__arguments, **kwargs})
 
     def __getitem__(self, arg_name: str):
         """Gets the value of a bound argument."""
-        return self.__bound_arguments.arguments[arg_name]
+        return self.__arguments[arg_name]
 
     def __delitem__(self, arg_name: str):
         """Deletes a bound argument."""
-        del self.__bound_arguments.arguments[arg_name]
+        del self.__arguments[arg_name]
 
     @property
     def _arguments(self):
         # TODO: This is used twice: in _get_parametrized_config and in vm.Action and should be removed when those
         # references are removed.
-        return self.__bound_arguments.arguments
+        return self.__arguments
+
+    # TODO-actions: Find a way how to compare CapturedCallable and function
+    @property
+    def _function(self):
+        return self.__function
 
     @classmethod
     def __get_validators__(cls):
@@ -136,11 +167,6 @@ class CapturedCallable:
             return captured_callable._captured_callable
         else:
             raise ValueError(f"_target_={function_name} must be wrapped in the @capture decorator.")
-
-    # TODO-actions: Find a way how to compare CapturedCallable and function
-    @property
-    def _function(self):
-        return self.__function
 
 
 class capture:
@@ -278,7 +304,8 @@ ComponentType = Annotated[
 NavigationPagesType = Annotated[
     Union[List[str], Dict[str, List[str]]],
     Field(
-        None, description="List of Page IDs or dict mapping of Page IDs and titles (for hierarchical sub-navigation)"
+        None,
+        description="List of Page IDs or dict mapping of Page IDs and titles (for hierarchical sub-navigation)",
     ),
 ]
 """Permissible value types for page attribute. Values are displayed as default."""


### PR DESCRIPTION
## Description

#114 uncovered a bug with `CapturedCallable`. In short, this would work ok:
```
function = lambda **kwargs: kwargs["a"]

CapturedCallable(function)(a=2) # a=2 only provided at runtime
```

And this would not:
```
CapturedCallable(function, a=2)() # a=2 is provided upfront
```

Now they should both work ok.

We have already had a couple of very small bugs that I've known about for a while, where the following sorts of functions do not work with `CapturedCallable`:
1. a function with variadic positional args like `def function(*args)`
2. a function with positional-only arguments like `def function(a, /)`

Fixing the new `**kwargs` bug, which is an important case, makes it much harder to fix these much less important cases, and so I've decided to just not support them at all. There's now an explicit check to make sure no one tries to use `CapturedCallable` with those sorts of functions (very unlikely they'd want to do so anyway).

Tests have been updated to be much more thorough so that we now test every case on all 3 sorts of valid function `positional_or_keyword_function, keyword_only_function, var_keyword_function`.

Thanks to @maxschulz-COL for spotting the bug and for his initial fix which is the basis for this!

## Checklist

- [x] I have not referenced individuals, products or companies in any commits, directly or indirectly
- [x] I have not added data or restricted code in any commits, directly or indirectly
- [x] I have updated the docstring of any public function/class/model changed
- [x] I have added the PR number to the change description in the changelog fragment, e.g. `Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))` (if applicable)
- [x] I have added tests to cover my changes (if applicable)

## Types of changes

- [ ] Docs/refactoring (non-breaking change which improves codebase)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
