### PR TITLE
Fix integration tests to work in a single pytest session

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+env:
+  PYTHON_VERSION: "3.9"
+
 jobs:
   check-version:
     runs-on: ubuntu-latest
@@ -13,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: $PYTHON_VERSION
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -50,7 +53,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: $PYTHON_VERSION
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -103,7 +106,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: $PYTHON_VERSION
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: $PYTHON_VERSION
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: $PYTHON_VERSION
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -106,7 +106,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: $PYTHON_VERSION
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/checks-vizro-ai.yml
+++ b/.github/workflows/checks-vizro-ai.yml
@@ -30,19 +30,19 @@ jobs:
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
 
-      - name: Set up Python $PYTHON_VERSION
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v4
         with:
-          python-version: $PYTHON_VERSION
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Hatch
         run: pip install --upgrade hatch
 
       - name: List dependencies
-        run: hatch run all.py$PYTHON_VERSION:pip freeze
+        run: hatch run all.py${{ env.PYTHON_VERSION }}:pip freeze
 
       - name: Check requirements for Snyk are up to date
-        run: hatch run all.py$PYTHON_VERSION:update-snyk-requirements --check
+        run: hatch run all.py${{ env.PYTHON_VERSION }}:update-snyk-requirements --check
 
       - name: Find added changelog fragments
         id: added-files

--- a/.github/workflows/checks-vizro-ai.yml
+++ b/.github/workflows/checks-vizro-ai.yml
@@ -20,33 +20,29 @@ concurrency:
 env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
+  PYTHON_VERSION: "3.9"
 
 jobs:
   run:
-    name: Python ${{ matrix.python-version }} on Linux
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9"]
-
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python $PYTHON_VERSION
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: $PYTHON_VERSION
 
       - name: Install Hatch
         run: pip install --upgrade hatch
 
       - name: List dependencies
-        run: hatch run all.py${{ matrix.python-version }}:pip freeze
+        run: hatch run all.py$PYTHON_VERSION:pip freeze
 
       - name: Check requirements for Snyk are up to date
-        run: hatch run all.py${{ matrix.python-version }}:update-snyk-requirements --check
+        run: hatch run all.py$PYTHON_VERSION:update-snyk-requirements --check
 
       - name: Find added changelog fragments
         id: added-files

--- a/.github/workflows/checks-vizro-core.yml
+++ b/.github/workflows/checks-vizro-core.yml
@@ -31,22 +31,22 @@ jobs:
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
 
-      - name: Set up Python $PYTHON_VERSION
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v4
         with:
-          python-version: $PYTHON_VERSION
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Hatch
         run: pip install --upgrade hatch
 
       - name: List dependencies
-        run: hatch run all.py$PYTHON_VERSION:pip freeze
+        run: hatch run all.py${{ env.PYTHON_VERSION }}:pip freeze
 
       - name: Check schema is up to date
-        run: hatch run all.py$PYTHON_VERSION:schema --check
+        run: hatch run all.py${{ env.PYTHON_VERSION }}:schema --check
 
       - name: Check requirements for Snyk are up to date
-        run: hatch run all.py$PYTHON_VERSION:update-snyk-requirements --check
+        run: hatch run all.py${{ env.PYTHON_VERSION }}:update-snyk-requirements --check
 
       - name: Find added changelog fragments
         id: added-files

--- a/.github/workflows/checks-vizro-core.yml
+++ b/.github/workflows/checks-vizro-core.yml
@@ -21,36 +21,32 @@ concurrency:
 env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
+  PYTHON_VERSION: "3.9"
 
 jobs:
   run:
-    name: Python ${{ matrix.python-version }} on Linux
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.8"]
-
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python $PYTHON_VERSION
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: $PYTHON_VERSION
 
       - name: Install Hatch
         run: pip install --upgrade hatch
 
       - name: List dependencies
-        run: hatch run all.py${{ matrix.python-version }}:pip freeze
+        run: hatch run all.py$PYTHON_VERSION:pip freeze
 
       - name: Check schema is up to date
-        run: hatch run all.py${{ matrix.python-version }}:schema --check
+        run: hatch run all.py$PYTHON_VERSION:schema --check
 
       - name: Check requirements for Snyk are up to date
-        run: hatch run all.py${{ matrix.python-version }}:update-snyk-requirements --check
+        run: hatch run all.py$PYTHON_VERSION:update-snyk-requirements --check
 
       - name: Find added changelog fragments
         id: added-files

--- a/.github/workflows/lint-vizro-all.yml
+++ b/.github/workflows/lint-vizro-all.yml
@@ -28,13 +28,13 @@ jobs:
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
 
-      - name: Set up Python $PYTHON_VERSION
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v4
         with:
-          python-version: $PYTHON_VERSION
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Hatch
         run: pip install --upgrade hatch
 
       - name: Lint
-        run: hatch run lint:lint
+        run: hatch run lint

--- a/.github/workflows/lint-vizro-all.yml
+++ b/.github/workflows/lint-vizro-all.yml
@@ -17,24 +17,21 @@ concurrency:
 env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
+  PYTHON_VERSION: "3.9"
 
 jobs:
   run:
-    name: Python ${{ matrix.python-version }} on Linux
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.8"]
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python $PYTHON_VERSION
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: $PYTHON_VERSION
 
       - name: Install Hatch
         run: pip install --upgrade hatch

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -5,6 +5,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 4 * * *" # run once a day at 4 AM
+
+env:
+  PYTHON_VERSION: "3.9"
+
 jobs:
   scan:
     name: gitleaks
@@ -14,10 +18,10 @@ jobs:
 
       - uses: actions/setup-go@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python $PYTHON_VERSION
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: $PYTHON_VERSION
 
       - name: Install pre-commit
         run: pip install pre-commit

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -18,10 +18,10 @@ jobs:
 
       - uses: actions/setup-go@v4
 
-      - name: Set up Python $PYTHON_VERSION
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v4
         with:
-          python-version: $PYTHON_VERSION
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install pre-commit
         run: pip install pre-commit

--- a/.github/workflows/test-integration-vizro-ai.yml
+++ b/.github/workflows/test-integration-vizro-ai.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   run:
-    name: Python ${{ matrix.python-version }} on Linux
+    name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/test-integration-vizro-core.yml
+++ b/.github/workflows/test-integration-vizro-core.yml
@@ -20,45 +20,27 @@ env:
 
 jobs:
   run:
-    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v4
-      - name: Get branch name
-        id: branch-name
-        uses: tj-actions/branch-names@v7
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: actions/cache@v3
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ matrix.os }}-${{ matrix.python-version }}-${{ steps.branch-name.outputs.current_branch }}-pip-${{ hashFiles('hatch.toml') }}-${{ hashFiles('pyproject.toml') }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-${{ steps.branch-name.outputs.current_branch }}-pip-
+      - name: Install Hatch
+        run: pip install --upgrade hatch
 
-      - name: Run ubuntu integration tests
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: |
-          pip install --upgrade hatch
-          hatch run all.py${{ matrix.python-version }}:test-integration
+      - name: List dependencies
+        run: hatch run all.py${{ matrix.python-version }}:pip freeze
 
-      - name: Run windows integration tests
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: |
-          $env:PYTHONPATH=".;D:\a\vizro\vizro\vizro-core\src"
-          pip install -r ../.github/requirements.txt
-          pip install .
-          pytest tests/integration --headless -k default
-          pytest tests/integration --headless -k dict
-          pytest tests/integration --headless -k json
-          pytest tests/integration --headless -k yaml
+      - name: Run integration tests
+        run: hatch run all.py${{ matrix.python-version }}:test-integration
+

--- a/.github/workflows/test-unit-vizro-ai.yml
+++ b/.github/workflows/test-unit-vizro-ai.yml
@@ -20,12 +20,11 @@ env:
 
 jobs:
   run:
-    name: Python ${{ matrix.python-version }} on ${{ startsWith(matrix.os, 'windows-') && 'Windows' || 'Linux' }}
-    runs-on: ${{ matrix.os }}
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
         python-version: ["3.9", "3.10", "3.11"]
 
     steps:

--- a/.github/workflows/test-unit-vizro-ai.yml
+++ b/.github/workflows/test-unit-vizro-ai.yml
@@ -44,4 +44,4 @@ jobs:
 
       - name: Run unit tests
         run: |
-          hatch run all.py${{ matrix.python-version }}:cov
+          hatch run all.py${{ matrix.python-version }}:test-unit-coverage

--- a/.github/workflows/test-unit-vizro-core.yml
+++ b/.github/workflows/test-unit-vizro-core.yml
@@ -44,4 +44,4 @@ jobs:
 
       - name: Run unit tests
         run: |
-          hatch run all.py${{ matrix.python-version }}:cov
+          hatch run all.py${{ matrix.python-version }}:test-unit-coverage

--- a/.github/workflows/test-unit-vizro-core.yml
+++ b/.github/workflows/test-unit-vizro-core.yml
@@ -20,12 +20,11 @@ env:
 
 jobs:
   run:
-    name: Python ${{ matrix.python-version }} on ${{ startsWith(matrix.os, 'windows-') && 'Windows' || 'Linux' }}
-    runs-on: ${{ matrix.os }}
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
@@ -43,5 +42,4 @@ jobs:
         run: hatch run all.py${{ matrix.python-version }}:pip freeze
 
       - name: Run unit tests
-        run: |
-          hatch run all.py${{ matrix.python-version }}:test-unit-coverage
+        run: hatch run all.py${{ matrix.python-version }}:test-unit-coverage

--- a/vizro-ai/changelog.d/20231205_121131_antony.milne.md
+++ b/vizro-ai/changelog.d/20231205_121131_antony.milne.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-ai/hatch.toml
+++ b/vizro-ai/hatch.toml
@@ -22,14 +22,6 @@ dependencies = [
 VIZRO_AI_LOG_LEVEL = "DEBUG"
 
 [envs.default.scripts]
-cov = [
-  "test-cov",
-  "cov-report"
-]
-cov-report = [
-  "- coverage combine",
-  "coverage report"
-]
 lint = "hatch run lint:lint {args:--all-files}"
 prep-release = [
   "hatch version release",
@@ -43,11 +35,15 @@ test = [
   "- test-unit",
   "test-integration"
 ]
-test-cov = "coverage run -m pytest tests/unit {args}"
 test-integration = [
   "pytest -v tests/integration"
 ]
 test-unit = "pytest tests/unit {args}"
+test-unit-coverage = [
+  "coverage run -m pytest tests/unit {args}",
+  "- coverage combine",
+  "coverage report"
+]
 update-snyk-requirements = "python ../tools/generate_snyk_requirements.py {args}"
 
 [envs.docs]

--- a/vizro-core/changelog.d/20231205_121059_antony.milne.md
+++ b/vizro-core/changelog.d/20231205_121059_antony.milne.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/docs/pages/development/contributing.md
+++ b/vizro-core/docs/pages/development/contributing.md
@@ -79,7 +79,7 @@ To run tests against a particular Python version, specify the particular Hatch e
 hatch run all.py3.10:test -vv
 ```
 
-The script executed by `hatch run cov` measures test coverage and generates a report.
+The script executed by `hatch run test-unit-coverage` measures test coverage and generates a report.
 
 To run jest unit tests for javascript functions, run `hatch run test-js`.
 Note that Node.js is required to run tests written in the jest framework. If you don't have `Node.js` installed, guidelines on how to install Node.js will appear when you run the command: `hatch run test-js`.

--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -31,14 +31,6 @@ DASH_DEBUG = "true"
 VIZRO_LOG_LEVEL = "DEBUG"
 
 [envs.default.scripts]
-cov = [
-  "test-cov",
-  "cov-report"
-]
-cov-report = [
-  "- coverage combine",
-  "coverage report"
-]
 example = "cd examples/{args:default}; python app.py"
 lint = "hatch run lint:lint {args:--all-files}"
 prep-release = [
@@ -57,16 +49,14 @@ test = [
   "- test-unit",
   "test-integration"
 ]
-test-cov = "coverage run -m pytest tests/unit {args}"
-test-integration = [
-  "- pytest tests/integration/test_examples.py::test_default_dashboard --headless",
-  "- pytest tests/integration/test_examples.py::test_dict_dashboard --headless",
-  "- pytest tests/integration/test_examples.py::test_json_dashboard --headless",
-  "- pytest tests/integration/test_examples.py::test_yaml_dashboard --headless",
-  "pytest tests/integration/test_navigation.py"
-]
+test-integration = "pytest tests/integration --headless {args}"
 test-js = "./tools/run_jest.sh {args}"
 test-unit = "pytest tests/unit {args}"
+test-unit-coverage = [
+  "coverage run -m pytest tests/unit {args}",
+  "- coverage combine",
+  "coverage report"
+]
 update-snyk-requirements = "python ../tools/generate_snyk_requirements.py {args}"
 
 [envs.docs]

--- a/vizro-core/src/vizro/actions/_action_loop/_action_loop.py
+++ b/vizro-core/src/vizro/actions/_action_loop/_action_loop.py
@@ -16,7 +16,7 @@ class ActionLoop:
         Returns:
             List of required components for the action loop and for each `Action` in the `Dashboard`.
         """
-        return html.Div([cls._build_action_loop(), cls._build_actions_models()], id="app_components_div")
+        return html.Div([cls._build_action_loop(), cls._build_actions_models()], id="app_components_div", hidden=True)
 
     @staticmethod
     def _build_action_loop():
@@ -36,4 +36,4 @@ class ActionLoop:
             List of required components for each `Action` in the `Dashboard` e.g. List[dcc.Download]
         """
         actions = _get_actions_on_registered_pages()
-        return html.Div([action.build() for action in actions], id="app_action_models_components_div")
+        return html.Div([action.build() for action in actions], id="app_action_models_components_div", hidden=True)

--- a/vizro-core/src/vizro/models/_action/_action.py
+++ b/vizro-core/src/vizro/models/_action/_action.py
@@ -158,7 +158,4 @@ class Action(VizroBaseModel):
         def callback_wrapper(trigger: None, **inputs: Dict[str, Any]) -> Dict[str, Any]:
             return self._action_callback_function(**inputs)
 
-        return html.Div(
-            children=action_components,
-            id=f"{self.id}_action_model_components_div",
-        )
+        return html.Div(children=action_components, id=f"{self.id}_action_model_components_div", hidden=True)

--- a/vizro-core/src/vizro/models/_dashboard.py
+++ b/vizro-core/src/vizro/models/_dashboard.py
@@ -83,7 +83,7 @@ class Dashboard(VizroBaseModel):
         return dbc.Container(
             id="dashboard_container_outer",
             children=[
-                html.Div(id=f"vizro_version_{vizro.__version__}"),
+                html.Div(vizro.__version__, id="vizro_version", hidden=True),
                 ActionLoop._create_app_callbacks(),
                 dash.page_container,
             ],

--- a/vizro-core/tests/integration/test_examples.py
+++ b/vizro-core/tests/integration/test_examples.py
@@ -1,5 +1,6 @@
 # ruff: noqa: F403, F405
 import os
+import runpy
 from pathlib import Path
 
 import chromedriver_autoinstaller_fix
@@ -25,65 +26,14 @@ def setup_integration_test_environment(monkeypatch_session):
         chromedriver_autoinstaller_fix.install()
 
 
-@pytest.fixture
-def default_dashboard(monkeypatch):
-    monkeypatch.chdir(Path(__file__).parents[2] / "examples/default")
-    monkeypatch.syspath_prepend(Path.cwd())
-    from app import dashboard
-
-    return dashboard
+@pytest.fixture(params=["default", "from_dict", "from_json", "from_yaml"])
+def dashboard(request, monkeypatch):
+    monkeypatch.chdir(Path(__file__).parents[2] / f"examples/{request.param}")
+    app = runpy.run_path("app.py")
+    return app["dashboard"]
 
 
-@pytest.fixture
-def dict_dashboard(monkeypatch):
-    monkeypatch.chdir(Path(__file__).parents[2] / "examples/from_dict")
-    monkeypatch.syspath_prepend(Path.cwd())
-    from app import dashboard
-
-    return dashboard
-
-
-@pytest.fixture
-def json_dashboard(monkeypatch):
-    monkeypatch.chdir(Path(__file__).parents[2] / "examples/from_json")
-    monkeypatch.syspath_prepend(Path.cwd())
-    from app import dashboard
-
-    return dashboard
-
-
-@pytest.fixture
-def yaml_dashboard(monkeypatch):
-    monkeypatch.chdir(Path(__file__).parents[2] / "examples/from_yaml")
-    monkeypatch.syspath_prepend(Path.cwd())
-    from app import dashboard
-
-    return dashboard
-
-
-def test_default_dashboard(dash_duo, default_dashboard):
-    """Test if default example dashboard starts and has no errors in logs."""
-    app = Vizro().build(default_dashboard).dash
-    dash_duo.start_server(app)
-    assert dash_duo.get_logs() == []
-
-
-def test_dict_dashboard(dash_duo, dict_dashboard):
-    """Test if dictionary example dashboard starts and has no errors in logs."""
-    app = Vizro().build(dict_dashboard).dash
-    dash_duo.start_server(app)
-    assert dash_duo.get_logs() == []
-
-
-def test_json_dashboard(dash_duo, json_dashboard):
-    """Test if json example dashboard starts and has no errors in logs."""
-    app = Vizro().build(json_dashboard).dash
-    dash_duo.start_server(app)
-    assert dash_duo.get_logs() == []
-
-
-def test_yaml_dashboard(dash_duo, yaml_dashboard):
-    """Test if yaml example dashboard starts and has no errors in logs."""
-    app = Vizro().build(yaml_dashboard).dash
+def test_dashboard(dash_duo, dashboard):
+    app = Vizro(assets_folder=Path(__file__).parents[2] / "examples/assets").build(dashboard).dash
     dash_duo.start_server(app)
     assert dash_duo.get_logs() == []

--- a/vizro-core/tests/unit/vizro/models/_action/test_action.py
+++ b/vizro-core/tests/unit/vizro/models/_action/test_action.py
@@ -61,6 +61,7 @@ def custom_action_build_expected():
     return html.Div(
         children=[],
         id="action_test_action_model_components_div",
+        hidden=True,
     )
 
 

--- a/vizro-core/tests/unit/vizro/models/test_dashboard.py
+++ b/vizro-core/tests/unit/vizro/models/test_dashboard.py
@@ -19,7 +19,7 @@ def dashboard_container():
     return dbc.Container(
         id="dashboard_container_outer",
         children=[
-            html.Div(id=f"vizro_version_{vizro.__version__}"),
+            html.Div(vizro.__version__, id="vizro_version", hidden=True),
             ActionLoop._create_app_callbacks(),
             dash.page_container,
         ],


### PR DESCRIPTION
## Description

Main change: we can now do `pytest tests/integration` in vizro-core in a single pytest session rather than needing to run each test separately. This is good because it means that any new integration tests we write (like `test_navigation` I added recently) will automatically run.

@l0uden thought that https://github.com/plotly/dash/issues/1933 was the issue here, but after some careful investigation (using `keep_open=True` is very useful) I decided that the failures were actually correct and not just a quirk of `dash_duo`. The root of the problem was something to do with the way we were handling imports, which I've changed to use `runpy` now.

Other minor changes:
* closes #125 by removing all Windows integration tests. I looked through our history of Github actions and decided that these don't add anything useful and are really just there for historic reasons
* tided some of our configurations e.g. ones which didn't need to use `matrix` to use a single version of Python
* tided some of our hatch scripts for running tests, because these always confuse me and we actually only use a couple of the commands
* made a couple more divs into `hidden`
## Checklist

- [ ] I have not referenced individuals, products or companies in any commits, directly or indirectly
- [ ] I have not added data or restricted code in any commits, directly or indirectly
- [ ] I have updated the docstring of any public function/class/model changed
- [ ] I have added tests to cover my changes (if applicable)

## Types of changes

- [ ] Docs/refactoring (non-breaking change which improves codebase)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
