### PR TITLE
Apply `ctx` abbreviation consistently

### DIFF
--- a/vizro-core/changelog.d/20240109_140626_huong_li_nguyen_use_ctx_short.md
+++ b/vizro-core/changelog.d/20240109_140626_huong_li_nguyen_use_ctx_short.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/src/vizro/actions/_actions_utils.py
+++ b/vizro-core/src/vizro/actions/_actions_utils.py
@@ -20,7 +20,7 @@ ValidatedNoneValueType = Union[SingleValueType, MultiValueType, None, List[None]
 
 
 class CallbackTriggerDict(TypedDict):
-    """Represent dash.callback_context.args_grouping item. Shortened as 'ctd' in the code.
+    """Represent dash.ctx.args_grouping item. Shortened as 'ctd' in the code.
 
     Args:
         id: The component ID. If it`s a pattern matching ID, it will be a dict.

--- a/vizro-core/tests/unit/vizro/actions/test_export_data_action.py
+++ b/vizro-core/tests/unit/vizro/actions/test_export_data_action.py
@@ -45,8 +45,8 @@ def managers_one_page_without_graphs_one_button():
 
 
 @pytest.fixture
-def callback_context_export_data(request):
-    """Mock dash.callback_context that represents filters and filter interactions applied."""
+def ctx_export_data(request):
+    """Mock dash.ctx that represents filters and filter interactions applied."""
     targets, pop_filter, continent_filter_interaction, country_table_filter_interaction = request.param
     args_grouping_filter_interaction = []
     if continent_filter_interaction:
@@ -97,7 +97,7 @@ def callback_context_export_data(request):
                 ),
             }
         )
-    mock_callback_context = {
+    mock_ctx = {
         "args_grouping": {
             "external": {
                 "filters": [
@@ -123,14 +123,14 @@ def callback_context_export_data(request):
         ],
     }
 
-    context_value.set(AttributeDict(**mock_callback_context))
+    context_value.set(AttributeDict(**mock_ctx))
     return context_value
 
 
 class TestExportData:
     @pytest.mark.usefixtures("managers_one_page_without_graphs_one_button")
-    @pytest.mark.parametrize("callback_context_export_data", [([[], None, None, None])], indirect=True)
-    def test_no_graphs_no_targets(self, callback_context_export_data):
+    @pytest.mark.parametrize("ctx_export_data", [([[], None, None, None])], indirect=True)
+    def test_no_graphs_no_targets(self, ctx_export_data):
         # Add action to relevant component
         model_manager["button"].actions = [vm.Action(id="test_action", function=export_data())]
 
@@ -141,10 +141,8 @@ class TestExportData:
         assert result == expected
 
     @pytest.mark.usefixtures("managers_one_page_two_graphs_one_button")
-    @pytest.mark.parametrize(
-        "callback_context_export_data", [([["scatter_chart", "box_chart"], None, None, None])], indirect=True
-    )
-    def test_graphs_no_targets(self, callback_context_export_data, gapminder_2007):
+    @pytest.mark.parametrize("ctx_export_data", [([["scatter_chart", "box_chart"], None, None, None])], indirect=True)
+    def test_graphs_no_targets(self, ctx_export_data, gapminder_2007):
         # Add action to relevant component
         model_manager["button"].actions = [vm.Action(id="test_action", function=export_data())]
 
@@ -169,14 +167,14 @@ class TestExportData:
 
     @pytest.mark.usefixtures("managers_one_page_two_graphs_one_button")
     @pytest.mark.parametrize(
-        "callback_context_export_data, targets",
+        "ctx_export_data, targets",
         [
             ([["scatter_chart", "box_chart"], None, None, None], None),
             ([["scatter_chart", "box_chart"], None, None, None], []),
         ],
-        indirect=["callback_context_export_data"],
+        indirect=["ctx_export_data"],
     )
-    def test_graphs_false_targets(self, callback_context_export_data, targets, gapminder_2007):
+    def test_graphs_false_targets(self, ctx_export_data, targets, gapminder_2007):
         # Add action to relevant component
         model_manager["button"].actions = [vm.Action(id="test_action", function=export_data(targets=targets))]
 
@@ -200,8 +198,8 @@ class TestExportData:
         assert result == expected
 
     @pytest.mark.usefixtures("managers_one_page_two_graphs_one_button")
-    @pytest.mark.parametrize("callback_context_export_data", [(["scatter_chart"], None, None, None)], indirect=True)
-    def test_one_target(self, callback_context_export_data, gapminder_2007):
+    @pytest.mark.parametrize("ctx_export_data", [(["scatter_chart"], None, None, None)], indirect=True)
+    def test_one_target(self, ctx_export_data, gapminder_2007):
         # Add action to relevant component
         model_manager["button"].actions = [vm.Action(id="test_action", function=export_data(targets=["scatter_chart"]))]
 
@@ -219,10 +217,8 @@ class TestExportData:
         assert result == expected
 
     @pytest.mark.usefixtures("managers_one_page_two_graphs_one_button")
-    @pytest.mark.parametrize(
-        "callback_context_export_data", [(["scatter_chart", "box_chart"], None, None, None)], indirect=True
-    )
-    def test_multiple_targets(self, callback_context_export_data, gapminder_2007):
+    @pytest.mark.parametrize("ctx_export_data", [(["scatter_chart", "box_chart"], None, None, None)], indirect=True)
+    def test_multiple_targets(self, ctx_export_data, gapminder_2007):
         # Add action to relevant component
         model_manager["button"].actions = [
             vm.Action(id="test_action", function=export_data(targets=["scatter_chart", "box_chart"]))
@@ -248,10 +244,10 @@ class TestExportData:
         assert result == expected
 
     @pytest.mark.usefixtures("managers_one_page_two_graphs_one_button")
-    @pytest.mark.parametrize("callback_context_export_data", [(["invalid_target_id"], None, None, None)], indirect=True)
+    @pytest.mark.parametrize("ctx_export_data", [(["invalid_target_id"], None, None, None)], indirect=True)
     def test_invalid_target(
         self,
-        callback_context_export_data,
+        ctx_export_data,
     ):
         # Add action to relevant component
         model_manager["button"].actions = [
@@ -264,7 +260,7 @@ class TestExportData:
 
     @pytest.mark.usefixtures("managers_one_page_two_graphs_one_button")
     @pytest.mark.parametrize(
-        "callback_context_export_data, target_scatter_filter_and_filter_interaction, target_box_filtered_pop",
+        "ctx_export_data, target_scatter_filter_and_filter_interaction, target_box_filtered_pop",
         [
             (
                 [["scatter_chart", "box_chart"], [10**6, 10**7], None, None],
@@ -282,7 +278,7 @@ class TestExportData:
     )
     def test_multiple_targets_with_filter_and_filter_interaction(
         self,
-        callback_context_export_data,
+        ctx_export_data,
         target_scatter_filter_and_filter_interaction,
         target_box_filtered_pop,
     ):
@@ -323,7 +319,7 @@ class TestExportData:
 
     @pytest.mark.usefixtures("managers_one_page_two_graphs_one_table_one_button")
     @pytest.mark.parametrize(
-        "callback_context_export_data, target_scatter_filter_and_filter_interaction, target_box_filtered_pop",
+        "ctx_export_data, target_scatter_filter_and_filter_interaction, target_box_filtered_pop",
         [
             (
                 [["scatter_chart", "box_chart"], [10**6, 10**7], None, "Algeria"],
@@ -341,7 +337,7 @@ class TestExportData:
     )
     def test_multiple_targets_with_filter_and_filter_interaction_and_table(
         self,
-        callback_context_export_data,
+        ctx_export_data,
         target_scatter_filter_and_filter_interaction,
         target_box_filtered_pop,
     ):

--- a/vizro-core/tests/unit/vizro/actions/test_filter_action.py
+++ b/vizro-core/tests/unit/vizro/actions/test_filter_action.py
@@ -30,10 +30,10 @@ def target_box_filtered_continent_and_pop(request, gapminder_2007, box_params):
 
 
 @pytest.fixture
-def callback_context_filter_continent(request):
-    """Mock dash.callback_context that represents continent Filter value selection."""
+def ctx_filter_continent(request):
+    """Mock dash.ctx that represents continent Filter value selection."""
     continent = request.param
-    mock_callback_context = {
+    mock_ctx = {
         "args_grouping": {
             "external": {
                 "filter_interaction": [],
@@ -57,15 +57,15 @@ def callback_context_filter_continent(request):
             }
         }
     }
-    context_value.set(AttributeDict(**mock_callback_context))
+    context_value.set(AttributeDict(**mock_ctx))
     return context_value
 
 
 @pytest.fixture
-def callback_context_filter_continent_and_pop(request):
-    """Mock dash.callback_context that represents continent and pop Filter value selection."""
+def ctx_filter_continent_and_pop(request):
+    """Mock dash.ctx that represents continent and pop Filter value selection."""
     continent, pop = request.param
-    mock_callback_context = {
+    mock_ctx = {
         "args_grouping": {
             "external": {
                 "filter_interaction": [],
@@ -96,20 +96,20 @@ def callback_context_filter_continent_and_pop(request):
             }
         }
     }
-    context_value.set(AttributeDict(**mock_callback_context))
+    context_value.set(AttributeDict(**mock_ctx))
     return context_value
 
 
 @pytest.mark.usefixtures("managers_one_page_two_graphs_one_button")
 class TestFilter:
     @pytest.mark.parametrize(
-        "callback_context_filter_continent,target_scatter_filtered_continent,target_box_filtered_continent",
+        "ctx_filter_continent,target_scatter_filtered_continent,target_box_filtered_continent",
         [(["Africa"], ["Africa"], ["Africa"]), (["Africa", "Europe"], ["Africa", "Europe"], ["Africa", "Europe"])],
         indirect=True,
     )
     def test_one_filter_no_targets(
         self,
-        callback_context_filter_continent,
+        ctx_filter_continent,
         target_scatter_filtered_continent,
         target_box_filtered_continent,
     ):
@@ -130,13 +130,13 @@ class TestFilter:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "callback_context_filter_continent,target_scatter_filtered_continent",
+        "ctx_filter_continent,target_scatter_filtered_continent",
         [(["Africa"], ["Africa"]), (["Africa", "Europe"], ["Africa", "Europe"])],
         indirect=True,
     )
     def test_one_filter_one_target(
         self,
-        callback_context_filter_continent,
+        ctx_filter_continent,
         target_scatter_filtered_continent,
     ):
         # Creating and adding a Filter object to the existing Page
@@ -157,13 +157,13 @@ class TestFilter:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "callback_context_filter_continent,target_scatter_filtered_continent,target_box_filtered_continent",
+        "ctx_filter_continent,target_scatter_filtered_continent,target_box_filtered_continent",
         [(["Africa"], ["Africa"], ["Africa"]), (["Africa", "Europe"], ["Africa", "Europe"], ["Africa", "Europe"])],
         indirect=True,
     )
     def test_one_filter_multiple_targets(
         self,
-        callback_context_filter_continent,
+        ctx_filter_continent,
         target_scatter_filtered_continent,
         target_box_filtered_continent,
     ):
@@ -189,7 +189,7 @@ class TestFilter:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "callback_context_filter_continent_and_pop,target_scatter_filtered_continent_and_pop,target_box_filtered_continent_and_pop",
+        "ctx_filter_continent_and_pop,target_scatter_filtered_continent_and_pop,target_box_filtered_continent_and_pop",
         [
             ([["Africa"], [10**6, 10**7]], [["Africa"], [10**6, 10**7]], [["Africa"], [10**6, 10**7]]),
             (
@@ -202,7 +202,7 @@ class TestFilter:
     )
     def test_multiple_filters_no_targets(
         self,
-        callback_context_filter_continent_and_pop,
+        ctx_filter_continent_and_pop,
         target_scatter_filtered_continent_and_pop,
         target_box_filtered_continent_and_pop,
     ):
@@ -227,7 +227,7 @@ class TestFilter:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "callback_context_filter_continent_and_pop,target_scatter_filtered_continent_and_pop",
+        "ctx_filter_continent_and_pop,target_scatter_filtered_continent_and_pop",
         [
             ([["Africa"], [10**6, 10**7]], [["Africa"], [10**6, 10**7]]),
             ([["Africa", "Europe"], [10**6, 10**7]], [["Africa", "Europe"], [10**6, 10**7]]),
@@ -236,7 +236,7 @@ class TestFilter:
     )
     def test_multiple_filters_one_target(
         self,
-        callback_context_filter_continent_and_pop,
+        ctx_filter_continent_and_pop,
         target_scatter_filtered_continent_and_pop,
     ):
         # Creating and adding a Filter objects to the existing Page
@@ -262,7 +262,7 @@ class TestFilter:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "callback_context_filter_continent_and_pop,target_scatter_filtered_continent_and_pop,target_box_filtered_continent_and_pop",
+        "ctx_filter_continent_and_pop,target_scatter_filtered_continent_and_pop,target_box_filtered_continent_and_pop",
         [
             ([["Africa"], [10**6, 10**7]], [["Africa"], [10**6, 10**7]], [["Africa"], [10**6, 10**7]]),
             (
@@ -275,7 +275,7 @@ class TestFilter:
     )
     def test_multiple_filters_multiple_targets(
         self,
-        callback_context_filter_continent_and_pop,
+        ctx_filter_continent_and_pop,
         target_scatter_filtered_continent_and_pop,
         target_box_filtered_continent_and_pop,
     ):

--- a/vizro-core/tests/unit/vizro/actions/test_filter_interaction_action.py
+++ b/vizro-core/tests/unit/vizro/actions/test_filter_interaction_action.py
@@ -12,8 +12,8 @@ from vizro.managers import model_manager
 
 
 @pytest.fixture
-def callback_context_filter_interaction(request):
-    """Mock dash.callback_context that represents a click on a continent data-point and table selected cell."""
+def ctx_filter_interaction(request):
+    """Mock dash.ctx that represents a click on a continent data-point and table selected cell."""
     continent_filter_interaction, country_table_filter_interaction = request.param
 
     args_grouping_filter_interaction = []
@@ -66,7 +66,7 @@ def callback_context_filter_interaction(request):
             }
         )
 
-    mock_callback_context = {
+    mock_ctx = {
         "args_grouping": {
             "external": {
                 "filters": [],
@@ -82,7 +82,7 @@ def callback_context_filter_interaction(request):
             }
         }
     }
-    context_value.set(AttributeDict(**mock_callback_context))
+    context_value.set(AttributeDict(**mock_ctx))
     return context_value
 
 
@@ -114,10 +114,10 @@ def target_box_filtered_continent(request, gapminder_2007, box_params):
 
 @pytest.mark.usefixtures("managers_one_page_two_graphs_one_table_one_button")
 class TestFilterInteraction:
-    @pytest.mark.parametrize("callback_context_filter_interaction", [("Africa", None), ("Europe", None)], indirect=True)
+    @pytest.mark.parametrize("ctx_filter_interaction", [("Africa", None), ("Europe", None)], indirect=True)
     def test_filter_interaction_without_targets_temporary_behavior(  # temporary fix, see below test
         self,
-        callback_context_filter_interaction,
+        ctx_filter_interaction,
     ):
         # Add action to relevant component - here component[0] is the source_chart
         model_manager["box_chart"].actions = [vm.Action(id="test_action", function=filter_interaction())]
@@ -130,7 +130,7 @@ class TestFilterInteraction:
 
     @pytest.mark.xfail  # This is the desired behavior, ie when no target is provided, then all charts filtered
     @pytest.mark.parametrize(
-        "callback_context_filter_interaction,target_scatter_filtered_continent,target_box_filtered_continent",
+        "ctx_filter_interaction,target_scatter_filtered_continent,target_box_filtered_continent",
         [
             (("Africa", None), ("Africa", None), ("Africa", None)),
             (("Europe", None), ("Europe", None), ("Europe", None)),
@@ -140,7 +140,7 @@ class TestFilterInteraction:
     )
     def test_filter_interaction_without_targets_desired_behavior(
         self,
-        callback_context_filter_interaction,
+        ctx_filter_interaction,
         target_scatter_filtered_continent,
         target_box_filtered_continent,
     ):
@@ -157,7 +157,7 @@ class TestFilterInteraction:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "callback_context_filter_interaction,target_scatter_filtered_continent",
+        "ctx_filter_interaction,target_scatter_filtered_continent",
         [
             (("Africa", None), ("Africa", None)),
             (("Europe", None), ("Europe", None)),
@@ -167,7 +167,7 @@ class TestFilterInteraction:
     )
     def test_filter_interaction_with_one_target(
         self,
-        callback_context_filter_interaction,
+        ctx_filter_interaction,
         target_scatter_filtered_continent,
     ):
         # Add action to relevant component - here component[0] is the source_chart
@@ -184,7 +184,7 @@ class TestFilterInteraction:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "callback_context_filter_interaction,target_scatter_filtered_continent,target_box_filtered_continent",
+        "ctx_filter_interaction,target_scatter_filtered_continent,target_box_filtered_continent",
         [
             (("Africa", None), ("Africa", None), ("Africa", None)),
             (("Europe", None), ("Europe", None), ("Europe", None)),
@@ -194,7 +194,7 @@ class TestFilterInteraction:
     )
     def test_filter_interaction_with_two_target(
         self,
-        callback_context_filter_interaction,
+        ctx_filter_interaction,
         target_scatter_filtered_continent,
         target_box_filtered_continent,
     ):
@@ -214,11 +214,11 @@ class TestFilterInteraction:
 
     @pytest.mark.xfail  # This (or similar code) should raise a Value/Validation error explaining next steps
     @pytest.mark.parametrize("target", ["scatter_chart", ["scatter_chart"]])
-    @pytest.mark.parametrize("callback_context_filter_interaction", [("Africa", None), ("Europe", None)], indirect=True)
+    @pytest.mark.parametrize("ctx_filter_interaction", [("Africa", None), ("Europe", None)], indirect=True)
     def test_filter_interaction_with_invalid_targets(
         self,
         target,
-        callback_context_filter_interaction,
+        ctx_filter_interaction,
     ):
         with pytest.raises(ValueError, match="Target invalid_target not found in model_manager."):
             # Add action to relevant component - here component[0] is the source_chart
@@ -227,7 +227,7 @@ class TestFilterInteraction:
             ]
 
     @pytest.mark.parametrize(
-        "callback_context_filter_interaction,target_scatter_filtered_continent",
+        "ctx_filter_interaction,target_scatter_filtered_continent",
         [
             ((None, "Algeria"), (None, "Algeria")),
             ((None, "Albania"), (None, "Albania")),
@@ -237,7 +237,7 @@ class TestFilterInteraction:
     )
     def test_table_filter_interaction_with_one_target(
         self,
-        callback_context_filter_interaction,
+        ctx_filter_interaction,
         target_scatter_filtered_continent,
     ):
         model_manager["box_chart"].actions = [
@@ -256,7 +256,7 @@ class TestFilterInteraction:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "callback_context_filter_interaction, target_scatter_filtered_continent, target_box_filtered_continent",
+        "ctx_filter_interaction, target_scatter_filtered_continent, target_box_filtered_continent",
         [
             ((None, "Algeria"), (None, "Algeria"), (None, "Algeria")),
             ((None, "Albania"), (None, "Albania"), (None, "Albania")),
@@ -266,7 +266,7 @@ class TestFilterInteraction:
     )
     def test_table_filter_interaction_with_two_targets(
         self,
-        callback_context_filter_interaction,
+        ctx_filter_interaction,
         target_scatter_filtered_continent,
         target_box_filtered_continent,
     ):
@@ -289,7 +289,7 @@ class TestFilterInteraction:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "callback_context_filter_interaction, target_scatter_filtered_continent, target_box_filtered_continent",
+        "ctx_filter_interaction, target_scatter_filtered_continent, target_box_filtered_continent",
         [
             (("Africa", "Algeria"), ("Africa", "Algeria"), ("Africa", "Algeria")),
             (("Europe", "Albania"), ("Europe", "Albania"), ("Europe", "Albania")),
@@ -299,7 +299,7 @@ class TestFilterInteraction:
     )
     def test_mixed_chart_and_table_filter_interaction_with_two_targets(
         self,
-        callback_context_filter_interaction,
+        ctx_filter_interaction,
         target_scatter_filtered_continent,
         target_box_filtered_continent,
     ):

--- a/vizro-core/tests/unit/vizro/actions/test_on_page_load_action.py
+++ b/vizro-core/tests/unit/vizro/actions/test_on_page_load_action.py
@@ -39,10 +39,10 @@ def target_box_filtered_continent_and_pop_parameter_y_and_x(request, gapminder_2
 
 
 @pytest.fixture
-def callback_context_on_page_load(request):
-    """Mock dash.callback_context that represents on page load."""
+def ctx_on_page_load(request):
+    """Mock dash.ctx that represents on page load."""
     continent_filter, pop, y, x, template = request.param
-    mock_callback_context = {
+    mock_ctx = {
         "args_grouping": {
             "external": {
                 "filter_interaction": [],
@@ -88,14 +88,14 @@ def callback_context_on_page_load(request):
             }
         }
     }
-    context_value.set(AttributeDict(**mock_callback_context))
+    context_value.set(AttributeDict(**mock_ctx))
     return context_value
 
 
 class TestOnPageLoad:
     @pytest.mark.usefixtures("managers_one_page_two_graphs_one_button")
     @pytest.mark.parametrize(
-        "callback_context_on_page_load, target_scatter_filtered_continent_and_pop_parameter_y_and_x, template",
+        "ctx_on_page_load, target_scatter_filtered_continent_and_pop_parameter_y_and_x, template",
         [
             (
                 ["Africa", [10**6, 10**7], "pop", "continent", "vizro_dark"],
@@ -108,11 +108,11 @@ class TestOnPageLoad:
                 "vizro_light",
             ),
         ],
-        indirect=["callback_context_on_page_load", "target_scatter_filtered_continent_and_pop_parameter_y_and_x"],
+        indirect=["ctx_on_page_load", "target_scatter_filtered_continent_and_pop_parameter_y_and_x"],
     )
     def test_multiple_controls_one_target(
         self,
-        callback_context_on_page_load,
+        ctx_on_page_load,
         target_scatter_filtered_continent_and_pop_parameter_y_and_x,
         template,
         box_chart,
@@ -163,7 +163,7 @@ class TestOnPageLoad:
 
     @pytest.mark.usefixtures("managers_one_page_two_graphs_one_button")
     @pytest.mark.parametrize(
-        "callback_context_on_page_load, "
+        "ctx_on_page_load, "
         "target_scatter_filtered_continent_and_pop_parameter_y_and_x, "
         "target_box_filtered_continent_and_pop_parameter_y_and_x",
         [
@@ -182,7 +182,7 @@ class TestOnPageLoad:
     )
     def test_multiple_controls_multiple_targets(
         self,
-        callback_context_on_page_load,
+        ctx_on_page_load,
         target_scatter_filtered_continent_and_pop_parameter_y_and_x,
         target_box_filtered_continent_and_pop_parameter_y_and_x,
     ):

--- a/vizro-core/tests/unit/vizro/actions/test_parameter_action.py
+++ b/vizro-core/tests/unit/vizro/actions/test_parameter_action.py
@@ -49,10 +49,10 @@ def target_box_parameter_y_and_x(request, gapminder_2007, box_params):
 
 
 @pytest.fixture
-def callback_context_parameter_y(request):
-    """Mock dash.callback_context that represents y-axis Parameter value selection."""
+def ctx_parameter_y(request):
+    """Mock dash.ctx that represents y-axis Parameter value selection."""
     y = request.param
-    mock_callback_context = {
+    mock_ctx = {
         "args_grouping": {
             "external": {
                 "filter_interaction": [],
@@ -76,15 +76,15 @@ def callback_context_parameter_y(request):
             }
         }
     }
-    context_value.set(AttributeDict(**mock_callback_context))
+    context_value.set(AttributeDict(**mock_ctx))
     return context_value
 
 
 @pytest.fixture
-def callback_context_parameter_hover_data(request):
-    """Mock dash.callback_context that represents hover_data Parameter value selection."""
+def ctx_parameter_hover_data(request):
+    """Mock dash.ctx that represents hover_data Parameter value selection."""
     hover_data = request.param
-    mock_callback_context = {
+    mock_ctx = {
         "args_grouping": {
             "external": {
                 "filter_interaction": [],
@@ -108,15 +108,15 @@ def callback_context_parameter_hover_data(request):
             }
         }
     }
-    context_value.set(AttributeDict(**mock_callback_context))
+    context_value.set(AttributeDict(**mock_ctx))
     return context_value
 
 
 @pytest.fixture
-def callback_context_parameter_y_and_x(request):
-    """Mock dash.callback_context that represents y-axis Parameter value selection."""
+def ctx_parameter_y_and_x(request):
+    """Mock dash.ctx that represents y-axis Parameter value selection."""
     y, x = request.param
-    mock_callback_context = {
+    mock_ctx = {
         "args_grouping": {
             "external": {
                 "filter_interaction": [],
@@ -147,20 +147,20 @@ def callback_context_parameter_y_and_x(request):
             }
         }
     }
-    context_value.set(AttributeDict(**mock_callback_context))
+    context_value.set(AttributeDict(**mock_ctx))
     return context_value
 
 
 @pytest.mark.usefixtures("managers_one_page_two_graphs_one_button")
 class TestParameter:
     @pytest.mark.parametrize(
-        "callback_context_parameter_y, target_scatter_parameter_y",
+        "ctx_parameter_y, target_scatter_parameter_y",
         [("pop", "pop"), ("gdpPercap", "gdpPercap"), ("NONE", None)],
         indirect=True,
     )
     def test_one_parameter_one_target(
         self,
-        callback_context_parameter_y,
+        ctx_parameter_y,
         target_scatter_parameter_y,
     ):
         # Creating and adding a Parameter object to the existing Page
@@ -183,7 +183,7 @@ class TestParameter:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "callback_context_parameter_hover_data, target_scatter_parameter_hover_data",
+        "ctx_parameter_hover_data, target_scatter_parameter_hover_data",
         [
             (["NONE"], [None]),
             (["NONE", "pop"], ["pop"]),
@@ -196,7 +196,7 @@ class TestParameter:
     )
     def test_one_parameter_one_target_NONE_list(
         self,
-        callback_context_parameter_hover_data,
+        ctx_parameter_hover_data,
         target_scatter_parameter_hover_data,
     ):
         # Creating and adding a Parameter object to the existing Page
@@ -221,13 +221,13 @@ class TestParameter:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "callback_context_parameter_y, target_scatter_parameter_y, target_box_parameter_y",
+        "ctx_parameter_y, target_scatter_parameter_y, target_box_parameter_y",
         [("pop", "pop", "pop"), ("gdpPercap", "gdpPercap", "gdpPercap")],
         indirect=True,
     )
     def test_one_parameter_multiple_targets(
         self,
-        callback_context_parameter_y,
+        ctx_parameter_y,
         target_scatter_parameter_y,
         target_box_parameter_y,
     ):
@@ -252,13 +252,13 @@ class TestParameter:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "callback_context_parameter_y_and_x, target_scatter_parameter_y_and_x",
+        "ctx_parameter_y_and_x, target_scatter_parameter_y_and_x",
         [(["pop", "continent"], ["pop", "continent"]), (["gdpPercap", "country"], ["gdpPercap", "country"])],
         indirect=True,
     )
     def test_multiple_parameters_one_target(
         self,
-        callback_context_parameter_y_and_x,
+        ctx_parameter_y_and_x,
         target_scatter_parameter_y_and_x,
     ):
         # Creating and adding a Parameter object to the existing Page
@@ -287,7 +287,7 @@ class TestParameter:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "callback_context_parameter_y_and_x, target_scatter_parameter_y_and_x, target_box_parameter_y_and_x",
+        "ctx_parameter_y_and_x, target_scatter_parameter_y_and_x, target_box_parameter_y_and_x",
         [
             (["pop", "continent"], ["pop", "continent"], ["pop", "continent"]),
             (["gdpPercap", "country"], ["gdpPercap", "country"], ["gdpPercap", "country"]),
@@ -296,7 +296,7 @@ class TestParameter:
     )
     def test_multiple_parameters_multiple_targets(
         self,
-        callback_context_parameter_y_and_x,
+        ctx_parameter_y_and_x,
         target_scatter_parameter_y_and_x,
         target_box_parameter_y_and_x,
     ):
@@ -327,7 +327,7 @@ class TestParameter:
         assert result == expected
 
     @pytest.mark.parametrize(
-        "callback_context_parameter_y_and_x, target_scatter_parameter_y_and_x, target_box_parameter_y_and_x",
+        "ctx_parameter_y_and_x, target_scatter_parameter_y_and_x, target_box_parameter_y_and_x",
         [
             (["pop", "continent"], ["pop", "pop"], ["continent", "continent"]),
             (["gdpPercap", "country"], ["gdpPercap", "gdpPercap"], ["country", "country"]),
@@ -336,7 +336,7 @@ class TestParameter:
     )
     def test_one_parameter_per_target_multiple_attributes(
         self,
-        callback_context_parameter_y_and_x,
+        ctx_parameter_y_and_x,
         target_scatter_parameter_y_and_x,
         target_box_parameter_y_and_x,
     ):

--- a/vizro-core/tests/unit/vizro/models/_components/test_graph.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_graph.py
@@ -110,7 +110,7 @@ class TestDunderMethodsGraph:
 
     @pytest.mark.parametrize("template", ["vizro_dark", "vizro_light"])
     def test_update_theme_inside_callback(self, standard_px_chart, template):
-        mock_callback_context = {
+        mock_ctx = {
             "args_grouping": {
                 "external": {
                     "theme_selector": CallbackTriggerDict(
@@ -123,7 +123,7 @@ class TestDunderMethodsGraph:
                 }
             }
         }
-        context_value.set(AttributeDict(**mock_callback_context))
+        context_value.set(AttributeDict(**mock_ctx))
         graph = vm.Graph(figure=standard_px_chart).__call__()
         assert graph == standard_px_chart.update_layout(margin_t=24, template=template)
 


### PR DESCRIPTION
## Description
- Small clean-up PR to use `ctx` instead of `callback_context` consistently to be less verbose and use official abbreviations, see [here](https://community.plotly.com/t/dash-2-4-released-improved-callback-context-clientside-callback-promises-typescript-components-minor-ticks-and-more/64203) 

Note: ctx shortcut currently doesn't exist for `dash_clientside` yet, so there we would use the old syntax. However, with this [recent PR](https://github.com/plotly/dash/pull/2695) on Dash that got merged (but not released), we should be able to replace something like:

`window.dash_clientside.callback_context.triggered[0].prop_id.split('.')[0]` with
`window.dash_clientside.callback_context.trigger_id` in the future if we upgrade to the latest Dash version

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
