### PR TITLE
Bump dash lower bound to 2.14.1

### DIFF
--- a/vizro-core/changelog.d/20231208_092136_lingyi_zhang_dash_lowerbound.md
+++ b/vizro-core/changelog.d/20231208_092136_lingyi_zhang_dash_lowerbound.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/changelog.d/20231208_092136_lingyi_zhang_dash_lowerbound.md
+++ b/vizro-core/changelog.d/20231208_092136_lingyi_zhang_dash_lowerbound.md
@@ -22,12 +22,11 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 - A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
 
 -->
-<!--
+
 ### Changed
 
-- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+- Bump dash lower bound to 2.14.1 ([#203](https://github.com/mckinsey/vizro/pull/203))
 
--->
 <!--
 ### Deprecated
 

--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -74,7 +74,10 @@ detached = true
 scripts = {lint = "SKIP=gitleaks pre-commit run {args:--all-files}"}
 
 [envs.lower-bounds]
-extra-dependencies = ["pydantic==1.10.13"]
+extra-dependencies = [
+  "pydantic==1.10.13",
+  "dash==2.14.1"
+]
 
 [publish.index]
 disable = true

--- a/vizro-core/pyproject.toml
+++ b/vizro-core/pyproject.toml
@@ -17,8 +17,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11"
 ]
 dependencies = [
-  "dash>=2.11",  # Needed to support https://dash.plotly.com/duplicate-callback-outputs#setting-allow_duplicate-on-duplicate-outputs.
-  # 2.11 needed for https://dash.plotly.com/dash-in-jupyter
+  "dash>=2.14.1",  # 2.14.1 needed for compatibility with werkzeug
   "dash_bootstrap_components",
   "pandas",
   "pydantic>=1.10.13",  # must be synced with pre-commit mypy hook manually

--- a/vizro-core/snyk/requirements.txt
+++ b/vizro-core/snyk/requirements.txt
@@ -1,4 +1,4 @@
-dash>=2.11
+dash>=2.14.1
 dash_bootstrap_components
 pandas
 pydantic>=1.10.13


### PR DESCRIPTION
## Description
This bump is required by a chain of dependency upgrade.
- The `werkzeug` version has recently been bumped in dash 2.14.1
https://github.com/plotly/dash/pull/2674/files
- We pinned the `werkzeug` version to avoid a security venerability 
    - https://github.com/mckinsey/vizro/pull/128
    - https://github.com/plotly/dash/issues/2673

## Screenshot

## Checklist

- [x] I have not referenced individuals, products or companies in any commits, directly or indirectly
- [x] I have not added data or restricted code in any commits, directly or indirectly
- [ ] I have updated the docstring of any public function/class/model changed
- [ ] I have added tests to cover my changes (if applicable)

## Types of changes

- [ ] Docs/refactoring (non-breaking change which improves codebase)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
