### PR TITLE
Remove pydantic upper bound

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,7 +71,7 @@ repos:
       - id: mypy
         files: ^vizro-core/src/
         additional_dependencies:
-          - pydantic>=1.10.13, <2
+          - pydantic>=2
 
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.16.4

--- a/vizro-core/changelog.d/20231201_155112_antony.milne_pydantic_v2.md
+++ b/vizro-core/changelog.d/20231201_155112_antony.milne_pydantic_v2.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/pyproject.toml
+++ b/vizro-core/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   # 2.11 needed for https://dash.plotly.com/dash-in-jupyter
   "dash_bootstrap_components",
   "pandas",
-  "pydantic>=1.10.13, <2",  # must be synced with pre-commit mypy hook
+  "pydantic>=1.10.13",  # must be synced with pre-commit mypy hook
   "dash_daq",
   "ipython>=8.10.0",  # not directly required, pinned by Snyk to avoid a vulnerability: https://app.snyk.io/vuln/SNYK-PYTHON-IPYTHON-3318382
   "numpy>=1.22.2",  # not directly required, pinned by Snyk to avoid a vulnerability: https://security.snyk.io/vuln/SNYK-PYTHON-NUMPY-2321970

--- a/vizro-core/src/vizro/__init__.py
+++ b/vizro-core/src/vizro/__init__.py
@@ -5,6 +5,6 @@ from ._vizro import Vizro
 
 __all__ = ["Vizro"]
 
-__version__ = "0.1.7.dev0"
+__version__ = "0.1.7.dev1"
 
 logging.basicConfig(level=os.getenv("VIZRO_LOG_LEVEL", "WARNING"))

--- a/vizro-core/src/vizro/models/_action/_action.py
+++ b/vizro-core/src/vizro/models/_action/_action.py
@@ -3,7 +3,11 @@ import logging
 from typing import Any, Dict, List
 
 from dash import Input, Output, State, callback, ctx, html
-from pydantic import Field, validator
+
+try:
+    from pydantic.v1 import Field, validator
+except ImportError:
+    from pydantic import Field, validator
 
 import vizro.actions
 from vizro.managers._model_manager import ModelID

--- a/vizro-core/src/vizro/models/_action/_actions_chain.py
+++ b/vizro-core/src/vizro/models/_action/_actions_chain.py
@@ -1,7 +1,10 @@
 from functools import partial
 from typing import Any, Dict, List, NamedTuple
 
-from pydantic import validator
+try:
+    from pydantic.v1 import validator
+except ImportError:
+    from pydantic import validator
 
 from vizro.models import Action, VizroBaseModel
 

--- a/vizro-core/src/vizro/models/_base.py
+++ b/vizro-core/src/vizro/models/_base.py
@@ -1,8 +1,14 @@
 from typing import Any, List, Type, Union
 
-from pydantic import BaseModel, Field, validator
-from pydantic.fields import SHAPE_LIST, ModelField
-from pydantic.typing import get_args
+try:
+    from pydantic.v1 import BaseModel, Field, validator
+    from pydantic.v1.fields import SHAPE_LIST, ModelField
+    from pydantic.v1.typing import get_args
+except ImportError:
+    from pydantic import BaseModel, Field, validator
+    from pydantic.fields import SHAPE_LIST, ModelField
+    from pydantic.typing import get_args
+
 from typing_extensions import Annotated
 
 from vizro.managers import model_manager

--- a/vizro-core/src/vizro/models/_components/_form.py
+++ b/vizro-core/src/vizro/models/_components/_form.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, List, Literal, Optional
 
 from dash import html
-from pydantic import validator
+
+try:
+    from pydantic.v1 import validator
+except ImportError:
+    from pydantic import validator
 
 from vizro.models import VizroBaseModel
 from vizro.models._components.form import (

--- a/vizro-core/src/vizro/models/_components/button.py
+++ b/vizro-core/src/vizro/models/_components/button.py
@@ -2,7 +2,11 @@ from typing import List, Literal
 
 import dash_bootstrap_components as dbc
 from dash import html
-from pydantic import Field
+
+try:
+    from pydantic.v1 import Field
+except ImportError:
+    from pydantic import Field
 
 from vizro.models import Action, VizroBaseModel
 from vizro.models._action._actions_chain import _action_validator_factory

--- a/vizro-core/src/vizro/models/_components/card.py
+++ b/vizro-core/src/vizro/models/_components/card.py
@@ -2,7 +2,11 @@ from typing import Literal
 
 import dash_bootstrap_components as dbc
 from dash import dcc, get_relative_path, html
-from pydantic import Field
+
+try:
+    from pydantic.v1 import Field
+except ImportError:
+    from pydantic import Field
 
 from vizro.models import VizroBaseModel
 from vizro.models._models_utils import _log_call

--- a/vizro-core/src/vizro/models/_components/form/_alert.py
+++ b/vizro-core/src/vizro/models/_components/form/_alert.py
@@ -2,7 +2,11 @@ from typing import List, Literal, Optional
 
 import dash_bootstrap_components as dbc
 from dash import html
-from pydantic import Field
+
+try:
+    from pydantic.v1 import Field
+except ImportError:
+    from pydantic import Field
 
 from vizro.models import Action, VizroBaseModel
 from vizro.models._models_utils import _log_call

--- a/vizro-core/src/vizro/models/_components/form/_user_input.py
+++ b/vizro-core/src/vizro/models/_components/form/_user_input.py
@@ -2,7 +2,11 @@ from typing import List, Literal
 
 import dash_bootstrap_components as dbc
 from dash import html
-from pydantic import Field
+
+try:
+    from pydantic.v1 import Field
+except ImportError:
+    from pydantic import Field
 
 from vizro.models import Action, VizroBaseModel
 from vizro.models._action._actions_chain import _action_validator_factory

--- a/vizro-core/src/vizro/models/_components/form/checklist.py
+++ b/vizro-core/src/vizro/models/_components/form/checklist.py
@@ -1,7 +1,11 @@
 from typing import List, Literal, Optional
 
 from dash import dcc, html
-from pydantic import Field, PrivateAttr, root_validator, validator
+
+try:
+    from pydantic.v1 import Field, PrivateAttr, root_validator, validator
+except ImportError:
+    from pydantic import Field, PrivateAttr, root_validator, validator
 
 from vizro.models import Action, VizroBaseModel
 from vizro.models._action._actions_chain import _action_validator_factory

--- a/vizro-core/src/vizro/models/_components/form/dropdown.py
+++ b/vizro-core/src/vizro/models/_components/form/dropdown.py
@@ -1,7 +1,11 @@
 from typing import List, Literal, Optional, Union
 
 from dash import dcc, html
-from pydantic import Field, PrivateAttr, root_validator, validator
+
+try:
+    from pydantic.v1 import Field, PrivateAttr, root_validator, validator
+except ImportError:
+    from pydantic import Field, PrivateAttr, root_validator, validator
 
 from vizro.models import Action, VizroBaseModel
 from vizro.models._action._actions_chain import _action_validator_factory

--- a/vizro-core/src/vizro/models/_components/form/radio_items.py
+++ b/vizro-core/src/vizro/models/_components/form/radio_items.py
@@ -1,7 +1,11 @@
 from typing import List, Literal, Optional
 
 from dash import dcc, html
-from pydantic import Field, PrivateAttr, root_validator, validator
+
+try:
+    from pydantic.v1 import Field, PrivateAttr, root_validator, validator
+except ImportError:
+    from pydantic import Field, PrivateAttr, root_validator, validator
 
 from vizro.models import Action, VizroBaseModel
 from vizro.models._action._actions_chain import _action_validator_factory

--- a/vizro-core/src/vizro/models/_components/form/range_slider.py
+++ b/vizro-core/src/vizro/models/_components/form/range_slider.py
@@ -1,7 +1,11 @@
 from typing import Dict, List, Literal, Optional
 
 from dash import ClientsideFunction, Input, Output, State, clientside_callback, dcc, html
-from pydantic import Field, PrivateAttr, validator
+
+try:
+    from pydantic.v1 import Field, PrivateAttr, validator
+except ImportError:
+    from pydantic import Field, PrivateAttr, validator
 
 from vizro.models import Action, VizroBaseModel
 from vizro.models._action._actions_chain import _action_validator_factory

--- a/vizro-core/src/vizro/models/_components/form/slider.py
+++ b/vizro-core/src/vizro/models/_components/form/slider.py
@@ -1,7 +1,11 @@
 from typing import Dict, List, Literal, Optional
 
 from dash import ClientsideFunction, Input, Output, State, clientside_callback, dcc, html
-from pydantic import Field, PrivateAttr, validator
+
+try:
+    from pydantic.v1 import Field, PrivateAttr, validator
+except ImportError:
+    from pydantic import Field, PrivateAttr, validator
 
 from vizro.models import Action, VizroBaseModel
 from vizro.models._action._actions_chain import _action_validator_factory

--- a/vizro-core/src/vizro/models/_components/graph.py
+++ b/vizro-core/src/vizro/models/_components/graph.py
@@ -4,7 +4,11 @@ from typing import List, Literal
 from dash import ctx, dcc
 from dash.exceptions import MissingCallbackContextException
 from plotly import graph_objects as go
-from pydantic import Field, PrivateAttr, validator
+
+try:
+    from pydantic.v1 import Field, PrivateAttr, validator
+except ImportError:
+    from pydantic import Field, PrivateAttr, validator
 
 import vizro.plotly.express as px
 from vizro import _themes as themes

--- a/vizro-core/src/vizro/models/_components/table.py
+++ b/vizro-core/src/vizro/models/_components/table.py
@@ -3,7 +3,11 @@ from typing import List, Literal
 
 from dash import dash_table, dcc, html
 from pandas import DataFrame
-from pydantic import Field, PrivateAttr, validator
+
+try:
+    from pydantic.v1 import Field, PrivateAttr, validator
+except ImportError:
+    from pydantic import Field, PrivateAttr, validator
 
 import vizro.tables as vt
 from vizro.managers import data_manager

--- a/vizro-core/src/vizro/models/_controls/filter.py
+++ b/vizro-core/src/vizro/models/_controls/filter.py
@@ -4,7 +4,11 @@ from typing import TYPE_CHECKING, List, Literal, Optional
 
 import pandas as pd
 from pandas.api.types import is_numeric_dtype
-from pydantic import Field, PrivateAttr, validator
+
+try:
+    from pydantic.v1 import Field, PrivateAttr, validator
+except ImportError:
+    from pydantic import Field, PrivateAttr, validator
 
 from vizro._constants import FILTER_ACTION_PREFIX
 from vizro.actions import _filter

--- a/vizro-core/src/vizro/models/_controls/parameter.py
+++ b/vizro-core/src/vizro/models/_controls/parameter.py
@@ -1,6 +1,9 @@
 from typing import List, Literal
 
-from pydantic import Field, validator
+try:
+    from pydantic.v1 import Field, validator
+except ImportError:
+    from pydantic import Field, validator
 
 from vizro._constants import PARAMETER_ACTION_PREFIX
 from vizro.actions import _parameter

--- a/vizro-core/src/vizro/models/_dashboard.py
+++ b/vizro-core/src/vizro/models/_dashboard.py
@@ -8,7 +8,11 @@ import dash
 import dash_bootstrap_components as dbc
 import dash_daq as daq
 from dash import ClientsideFunction, Input, Output, clientside_callback, get_relative_path, html
-from pydantic import Field, validator
+
+try:
+    from pydantic.v1 import Field, validator
+except ImportError:
+    from pydantic import Field, validator
 
 import vizro
 from vizro._constants import MODULE_PAGE_404, STATIC_URL_PREFIX

--- a/vizro-core/src/vizro/models/_layout.py
+++ b/vizro-core/src/vizro/models/_layout.py
@@ -2,7 +2,11 @@ from typing import List, NamedTuple, Optional, Tuple
 
 import numpy as np
 from numpy import ma
-from pydantic import Field, PrivateAttr, ValidationError, validator
+
+try:
+    from pydantic.v1 import Field, PrivateAttr, ValidationError, validator
+except ImportError:
+    from pydantic import Field, PrivateAttr, ValidationError, validator
 
 from vizro._constants import EMPTY_SPACE_CONST
 from vizro.models import VizroBaseModel

--- a/vizro-core/src/vizro/models/_navigation/accordion.py
+++ b/vizro-core/src/vizro/models/_navigation/accordion.py
@@ -5,7 +5,11 @@ from typing import Dict, List, Literal
 import dash
 import dash_bootstrap_components as dbc
 from dash import html
-from pydantic import Field, validator
+
+try:
+    from pydantic.v1 import Field, validator
+except ImportError:
+    from pydantic import Field, validator
 
 from vizro._constants import ACCORDION_DEFAULT_TITLE
 from vizro.models import VizroBaseModel

--- a/vizro-core/src/vizro/models/_navigation/nav_bar.py
+++ b/vizro-core/src/vizro/models/_navigation/nav_bar.py
@@ -4,7 +4,11 @@ from collections.abc import Mapping
 from typing import Dict, List, Literal
 
 from dash import html
-from pydantic import Field, validator
+
+try:
+    from pydantic.v1 import Field, validator
+except ImportError:
+    from pydantic import Field, validator
 
 from vizro.models import VizroBaseModel
 from vizro.models._models_utils import _log_call

--- a/vizro-core/src/vizro/models/_navigation/nav_link.py
+++ b/vizro-core/src/vizro/models/_navigation/nav_link.py
@@ -5,7 +5,11 @@ import itertools
 import dash
 import dash_bootstrap_components as dbc
 from dash import html
-from pydantic import Field, PrivateAttr, validator
+
+try:
+    from pydantic.v1 import Field, PrivateAttr, validator
+except ImportError:
+    from pydantic import Field, PrivateAttr, validator
 
 from vizro.models import VizroBaseModel
 from vizro.models._models_utils import _log_call

--- a/vizro-core/src/vizro/models/_navigation/navigation.py
+++ b/vizro-core/src/vizro/models/_navigation/navigation.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 from dash import html
-from pydantic import validator
+
+try:
+    from pydantic.v1 import validator
+except ImportError:
+    from pydantic import validator
 
 from vizro.models import VizroBaseModel
 from vizro.models._models_utils import _log_call

--- a/vizro-core/src/vizro/models/_page.py
+++ b/vizro-core/src/vizro/models/_page.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from typing import List, Optional, TypedDict
 
 from dash import Input, Output, Patch, callback, dcc, html
-from pydantic import Field, root_validator, validator
+
+try:
+    from pydantic.v1 import Field, root_validator, validator
+except ImportError:
+    from pydantic import Field, root_validator, validator
 
 from vizro._constants import ON_PAGE_LOAD_ACTION_PREFIX
 from vizro.actions import _on_page_load

--- a/vizro-core/src/vizro/models/types.py
+++ b/vizro-core/src/vizro/models/types.py
@@ -6,9 +6,15 @@ import functools
 import inspect
 from typing import Any, Dict, List, Literal, Protocol, Union, runtime_checkable
 
-from pydantic import Field, StrictBool
-from pydantic.fields import ModelField
-from pydantic.schema import SkipField
+try:
+    from pydantic.v1 import Field, StrictBool
+    from pydantic.v1.fields import ModelField
+    from pydantic.v1.schema import SkipField
+except ImportError:
+    from pydantic import Field, StrictBool
+    from pydantic.fields import ModelField
+    from pydantic.schema import SkipField
+
 from typing_extensions import Annotated, TypedDict
 
 from vizro.charts._charts_utils import _DashboardReadyFigure

--- a/vizro-core/tests/unit/vizro/models/_action/test_action.py
+++ b/vizro-core/tests/unit/vizro/models/_action/test_action.py
@@ -9,7 +9,11 @@ import pytest
 from dash import html
 from dash._callback_context import context_value
 from dash._utils import AttributeDict
-from pydantic import ValidationError
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 from vizro.actions import export_data
 from vizro.models._action._action import Action

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_checklist.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_checklist.py
@@ -4,7 +4,11 @@ import json
 import plotly
 import pytest
 from dash import dcc, html
-from pydantic import ValidationError
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 from vizro.models._action._action import Action
 from vizro.models._components.form import Checklist

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_dropdown.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_dropdown.py
@@ -4,7 +4,11 @@ import json
 import plotly
 import pytest
 from dash import dcc, html
-from pydantic import ValidationError
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 from vizro.models._action._action import Action
 from vizro.models._components.form import Dropdown

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_radioitems.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_radioitems.py
@@ -4,7 +4,11 @@ import json
 import plotly
 import pytest
 from dash import dcc, html
-from pydantic import ValidationError
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 from vizro.models._action._action import Action
 from vizro.models._components.form import RadioItems

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_range_slider.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_range_slider.py
@@ -4,7 +4,11 @@ import json
 import plotly
 import pytest
 from dash import dcc, html
-from pydantic import ValidationError
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 import vizro.models as vm
 

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_slider.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_slider.py
@@ -4,7 +4,11 @@ import json
 import plotly
 import pytest
 from dash import dcc, html
-from pydantic import ValidationError
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 import vizro.models as vm
 

--- a/vizro-core/tests/unit/vizro/models/_components/test_card.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_card.py
@@ -5,7 +5,11 @@ import dash_bootstrap_components as dbc
 import plotly
 import pytest
 from dash import dcc, html
-from pydantic import ValidationError
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 import vizro.models as vm
 

--- a/vizro-core/tests/unit/vizro/models/_components/test_graph.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_graph.py
@@ -7,7 +7,11 @@ import pytest
 from dash import dcc
 from dash._callback_context import context_value
 from dash._utils import AttributeDict
-from pydantic import ValidationError
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 import vizro.models as vm
 import vizro.plotly.express as px

--- a/vizro-core/tests/unit/vizro/models/_components/test_table.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_table.py
@@ -4,7 +4,11 @@ import json
 import plotly
 import pytest
 from dash import dash_table, dcc, html
-from pydantic import ValidationError
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 import vizro.models as vm
 import vizro.plotly.express as px

--- a/vizro-core/tests/unit/vizro/models/_navigation/test_accordion.py
+++ b/vizro-core/tests/unit/vizro/models/_navigation/test_accordion.py
@@ -5,7 +5,11 @@ import dash_bootstrap_components as dbc
 import pytest
 from asserts import assert_component_equal
 from dash import html
-from pydantic import ValidationError
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 import vizro.models as vm
 from vizro._constants import ACCORDION_DEFAULT_TITLE

--- a/vizro-core/tests/unit/vizro/models/_navigation/test_nav_bar.py
+++ b/vizro-core/tests/unit/vizro/models/_navigation/test_nav_bar.py
@@ -5,7 +5,11 @@ import dash_bootstrap_components as dbc
 import pytest
 from asserts import assert_component_equal
 from dash import html
-from pydantic import ValidationError
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 import vizro.models as vm
 

--- a/vizro-core/tests/unit/vizro/models/_navigation/test_nav_item.py
+++ b/vizro-core/tests/unit/vizro/models/_navigation/test_nav_item.py
@@ -5,7 +5,11 @@ import dash_bootstrap_components as dbc
 import pytest
 from asserts import assert_component_equal
 from dash import html
-from pydantic import ValidationError
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 import vizro.models as vm
 

--- a/vizro-core/tests/unit/vizro/models/_navigation/test_navigation.py
+++ b/vizro-core/tests/unit/vizro/models/_navigation/test_navigation.py
@@ -5,7 +5,11 @@ import dash_bootstrap_components as dbc
 import pytest
 from asserts import assert_component_equal
 from dash import html
-from pydantic import ValidationError
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 import vizro.models as vm
 

--- a/vizro-core/tests/unit/vizro/models/test_base.py
+++ b/vizro-core/tests/unit/vizro/models/test_base.py
@@ -1,7 +1,11 @@
 from typing import List, Literal, Optional, Union
 
 import pytest
-from pydantic import Field, ValidationError
+
+try:
+    from pydantic.v1 import Field, ValidationError
+except ImportError:
+    from pydantic import Field, ValidationError
 from typing_extensions import Annotated
 
 import vizro.models as vm

--- a/vizro-core/tests/unit/vizro/models/test_dashboard.py
+++ b/vizro-core/tests/unit/vizro/models/test_dashboard.py
@@ -7,7 +7,11 @@ import dash_bootstrap_components as dbc
 import plotly
 import pytest
 from dash import html
-from pydantic import ValidationError
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 import vizro
 import vizro.models as vm

--- a/vizro-core/tests/unit/vizro/models/test_layout.py
+++ b/vizro-core/tests/unit/vizro/models/test_layout.py
@@ -1,6 +1,10 @@
 import numpy as np
 import pytest
-from pydantic import ValidationError
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 import vizro.models as vm
 from vizro.models._layout import GAP_DEFAULT, MIN_DEFAULT, ColRowGridLines

--- a/vizro-core/tests/unit/vizro/models/test_page.py
+++ b/vizro-core/tests/unit/vizro/models/test_page.py
@@ -2,7 +2,11 @@ import re
 
 import pandas as pd
 import pytest
-from pydantic import ValidationError
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 import vizro.models as vm
 import vizro.plotly.express as px

--- a/vizro-core/tests/unit/vizro/models/test_types.py
+++ b/vizro-core/tests/unit/vizro/models/test_types.py
@@ -3,7 +3,11 @@ import importlib
 import plotly.express as plotly_express
 import plotly.graph_objects as go
 import pytest
-from pydantic import Field, ValidationError
+
+try:
+    from pydantic.v1 import Field, ValidationError
+except ImportError:
+    from pydantic import Field, ValidationError
 
 from vizro.charts._charts_utils import _DashboardReadyFigure
 from vizro.models import VizroBaseModel


### PR DESCRIPTION
## Description

Currently we have `pydantic<2`, which is not ideal for compatibility with other tools.

I've tried to release remove this upper bound and see if it works...

We are still using the pydantic v1 API everywhere. At some point in the future we should switch fully to v2 but that is a bigger project (and would make us incompatible with kedro-viz, [which currently pins `pydantic<2`](https://github.com/kedro-org/kedro-viz/pull/1529)).

Todo:
- [ ] test if it works in practice
- [ ] get tests to run for both pydantic v1 and v2

## Screenshot

## Checklist

- [ ] I have not referenced individuals, products or companies in any commits, directly or indirectly
- [ ] I have not added data or restricted code in any commits, directly or indirectly
- [ ] I have updated the docstring of any public function/class/model changed
- [ ] I have added tests to cover my changes (if applicable)

## Types of changes

- [ ] Docs/refactoring (non-breaking change which improves codebase)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
