### PR TITLE
Fix linting of release process

### DIFF
--- a/vizro-core/changelog.d/20231113_103808_antony.milne_prep_release.md
+++ b/vizro-core/changelog.d/20231113_103808_antony.milne_prep_release.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -11,7 +11,7 @@ matrix.python.features = [
 [envs.changelog]
 dependencies = ["scriv"]
 detached = true
-scripts = {add = "scriv create --add"}
+scripts = {add = "scriv create --add", collect = ["scriv collect --add", "- hatch run lint:lint --files=CHANGELOG.md > /dev/null"]}
 
 [envs.default]
 dependencies = [
@@ -43,15 +43,15 @@ example = "cd examples/{args:default}; python app.py"
 lint = "hatch run lint:lint {args:--all-files}"
 prep-release = [
   "hatch version release",
-  "hatch run changelog:scriv collect --add",
+  "hatch run changelog:collect",
+  "hatch run changelog:add",
   "rm -rf schemas/*json",
   "schema",
   "git add schemas",
-  "hatch run changelog:add",
   'echo "Now raise a PR to merge into main with title: Release of vizro-core $(hatch version)"'
 ]
 pypath = "python -c 'import sys; print(sys.executable)'"
-schema = ["python schemas/generate.py {args}", 'hatch run lint --files="schemas/$(hatch version).json" > /dev/null']
+schema = ["python schemas/generate.py {args}", '- hatch run lint --files="schemas/$(hatch version).json" > /dev/null']
 secrets = "pre-commit run gitleaks --all-files"
 test = [
   "test-unit",


### PR DESCRIPTION
## Description

Just fixing the minor linting niggles of the release process shown in #155.

Linting commands which have non-zero exit codes will no longer prevent the rest of the scripts from running, and the CHANGELOG.md will now come already linted.

## Checklist

- [x] I have not referenced individuals, products or companies in any commits, directly or indirectly
- [x] I have not added data or restricted code in any commits, directly or indirectly
- [x] I have updated the docstring of any public function/class/model changed
- [x] I have added tests to cover my changes (if applicable)

## Types of changes

- [ ] Docs/refactoring (non-breaking change which improves codebase)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
