### PR TITLE
Fix vm.Slider and vm.RangeSlider to work with incorrect textual input

### DIFF
--- a/vizro-core/changelog.d/20231114_095856_petar_pejovic_fix_sliders_incorrect_input.md
+++ b/vizro-core/changelog.d/20231114_095856_petar_pejovic_fix_sliders_incorrect_input.md
@@ -1,0 +1,46 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+### Fixed
+
+- Fixed `vm.Slider` and `vm.RangeSlider` to work with incorrect text input. ([#173](https://github.com/mckinsey/vizro/pull/173))
+
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/changelog.d/20231114_095856_petar_pejovic_fix_sliders_incorrect_input.md
+++ b/vizro-core/changelog.d/20231114_095856_petar_pejovic_fix_sliders_incorrect_input.md
@@ -34,6 +34,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 - A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
 
 -->
+
 ### Fixed
 
 - Fixed `vm.Slider` and `vm.RangeSlider` to work with incorrect text input. ([#173](https://github.com/mckinsey/vizro/pull/173))

--- a/vizro-core/src/vizro/static/js/models/range_slider.js
+++ b/vizro-core/src/vizro/static/js/models/range_slider.js
@@ -21,6 +21,9 @@ export function _update_range_slider_values(
     trigger_id === `${self_data["id"]}_start_value` ||
     trigger_id === `${self_data["id"]}_end_value`
   ) {
+    if (isNaN(start) || isNaN(end)) {
+      return dash_clientside.no_update;
+    }
     [start_text_value, end_text_value] = [start, end];
   } else if (trigger_id === self_data["id"]) {
     [start_text_value, end_text_value] = [slider[0], slider[1]];

--- a/vizro-core/src/vizro/static/js/models/slider.js
+++ b/vizro-core/src/vizro/static/js/models/slider.js
@@ -7,6 +7,9 @@ export function _update_slider_values(start, slider, input_store, self_data) {
       dash_clientside.callback_context.triggered[0]["prop_id"].split(".")[0];
   }
   if (trigger_id === `${self_data["id"]}_text_value`) {
+    if (isNaN(start)) {
+      return dash_clientside.no_update;
+    }
     text_value = start;
   } else if (trigger_id === self_data["id"]) {
     text_value = slider;


### PR DESCRIPTION
## Description
Fixed `vm.Slider` and `vm.RangeSlider` to work with incorrect text input.

## Screenshot
Example on the `main` branch:
https://github.com/mckinsey/vizro/assets/108530920/455e6d69-beb3-43d5-a4b4-50eef5900f94

Example on the `bugs/fix_sliders_incorrect_input` branch:
https://github.com/mckinsey/vizro/assets/108530920/bf884f34-ec3e-4d9a-bfec-80b399229745

## Checklist

- [x] I have not referenced individuals, products or companies in any commits, directly or indirectly
- [x] I have not added data or restricted code in any commits, directly or indirectly
- [x] I have updated the docstring of any public function/class/model changed
- [ ] I have added tests to cover my changes (if applicable)

## Types of changes

- [ ] Docs/refactoring (non-breaking change which improves codebase)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
