### PR TITLE
Show `hatch changelog:collect` linting output

### DIFF
--- a/vizro-ai/hatch.toml
+++ b/vizro-ai/hatch.toml
@@ -6,7 +6,7 @@ python = ["3.9", "3.10", "3.11"]
 [envs.changelog]
 dependencies = ["scriv"]
 detached = true
-scripts = {add = "scriv create --add", collect = ["scriv collect --add", "- hatch run lint:lint --files=CHANGELOG.md > /dev/null"]}
+scripts = {add = "scriv create --add", collect = ["scriv collect --add", "- hatch run lint:lint --files=CHANGELOG.md"]}
 
 [envs.default]
 dependencies = [

--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -11,7 +11,7 @@ matrix.python.features = [
 [envs.changelog]
 dependencies = ["scriv"]
 detached = true
-scripts = {add = "scriv create --add", collect = ["scriv collect --add", "- hatch run lint:lint --files=CHANGELOG.md > /dev/null"]}
+scripts = {add = "scriv create --add", collect = ["scriv collect --add", "- hatch run lint:lint --files=CHANGELOG.md"]}
 
 [envs.default]
 dependencies = [


### PR DESCRIPTION
## Description

The vizro-ai release process needed manual linting again after `hatch changelog:collect` 😞 No idea why, but let's not send the output to `/dev/null` any more so that next time we can see the reason at least...

## Screenshot

## Checklist

- [ ] I have not referenced individuals, products or companies in any commits, directly or indirectly
- [ ] I have not added data or restricted code in any commits, directly or indirectly
- [ ] I have updated the docstring of any public function/class/model changed
- [ ] I have added tests to cover my changes (if applicable)

## Types of changes

- [ ] Docs/refactoring (non-breaking change which improves codebase)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
