### PR TITLE
Tidy changelog and release process

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -107,7 +107,7 @@ jobs:
           cd "${{ needs.check-version.outputs.package_name }}"
           git checkout -b "release/version_bump_next_minor/${formatted_date}"
           hatch version patch,dev
-          hatch run docs:changelog
+          hatch run changelog:add
           hatch run schema
           hatch run lint || hatch run lint
           git config user.email "145135826+vizro-svc@users.noreply.github.com"

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -118,7 +118,3 @@ jobs:
           ./../tools/version-bump.sh mckinsey vizro ${{ secrets.GITHUB_TOKEN }} \
           ${{needs.check-version.outputs.package_name}} \
           ${{needs.check-version.outputs.package_version}} release/version_bump_next_minor/${formatted_date}
-
-# automate merging of this?
-# why need lint here?
-# does github release notes automatically? Why not scriv github-release?

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -118,3 +118,7 @@ jobs:
           ./../tools/version-bump.sh mckinsey vizro ${{ secrets.GITHUB_TOKEN }} \
           ${{needs.check-version.outputs.package_name}} \
           ${{needs.check-version.outputs.package_version}} release/version_bump_next_minor/${formatted_date}
+
+# automate merging of this?
+# why need lint here?
+# does github release notes automatically? Why not scriv github-release?

--- a/.github/workflows/lint-vizro-core.yml
+++ b/.github/workflows/lint-vizro-core.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}  #why?
+          fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/lint-vizro-core.yml
+++ b/.github/workflows/lint-vizro-core.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+          fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}  #why?
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -50,14 +50,11 @@ jobs:
         run: hatch run all.py${{ matrix.python-version }}:schema --check
 
       - name: Check requirements for Snyk are up to date
-        run: |
-          pwd
-          hatch run all.py${{ matrix.python-version }}:update-snyk-requirements --check
+        run: hatch run all.py${{ matrix.python-version }}:update-snyk-requirements --check
 
       - name: Find added changelog fragments
         id: added-files
         run: |
-          pwd
           if ${{ github.event_name == 'pull_request' }}; then
               echo "added_files=$(git diff --name-only --diff-filter=A -r HEAD^1 HEAD -- changelog.d/*.md | xargs)" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/lint-vizro-core.yml
+++ b/.github/workflows/lint-vizro-core.yml
@@ -68,9 +68,9 @@ jobs:
         run: |
           if [ -z "${{ steps.added-files.outputs.added_files }}" ];
           then
-            echo "No changelog fragment .md file within changelog.d was detected.  Run 'hatch run docs:changelog' to create such a fragment.";
+            echo "No changelog fragment .md file within changelog.d was detected.  Run 'hatch run changelog:add' to create such a fragment.";
             echo "If your PR contains changes that should be mentioned in the CHANGELOG in the next release, please uncomment the relevant section in your created fragment and describe the changes to the user."
-            echo "If your changes are not relevant for the CHANGELOG, please save and commit the file as."
+            echo "If your changes are not relevant for the CHANGELOG, please save and commit the file as is."
             exit 1
           else
           echo "${{ steps.added-files.outputs.added_files }} was added - ready to go!";

--- a/vizro-core/changelog.d/20231025_154920_antony.milne_scriv.md
+++ b/vizro-core/changelog.d/20231025_154920_antony.milne_scriv.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/vizro-core/docs/pages/development/contributing.md
+++ b/vizro-core/docs/pages/development/contributing.md
@@ -155,7 +155,7 @@ a changelog fragment has been created in the folder `changelog.d`. This fragment
 You can easily create such a fragment by running
 
 ```bash
-hatch run docs:changelog
+hatch run changelog:add
 ```
 
 Please begin by uncommenting the relevant section(s) you wish to describe. If your PR includes changes that are not relevant to `CHANGELOG.md`, please leave everything commented out. If you are uncertain about what to add or whether to add anything, please refer to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). The rule of thumb should be, if in doubt, or if the user is affected in any way, it should be described in the `CHANGELOG.md`.

--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -8,6 +8,11 @@ matrix.python.features = [
   {value = "kedro", if = ["3.8", "3.9", "3.10"]}
 ]
 
+[envs.changelog]
+dependencies = ["scriv"]
+detached = true
+scripts = {add = "scriv create --add"}
+
 [envs.default]
 dependencies = [
   "devtools[pygments]",
@@ -37,11 +42,6 @@ cov-report = [
 ]
 example = "cd examples/{args:default}; python app.py"
 lint = "SKIP=gitleaks pre-commit run {args} --all-files"
-post-release = [
-  "hatch version patch,dev",
-  "echo 'Raise a PR to bump to the new development version'"
-] # No longer needed?
-
 prep-release = [
   "hatch version release",
   "hatch run changelog:scriv collect --add",
@@ -49,7 +49,7 @@ prep-release = [
   "schema",
   "hatch run lint || hatch run lint",
   "hatch run changelog:add",
-  'echo "Now raise a PR to merge into main with title: Release of vizro-core $(hatch version)"',
+  'echo "Now raise a PR to merge into main with title: Release of vizro-core $(hatch version)"'
 ]
 pypath = "python -c 'import sys; print(sys.executable)'"
 schema = "python schemas/generate.py {args}"
@@ -79,12 +79,6 @@ dependencies = [
 ]
 detached = true
 scripts = {serve = "mkdocs serve"}
-
-[envs.changelog]
-dependencies = ["scriv"]
-detached = true
-scripts = {add = "scriv create --add"}
-
 
 [publish.index]
 disable = true

--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -40,17 +40,19 @@ lint = "SKIP=gitleaks pre-commit run {args} --all-files"
 post-release = [
   "hatch version patch,dev",
   "echo 'Raise a PR to bump to the new development version'"
-]
+] # can it be automated?
+
 prep-release = [
   "hatch version release",
-  "hatch run changelog:scriv collect",
-  "rm -rf schemas/*json",
-  "hatch run schema",
-  "hatch run lint || hatch run lint",
-  "hatch run changelog:add",
-  "echo 'Raise a PR to prepare main for release'"
+  "git checkout -b release/vizro-core/$(hatch version) origin/main",
+  #"hatch run changelog:scriv collect --add",
+#  "rm -rf schemas/*json",
+#  "schema",
+#  "hatch run lint || hatch run lint",  #why?
+#  "hatch run changelog:add",
+  'echo "Now raise a PR to merge into main with title: Release of vizro-core $(hatch version)"',
 ]
-pypath = "hatch run python -c 'import sys; print(sys.executable)'"
+pypath = "python -c 'import sys; print(sys.executable)'"
 schema = "python schemas/generate.py {args}"
 secrets = "pre-commit run gitleaks --all-files"
 test = [

--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -40,16 +40,15 @@ lint = "SKIP=gitleaks pre-commit run {args} --all-files"
 post-release = [
   "hatch version patch,dev",
   "echo 'Raise a PR to bump to the new development version'"
-] # can it be automated?
+] # No longer needed?
 
 prep-release = [
   "hatch version release",
-  "git checkout -b release/vizro-core/$(hatch version) origin/main",
-  #"hatch run changelog:scriv collect --add",
-#  "rm -rf schemas/*json",
-#  "schema",
-#  "hatch run lint || hatch run lint",  #why?
-#  "hatch run changelog:add",
+  "hatch run changelog:scriv collect --add",
+  "rm -rf schemas/*json",
+  "schema",
+  "hatch run lint || hatch run lint",
+  "hatch run changelog:add",
   'echo "Now raise a PR to merge into main with title: Release of vizro-core $(hatch version)"',
 ]
 pypath = "python -c 'import sys; print(sys.executable)'"

--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -83,7 +83,7 @@ scripts = {serve = "mkdocs serve"}
 [envs.changelog]
 dependencies = ["scriv"]
 detached = true
-scripts = {add = "scriv create -add"}
+scripts = {add = "scriv create --add"}
 
 
 [publish.index]

--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -43,11 +43,11 @@ post-release = [
 ]
 prep-release = [
   "hatch version release",
-  "hatch run docs:scriv collect",
+  "hatch run changelog:scriv collect",
   "rm -rf schemas/*json",
   "hatch run schema",
   "hatch run lint || hatch run lint",
-  "hatch run docs:changelog",
+  "hatch run changelog:add",
   "echo 'Raise a PR to prepare main for release'"
 ]
 pypath = "hatch run python -c 'import sys; print(sys.executable)'"
@@ -77,10 +77,13 @@ dependencies = [
   "scriv"
 ]
 detached = true
+scripts = {serve = "mkdocs serve"}
 
-[envs.docs.scripts]
-changelog = "scriv create"
-serve = "mkdocs serve"
+[envs.changelog]
+dependencies = ["scriv"]
+detached = true
+scripts = {add = "scriv create -add"}
+
 
 [publish.index]
 disable = true


### PR DESCRIPTION
## Description

Just some very minor tidying of the changelog and release process.

The only thing that matters here is that the command `hatch run docs:changelog` is now `hatch run changelog:add`. This is due to separating the `scriv` environment into its own new one to make adding to the changelog as quick and easy as possible (e.g. for someone who just correct a typo but doesn't want to install all the docs dependencies).

## Screenshot

## Checklist

- [x] I have not referenced individuals, products or companies in any commits, directly or indirectly
- [x] I have not added data or restricted code in any commits, directly or indirectly
- [ ] I have updated the docstring of any public function/class/model changed
- [ ] I have added the PR number to the change description in the changelog fragment, e.g. `Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))` (if applicable)
- [ ] I have added tests to cover my changes (if applicable)

## Types of changes

- [x] Docs/refactoring (non-breaking change which improves codebase)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
