### PR TITLE
[Spike] Use Flask-Caching for shared caching - prototype 2

### DIFF
--- a/tools/check_package_release.py
+++ b/tools/check_package_release.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
 
         if _check_no_dev_version(package_name, package_version) and _check_no_version_pypi(
             package_name, package_version
-            ):
+        ):
             if new_release:
                 sys.exit("Cannot release two packages at the same time. Please modify your PR.")
             new_release = True

--- a/vizro-core/examples/default/app.py
+++ b/vizro-core/examples/default/app.py
@@ -32,6 +32,7 @@ data_manager["gapminder2"]._cache_arguments = {
 }
 print(f"_cache_arguments: {data_manager['gapminder2']._cache_arguments}")
 
+
 @capture("action")
 def delete_memoized_cache(delete_button_id_n_clicks):
     """Delete one memoized cache."""

--- a/vizro-core/examples/default/app.py
+++ b/vizro-core/examples/default/app.py
@@ -14,12 +14,23 @@ def retrieve_gapminder():
     return px.data.gapminder()
 
 
-data_manager["gapminder"] = retrieve_gapminder
-data_manager["gapminder2"] = retrieve_gapminder
-
 df_gapminder = px.data.gapminder()
 df_gapminder2 = px.data.gapminder()
 
+
+# Options for configuring per-dataset arguments:
+data_manager["gapminder"] = retrieve_gapminder
+print("to update per dataset cache config")
+data_manager["gapminder"]._cache_arguments = {"timeout": 600}
+print(f"_cache_arguments: {data_manager['gapminder']._cache_arguments}")
+
+data_manager["gapminder2"] = retrieve_gapminder
+print("to update per dataset cache config")
+data_manager["gapminder2"]._cache_arguments = {
+    "timeout": 0,
+    # "unless": (lambda: True)
+}
+print(f"_cache_arguments: {data_manager['gapminder2']._cache_arguments}")
 
 @capture("action")
 def delete_memoized_cache(delete_button_id_n_clicks):
@@ -147,18 +158,3 @@ if __name__ == "__main__":
     #     processes=3,
     #     dev_tools_hot_reload=False
     # )
-
-# Options for configuring per-dataset arguments:
-# 1.
-data_manager["iris"] = lambda: pd.DataFrame()
-data_manager["iris"].set_cache(timeout=50)
-
-
-# 2.
-class VizroDataSet:
-    pass
-
-
-data_manager["iris"] = VizroDataSet(lambda: pd.DataFrame(), timeout=50)
-
-# 3.

--- a/vizro-core/examples/default/app.py
+++ b/vizro-core/examples/default/app.py
@@ -1,5 +1,6 @@
 """Example to show dashboard configuration."""
 import os
+import pandas as pd
 
 import vizro.models as vm
 import vizro.plotly.express as px
@@ -146,3 +147,18 @@ if __name__ == "__main__":
     #     processes=3,
     #     dev_tools_hot_reload=False
     # )
+
+# Options for configuring per-dataset arguments:
+# 1.
+data_manager["iris"] = lambda: pd.DataFrame()
+data_manager["iris"].set_cache(timeout=50)
+
+
+# 2.
+class VizroDataSet:
+    pass
+
+
+data_manager["iris"] = VizroDataSet(lambda: pd.DataFrame(), timeout=50)
+
+# 3.

--- a/vizro-core/examples/default/app.py
+++ b/vizro-core/examples/default/app.py
@@ -1,6 +1,5 @@
 """Example to show dashboard configuration."""
 import os
-import pandas as pd
 
 import vizro.models as vm
 import vizro.plotly.express as px

--- a/vizro-core/examples/default/app.py
+++ b/vizro-core/examples/default/app.py
@@ -36,14 +36,14 @@ print(f"_cache_arguments: {data_manager['gapminder2']._cache_arguments}")
 def delete_memoized_cache(delete_button_id_n_clicks):
     """Delete one memoized cache."""
     if delete_button_id_n_clicks:
-        data_manager._cache.delete_memoized(data_manager._get_original_data, data_manager, "gapminder")
+        data_manager.cache.delete_memoized(data_manager._get_original_data, data_manager, "gapminder")
 
 
 @capture("action")
 def empty_cache(empty_button_id_n_clicks):
     """Empty the entire cache."""
     if empty_button_id_n_clicks:
-        data_manager._cache.cache.clear()
+        data_manager.cache.cache.clear()
 
 
 page = vm.Page(
@@ -147,7 +147,7 @@ if __name__ == "__main__":
     #     "CACHE_THRESHOLD": 20,  # The maximum number of items the cache can hold
     #     "CACHE_DEFAULT_TIMEOUT": 3000,  # Unit of time is seconds
     # }
-    data_manager._cache.config = {
+    data_manager.cache.config = {
         "CACHE_TYPE": "RedisCache",
         "CACHE_REDIS_URL": "redis://localhost:6379/0",
         "CACHE_DEFAULT_TIMEOUT": 60,

--- a/vizro-core/examples/default/test.py
+++ b/vizro-core/examples/default/test.py
@@ -1,4 +1,5 @@
 """Example to show dashboard configuration."""
+import logging
 import os
 
 from flask_caching import Cache
@@ -8,8 +9,6 @@ import vizro.plotly.express as px
 from vizro import Vizro
 from vizro.managers import data_manager
 from vizro.models.types import capture
-
-import logging
 
 log = logging.getLogger("werkzeug")
 log.setLevel(logging.ERROR)

--- a/vizro-core/examples/default/test.py
+++ b/vizro-core/examples/default/test.py
@@ -9,6 +9,11 @@ from vizro import Vizro
 from vizro.managers import data_manager
 from vizro.models.types import capture
 
+import logging
+
+log = logging.getLogger("werkzeug")
+log.setLevel(logging.ERROR)
+
 
 def retrieve_gapminder():
     """This is a function that returns gapminder data."""
@@ -29,6 +34,8 @@ data_manager["gapminder_fast_expire"] = retrieve_gapminder
 data_manager["gapminder_fast_expire"]._timeout = 5
 
 data_manager._cache = Cache(config={"CACHE_TYPE": "SimpleCache", "CACHE_DEFAULT_TIMEOUT": 20})
+# data_manager._cache = Cache(config={"CACHE_TYPE": "FileSystemCache", "CACHE_DIR": "cache", "CACHE_DEFAULT_TIMEOUT":
+# 20})
 
 
 @capture("action")

--- a/vizro-core/examples/default/test.py
+++ b/vizro-core/examples/default/test.py
@@ -1,0 +1,111 @@
+"""Example to show dashboard configuration."""
+import os
+import pandas as pd
+from flask_caching import Cache
+
+import vizro.models as vm
+import vizro.plotly.express as px
+from vizro import Vizro
+from vizro.managers import data_manager
+from vizro.models.types import capture
+
+
+def retrieve_gapminder():
+    """This is a function that returns gapminder data."""
+    return px.data.gapminder()
+
+
+df_gapminder = px.data.gapminder()
+df_gapminder2 = px.data.gapminder()
+
+
+# Options for configuring per-dataset arguments:
+data_manager["gapminder_no_expire"] = retrieve_gapminder
+data_manager["gapminder_no_expire"]._timeout = 0
+
+data_manager["gapminder_default_expire"] = retrieve_gapminder
+
+data_manager["gapminder_fast_expire"] = retrieve_gapminder
+data_manager["gapminder_fast_expire"]._timeout = 5
+
+data_manager._cache = Cache(config={"CACHE_TYPE": "SimpleCache", "CACHE_DEFAULT_TIMEOUT": 20})
+
+
+@capture("action")
+def refresh():
+    data_manager["gapminder_default_expire"].refresh()
+
+
+page = vm.Page(
+    title="test_page",
+    components=[
+        vm.Graph(
+            figure=px.box(
+                "gapminder_no_expire",
+                x="continent",
+                y="lifeExp",
+                color="continent",
+                title="Distribution per continent",
+            ),
+        ),
+        vm.Graph(
+            figure=px.box(
+                "gapminder_default_expire",
+                x="continent",
+                y="lifeExp",
+                color="continent",
+                title="Distribution per continent",
+            ),
+        ),
+        vm.Graph(
+            figure=px.box(
+                "gapminder_fast_expire",
+                x="continent",
+                y="lifeExp",
+                color="continent",
+                title="Distribution per continent",
+            ),
+        ),
+        vm.Button(actions=[vm.Action(function=refresh())]),
+    ],
+)
+dashboard = vm.Dashboard(pages=[page])
+
+# ### when launching with gunicorn ###
+# Vizro._user_assets_folder = os.path.abspath("../assets")
+# data_manager._cache.config = {
+#     "CACHE_TYPE": "FileSystemCache",
+#     "CACHE_DIR": "cache",
+#     "CACHE_THRESHOLD": 20,  # The maximum number of items the cache can hold
+#     "CACHE_DEFAULT_TIMEOUT": 3000,  # Unit of time is seconds
+# }
+# data_manager._cache.config = {
+#     "CACHE_TYPE": "RedisCache",
+#     "CACHE_REDIS_URL": "redis://localhost:6379/0",
+#     "CACHE_DEFAULT_TIMEOUT": 120,
+# }
+# app = Vizro()
+# app.build(dashboard)
+# server = app.dash.server
+# ### when launching with gunicorn ###
+app = Vizro().build(dashboard)
+server = app.dash.server
+if __name__ == "__main__":
+    Vizro._user_assets_folder = os.path.abspath("../assets")
+    # data_manager._cache.config = {
+    #     "CACHE_TYPE": "FileSystemCache",
+    #     "CACHE_DIR": "cache",
+    #     "CACHE_THRESHOLD": 20,  # The maximum number of items the cache can hold
+    #     "CACHE_DEFAULT_TIMEOUT": 3000,  # Unit of time is seconds
+    # }
+    # data_manager._cache.config = {
+    #     "CACHE_TYPE": "RedisCache",
+    #     "CACHE_REDIS_URL": "redis://localhost:6379/0",
+    #     "CACHE_DEFAULT_TIMEOUT": 60,
+    app.run(processes=2, threaded=False)
+    # app.run()
+    # Vizro().build(dashboard).run(
+    #     threaded=False,
+    #     processes=3,
+    #     dev_tools_hot_reload=False
+    # )

--- a/vizro-core/examples/default/test.py
+++ b/vizro-core/examples/default/test.py
@@ -1,6 +1,6 @@
 """Example to show dashboard configuration."""
 import os
-import pandas as pd
+
 from flask_caching import Cache
 
 import vizro.models as vm

--- a/vizro-core/examples/default/test.py
+++ b/vizro-core/examples/default/test.py
@@ -33,7 +33,7 @@ data_manager["gapminder_default_expire"] = retrieve_gapminder
 data_manager["gapminder_fast_expire"] = retrieve_gapminder
 data_manager["gapminder_fast_expire"]._timeout = 5
 
-data_manager._cache = Cache(config={"CACHE_TYPE": "SimpleCache", "CACHE_DEFAULT_TIMEOUT": 20})
+data_manager.cache = Cache(config={"CACHE_TYPE": "SimpleCache", "CACHE_DEFAULT_TIMEOUT": 20})
 # data_manager._cache = Cache(config={"CACHE_TYPE": "FileSystemCache", "CACHE_DIR": "cache", "CACHE_DEFAULT_TIMEOUT":
 # 20})
 

--- a/vizro-core/src/vizro/_vizro.py
+++ b/vizro-core/src/vizro/_vizro.py
@@ -35,6 +35,8 @@ class Vizro:
             """Serve vizro static contents."""
             return flask.send_from_directory(self._lib_assets_folder, filepath)
 
+        data_manager._init_cache(self.dash.server)
+
     def build(self, dashboard: Dashboard):
         """Builds the dashboard.
 
@@ -44,7 +46,7 @@ class Vizro:
         Returns:
             Vizro: App object
         """
-        data_manager._init_cache(self.dash.server)
+
         # Note that model instantiation and pre_build are independent of Dash.
         self._pre_build()
 

--- a/vizro-core/src/vizro/_vizro.py
+++ b/vizro-core/src/vizro/_vizro.py
@@ -44,7 +44,7 @@ class Vizro:
         Returns:
             Vizro: App object
         """
-        data_manager._cache.init_app(self.dash.server)
+        data_manager._init_cache(self.dash.server)
         # Note that model instantiation and pre_build are independent of Dash.
         self._pre_build()
 

--- a/vizro-core/src/vizro/_vizro.py
+++ b/vizro-core/src/vizro/_vizro.py
@@ -35,7 +35,7 @@ class Vizro:
             """Serve vizro static contents."""
             return flask.send_from_directory(self._lib_assets_folder, filepath)
 
-        data_manager._init_cache(self.dash.server)
+        data_manager._cache.init_app(self.dash.server)
 
     def build(self, dashboard: Dashboard):
         """Builds the dashboard.

--- a/vizro-core/src/vizro/_vizro.py
+++ b/vizro-core/src/vizro/_vizro.py
@@ -46,7 +46,6 @@ class Vizro:
         Returns:
             Vizro: App object
         """
-
         # Note that model instantiation and pre_build are independent of Dash.
         self._pre_build()
 

--- a/vizro-core/src/vizro/integrations/kedro/_data_manager.py
+++ b/vizro-core/src/vizro/integrations/kedro/_data_manager.py
@@ -5,7 +5,7 @@ from kedro.framework.session import KedroSession
 from kedro.framework.startup import bootstrap_project
 from kedro.io import DataCatalog
 
-from vizro.managers._data_manager import pd_LazyDataFrame
+from vizro.managers._data_manager import pd_DataFrameCallable
 
 
 def catalog_from_project(
@@ -18,7 +18,7 @@ def catalog_from_project(
         return session.load_context().catalog
 
 
-def datasets_from_catalog(catalog: DataCatalog) -> Dict[str, pd_LazyDataFrame]:
+def datasets_from_catalog(catalog: DataCatalog) -> Dict[str, pd_DataFrameCallable]:
     datasets = {}
     for name in catalog.list():
         dataset = catalog._get_dataset(name, suggest=False)

--- a/vizro-core/src/vizro/managers/_data_manager.py
+++ b/vizro-core/src/vizro/managers/_data_manager.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import logging
 from typing import Callable, Dict, Optional, Union
 
-import flask
 import pandas as pd
 from flask_caching import Cache
 
@@ -238,7 +237,7 @@ class DataManager:
         if component_id not in self.__component_to_dataset:
             raise KeyError(f"Component {component_id} does not exist. You need to call add_component first.")
         dataset_name = self.__component_to_dataset[component_id]
-        logger.debug(f"Loading dataset %s with id %s", dataset_name, id(self[dataset_name]))
+        logger.debug("Loading dataset %s with id %s", dataset_name, id(self[dataset_name]))
         return self[dataset_name].load()
 
     # TODO: we should be able to remove this soon. Try to avoid using it.

--- a/vizro-core/src/vizro/managers/_data_manager.py
+++ b/vizro-core/src/vizro/managers/_data_manager.py
@@ -1,6 +1,5 @@
 """The data manager handles access to all DataFrames used in a Vizro app."""
 import logging
-import time
 from typing import Callable, Dict, Optional, Union
 
 import flask

--- a/vizro-core/src/vizro/managers/_data_manager.py
+++ b/vizro-core/src/vizro/managers/_data_manager.py
@@ -23,7 +23,7 @@ pd_LazyDataFrame = Callable[[], pd.DataFrame]
 
 
 # TODO: test, idea 2 (see shelf), think about preload and automatically named datasets, whether we still need
-#  components to dataset mapping
+#  components to dataset mapping, want _cache in DM and _Dataset and timeout also? Call _cache_timeout?
 
 
 class _Dataset:
@@ -55,6 +55,8 @@ class _Dataset:
         # Since the function is labelled by the unique self._name, there's no need to include self in the arguments.
         # Doing so would be ok but means also defining a __caching_id__ = self._name property for _Dataset so that
         # Flask Caching does not fall back on __repr__ to identify the _Dataset instance, which is risky.
+        # Another option would be to use cached rather than memoize, but that is generally intended only for use
+        # during a request, and we want to call _load_data during the build stage, not just at run time.
         @self._cache.memoize(timeout=self._timeout)
         def _load_data():
             logger.debug("Cache for dataset %s not found; reloading data", self._name)

--- a/vizro-core/src/vizro/managers/_data_manager.py
+++ b/vizro-core/src/vizro/managers/_data_manager.py
@@ -20,12 +20,23 @@ pd_LazyDataFrame = Callable[[], pd.DataFrame]
 # don't want this for now but might have in future.
 # how to turn cache off? For now just specify nullcache. Maybe in future have _dataset._cache = False as shortcut for
 # this. Implementation could be using unless or nullcache or if conditional.
-# If want to turn cache off for one dataset, basically just set low timeout
-# timeout=0 means it never expires
+# If want to turn cache off for one dataset, basically just set low timeout for now?
+# timeout=0 means it never expires. 0 means cache forever and never refresh -> never re-run function.
+# Ones set with timeout=0 can still be manually refreshed with forced_update.
 
+# TODO: test, idea 2 (see shelf)
+#  whether we still need  components to dataset mapping - we don't but save this for future PR. Put mapping to
+#  dataset in callable model itself. So it's still one DS to many components but no need to store mapping here.
+#  Call it _cache_timeout? Only if might have cache_update etc. in future. Think about refresh_cache function
 
-# TODO: test, idea 2 (see shelf), think about preload and automatically named datasets, whether we still need
-#  components to dataset mapping, want _cache in DM and _Dataset and timeout also? Call _cache_timeout?
+# Try out callable with parametrised args
+
+# How to actually update/invalidate/reset cache on demand? rather than just waiting for timeout.
+# Use forced_update as in shelf "This is how to refresh cache for one dataset"
+
+# Note limitation than you need to set preload
+
+# Remove _name - just there for debugging purposes
 
 
 class _Dataset:
@@ -34,39 +45,71 @@ class _Dataset:
         # timeout will probably become public in future.
         self._timeout: Optional[int] = None
         # self._cache is the same for all datasets and is just the data_manager._cache. Only one global cache for now.
+        # TODO: just call data_manager._cache directly?
         self._cache: Optional[Cache] = None
         # name should never become public since it's taken from the key in data_manager.
-        # This scheme seems ugly - is there a better way?
+        # This scheme seems ugly - is there a better way? Yes - just use id(self). self._name is only here for
+        # debugging.
         self._name: str = ""
-
         # We might also want a _cache_arguments dictionary in future that allows user to customise more than just
         # timeout, but no rush to do this.
 
     def __call__(self) -> pd.DataFrame:
         # In future this will probably take arguments that are passed through to _load_data in order to re-run the
         # loading function with different arguments. We might want to use CapturedCallable for self.__load_data then.
-        logger.debug("Calling dataset %s", self._name)
+        logger.debug("** Calling dataset %s", self._name)
 
         # memoize is designed to apply the same timeout setting to every call of the function, but we want to
-        # have a dataset-dependent timeout in the same cache. The only way to do this is to alter the function qualname
-        # used in flask_caching.utils.function_namespace so that each _Dataset instance has a different cache for
-        # load_data.
+        # have a dataset-dependent timeout in the same cache. The only way to do this is to write a closure and alter
+        # the function qualname used in flask_caching.utils.function_namespace so that each _Dataset instance has a
+        # different cache for load_data.
         # The following things *do not* work to achieve the same thing - there will still be interference between
         # different load_data caches:
         # * altering load_data.cache_timeout
         # * using make_name argument (since this is only applied after function_namespace is called)
         # * including self or self._name in the load_data arguments
-        # Since the function is labelled by the unique self._name, there's no need to include self in the arguments.
-        # Doing so would be ok but means also defining a __caching_id__ = self._name property for _Dataset so that
-        # Flask Caching does not fall back on __repr__ to identify the _Dataset instance, which is risky.
+        # * whenever function_namespace recognise the memoized function as a bound method (even when __caching_id__ is
+        # defined so that Flask Caching does not fall back on __repr__ which is risky)
         # Another option would be to use cached rather than memoize, but that is generally intended only for use
         # during a request, and we want to call _load_data during the build stage, not just at run time.
+
+        # HERE: maybe doing as bound method and/or using data_manager._cache rather than self._cache was actually ok and
+        # it just didn't work properly because had multiple processes with SimpleCache?
+        #
+        # With flask.run and multiple processes:
+        #  - FileSystemCache: Get lots of different processes but works ok
+        #  - SimpleCache: Get lots of different processes and doesn't work ok - get interference. Put warning in
+        #  place to prevent this.
+        # When use gunicorn with two processes:
+        #   - FileSystemCache: get initial process for loading data and then boots two processes and just uses those from then on.
+        #   Cache works correctly.
+        #  - SimpleCache: same number of processes. Cache works sort of correctly - don't have interference,
+        #    but cache not being shared between processes, as expected.
+
+        # SimpleCache: Simple memory cache for single process environments. This class exists mainly for the
+        # development server and is not 100% thread safe.
+        # As soon as move to gunicorn, need to setup proper cache -> yes. SimpleCache still works ok but not memory
+        # efficient.
+        # Note threaded=True by default with run and probably shouldn't change that (?). And SimpleCache not 100%
+        # thread-safe.
+        # Problem with cache not shard between workers while running is not just inefficiency but that invalidating
+        # cache will not work properly.
+        # But NullCache would probably be too slow as default.
+        # Use SimpleCache with no timeout as default?
+
+        # What should default cache be?
+        # Check preload and non-preload behaviour
+        # Clear up debugging messaging and go through above again.
+        import os
+
+        logger.debug(f"{self._name=}\t{id(self)}\t{os.getpid()=}")
+
         @self._cache.memoize(timeout=self._timeout)
         def _load_data():
-            logger.debug("Cache for dataset %s not found; reloading data", self._name)
+            logger.debug("** Cache for dataset %s not found; reloading data", self._name)
             return self.__load_data()
 
-        _load_data.uncached.__qualname__ += f"__{self._name}"
+        _load_data.uncached.__qualname__ += f"__{id(self)}"
         return _load_data()
 
 
@@ -79,6 +122,19 @@ class _Dataset:
 #         >>> data_manager["iris"] = pd.DataFrame()
 #         >>> data_manager["iris"]._cache_arguments = {"timeout": 600}
 #     """
+# Old notes:
+# # Options for configuring per-dataset arguments:
+# # 1.
+# data_manager["iris"] = lambda: pd.DataFrame()
+# data_manager["iris"].set_cache(timeout=50)
+#
+#
+# # 2.
+# class VizroDataSet:
+#     pass
+#
+#
+# data_manager["iris"] = VizroDataSet(lambda: pd.DataFrame(), timeout=50)
 
 
 class DataManager:
@@ -97,6 +153,7 @@ class DataManager:
         self.__component_to_original: Dict[ComponentID, DatasetName] = {}
         self._frozen_state = False
         self._cache = Cache(config={"CACHE_TYPE": "SimpleCache"})
+        # Note possibility of accepting just config dict in future
 
     # AM: consider if this should also call the lazy data to populate the cache? Probably doesn't matter.
     # Probably not because then it would load up all data even in not used.
@@ -162,6 +219,7 @@ class DataManager:
 
     def _init_cache(self, app: flask.Flask):
         """Sets the default cache for all datasets to be the same as the data_manager cache and initializes cache."""
+        # Need to inject it here rather than in setitem so that you can set cache *after* adding things to DM
         for dataset in self.__lazy_data.values():
             dataset._cache = self._cache
         self._cache.init_app(app)
@@ -177,6 +235,7 @@ class DataManager:
             return False
 
     def _clear(self):
+        # CLEAR CACHE?
         self.__init__()  # type: ignore[misc]
 
 

--- a/vizro-core/src/vizro/managers/_data_manager.py
+++ b/vizro-core/src/vizro/managers/_data_manager.py
@@ -22,6 +22,10 @@ pd_LazyDataFrame = Callable[[], pd.DataFrame]
 # this. Implementation could be using unless or nullcache or if conditional.
 
 
+# TODO: test, idea 2 (see shelf), think about preload and automatically named datasets, whether we still need
+#  components to dataset mapping
+
+
 class _Dataset:
     def __init__(self, load_data: pd_LazyDataFrame, /):
         self.__load_data: pd_LazyDataFrame = load_data

--- a/vizro-core/src/vizro/managers/_data_manager.py
+++ b/vizro-core/src/vizro/managers/_data_manager.py
@@ -29,8 +29,7 @@ class DataManager:
 
     def __init__(self):
         self.__lazy_data: Dict[DatasetName, pd_LazyDataFrame] = {}
-        self.__original_data: Dict[DatasetName, pd.DataFrame] = {}
-        self.__component_to_original: Dict[ComponentID, DatasetName] = {}
+        self.__component_to_lazy: Dict[ComponentID, DatasetName] = {}
         self._frozen_state = False
 
     # happens before dashboard build
@@ -41,13 +40,13 @@ class DataManager:
         This is the only user-facing function when configuring a simple dashboard. Others are only used internally
         in Vizro or advanced users who write their own actions.
         """
-        if dataset_name in self.__original_data or dataset_name in self.__lazy_data:
+        if dataset_name in self.__lazy_data:
             raise ValueError(f"Dataset {dataset_name} already exists.")
 
         if callable(data):
             self.__lazy_data[dataset_name] = data
         elif isinstance(data, pd.DataFrame):
-            self.__original_data[dataset_name] = data
+            self.__lazy_data[dataset_name] = lambda: data
         else:
             raise TypeError(
                 f"Dataset {dataset_name} must be a pandas DataFrame or callable that returns pandas DataFrame."
@@ -57,16 +56,16 @@ class DataManager:
     @_state_modifier
     def _add_component(self, component_id: ComponentID, dataset_name: DatasetName):
         """Adds a mapping from `component_id` to `dataset_name`."""
-        if dataset_name not in self.__original_data and dataset_name not in self.__lazy_data:
+        if dataset_name not in self.__lazy_data:
             raise KeyError(f"Dataset {dataset_name} does not exist.")
-        if component_id in self.__component_to_original:
+        if component_id in self.__component_to_lazy:
             raise ValueError(
                 f"Component with id={component_id} already exists and is mapped to dataset "
-                f"{self.__component_to_original[component_id]}. Components must uniquely map to a dataset across the "
+                f"{self.__component_to_lazy[component_id]}. Components must uniquely map to a dataset across the "
                 f"whole dashboard. If you are working from a Jupyter Notebook, please either restart the kernel, or "
                 f"use 'from vizro import Vizro; Vizro._reset()`."
             )
-        self.__component_to_original[component_id] = dataset_name
+        self.__component_to_lazy[component_id] = dataset_name
 
     @_cache.memoize()
     def _load_lazy_data(self, dataset_name: DatasetName) -> pd.DataFrame:
@@ -78,16 +77,15 @@ class DataManager:
     def _get_component_data(self, component_id: ComponentID) -> pd.DataFrame:
         """Returns the original data for `component_id`."""
         logger.debug("get_component_data: %s", component_id)
-        if component_id not in self.__component_to_original:
+        if component_id not in self.__component_to_lazy:
             raise KeyError(f"Component {component_id} does not exist. You need to call add_component first.")
-        dataset_name = self.__component_to_original[component_id]
+        dataset_name = self.__component_to_lazy[component_id]
 
-        if dataset_name in self.__lazy_data:
-            return self._load_lazy_data(dataset_name)
-        else:  # dataset_name is in self.__original_data
-            # Return a copy so that the original data cannot be modified. This is not necessary if we are careful
-            # to not do any inplace=True operations, but probably safest to leave it here.
-            return self.__original_data[dataset_name].copy()
+        return self._load_lazy_data(dataset_name)
+        # else:  # dataset_name is in self.__original_data
+        #     # Return a copy so that the original data cannot be modified. This is not necessary if we are careful
+        #     # to not do any inplace=True operations, but probably safest to leave it here.
+        #     return self.__original_data[dataset_name].copy()
 
     def _has_registered_data(self, component_id: ComponentID) -> bool:
         try:

--- a/vizro-core/src/vizro/managers/_data_manager.py
+++ b/vizro-core/src/vizro/managers/_data_manager.py
@@ -18,6 +18,8 @@ pd_LazyDataFrame = Callable[[], pd.DataFrame]
 
 # _caches = {"simple": Cache(config={"CACHE_TYPE": "SimpleCache"}), "null": Cache(config={"CACHE_TYPE": "NullCache"})}
 # don't want this for now but might have in future.
+# how to turn cache off? For now just specify nullcache. Maybe in future have _dataset._cache = False as shortcut for
+# this. Implementation could be using unless or nullcache or if conditional.
 
 
 class _Dataset:
@@ -29,9 +31,8 @@ class _Dataset:
         # name should never become public since it's taken from the key in data_manager.
         self._name: str = ""
 
-    @property
-    def _cache_arguments(self):
-        return {"timeout": self._timeout}
+        # We might also want a _cache_arguments dictionary in future that allows user to customise more than just
+        # timeout, but no rush to do this.
 
     def __call__(self) -> pd.DataFrame:
         # In future this will probably take arguments that are passed through to _load_data in order to re-run the
@@ -50,7 +51,7 @@ class _Dataset:
         # Since the function is labelled by the unique self._name, there's no need to include self in the arguments.
         # Doing so would be ok but means also defining a __caching_id__ = self._name property for _Dataset so that
         # Flask Caching does not fall back on __repr__ to identify the _Dataset instance, which is risky.
-        @self._cache.memoize(**self._cache_arguments)
+        @self._cache.memoize(timeout=self._timeout)
         def _load_data():
             logger.debug("Cache for dataset %s not found; reloading data", self._name)
             return self.__load_data()


### PR DESCRIPTION
## Description

A couple of schemes that could simplify our caching solution. There's two commits here showing slightly different things:

### Idea 1: https://github.com/mckinsey/vizro/pull/133/commits/843c8130eace126f6241f7c15663d4392a8ce914

If we have lazy data then it bypasses `original_data` entirely. This removes the original behaviour that's in `main` that lazy data is only loaded on first access. This means that there's only one caching mechanism which is the "proper" flask-caching one. Hence there's no need to clear up original data afterwards. If a dataframe is originally set as `original_data` then there's no caching and there's a copy of the data on each worker still - it's just lazy data that is treated differently here.

### Idea 2: https://github.com/mckinsey/vizro/pull/133/commits/8b7aeb8c83726c181568c89bacd9994d1ae108da

Building on the last commit: can we simplify further and just treat both `original_data` and `lazy_data` as a single paradigm? I convert something that is a `pd.DataFrame` into a callable that returns a `pd.DataFrame` just by sticking `lambda` in front of it. Hence after that point there's no distinction between lazy vs. original data which simplifies things even more.

---

At a glance, idea 1 here seems like an improvement on #116. Not sure whether/how idea 2 would work but it may be better still - needs some more thought though.

As it stands, there's no way to configure the caching on a per-dataset basis. So by default there are two options:
* `NullCache`: means that `_load_lazy_data` call is effectively not cached at all, so every data loading query will be re-run
* `SimpleCache`: means that `_load_lazy_data` call has some kind of caching, so reloading the same data does not run every time

There's actually two different scenarios where we care about caching:

1. A single HTTP request where we have a page that contains 10 figures, all of which refer to the same underlying dataset
2. Subsequent HTTP requests (either the same user or different, we don't distinguish) want to load the same data.

In our discussion earlier I forgot all about scenario 1, which was stupid because this was actually the original motivation for the whole `original_data` thing 😅 You run the query once for the first figure to populate `original_data` from `lazy_data`, and then all subsequent requests for component data take from `original_data` rather than re-running the query. The problem with this is that it becomes impossible to ever re-run the query and refresh `original_data` consistently across workers.

Now in theory we could handle these two above scenarios differently by identifying whether the call for data is in the same HTTP request or not (you could tell this e.g. with `X-Request-ID` header in the request though I don't know whether this is really good practice). This would be fine from a consistency point of view because one HTTP request will always be processed on one worker. But it might be an unnecessary complication because we can maybe handle both scenarios in exactly the same way: **by setting a sensible default timeout for the cache.**

e.g. let's say we have the cachelib default timeout of 5 minutes. The proposed solution here means that a single HTTP request will only ever call `_load_lazy_data` once because multiple calls to it will be easily within 5 minutes of each other. And subsequent HTTP requests will also not re-run `_load_lazy_data` so long as they're in the 5 minutes of the cache being populated originally.

In fact, I think that just being able to set timeouts differently for different datasets will get 90% towards answering the question of how we do data refreshes also:
* if you set timeout = 5 minutes then naturally the cache expires after 5 minutes and hence `_load_lazy_data` will be re-run on next request after that
* if you set timeout = 0 the cache never expires
* I don't know whether we'll need an option to disable the cache entirely for a dataset, because you can achieve essentially the same thing just by setting a very low timeout. But it is possible to disable cache for particular arguments entirely in cachelib which is probably cleaner

The only thing this proposal misses compared to previous ideas is that in theory I think it could lead to inconsistent data on the screen. e.g. what happens if you have 10 figures on screen, and during one HTTP request after 5 calls to `_load_lazy_data` the cache expires and so the remaining 5 calls get different data. No idea whether this is likely to be a problem in reality, but maybe it suggests that we do need to somehow handle the two above scenarios slightly differently after all? In which case I think we do need the two layers of caching that #116 provides.

---

I know I'm having a conversation with myself here, but my latest thinking is:
* we do need two layers of caching: 1. to ensure consistency on the same worker within one HTTP request and 2. to improve performance and share memory over multiple requests
* let's try using `flask.g` or similar + our own cache or e.g. `lru_cache` or in fact just cachelib to achieve 1 and cachelib for 2
* need to think about how to handle the application building process (outside any requests) and whether to warm up the cache - probably not worth doing manually but instead would point towards `SimpleCache` as the default so that lazy data doesn't get fetched twice (at build time and runtime immediately afterwards)
* I'll do a new prototype of this when I get a chance. It will be a bit more complex than the code here but think it could well be the best solution 

---
## Options for configuring per-dataset arguments:
```
data_manager["gapminder"] = retrieve_gapminder
data_manager["gapminder"]._cache_arguments = {"timeout": 600}

data_manager["gapminder2"] = retrieve_gapminder
data_manager["gapminder2"]._cache_arguments = {
    "timeout": 0,
    "unless": (lambda: True)
}
```

## Screenshot

## Checklist

- [ ] I have not referenced individuals, products or companies in any commits, directly or indirectly
- [ ] I have not added data or restricted code in any commits, directly or indirectly
- [ ] I have updated the docstring of any public function/class/model changed
- [ ] I have added the PR number to the change description in the changelog fragment, e.g. `Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))` (if applicable)
- [ ] I have added tests to cover my changes (if applicable)

## Types of changes

- [ ] Docs/refactoring (non-breaking change which improves codebase)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
