### PR TITLE
Add warnings about incompatibility with dbc.themes

### DIFF
--- a/vizro-core/changelog.d/20240109_183336_huong_li_nguyen_warning_bootstrap.md
+++ b/vizro-core/changelog.d/20240109_183336_huong_li_nguyen_warning_bootstrap.md
@@ -1,0 +1,47 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+
+### Changed
+
+- Add warning to docs about incompatibility with Dash Bootstrap Themes. ([#258](https://github.com/mckinsey/vizro/pull/258))
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/changelog.d/20240109_183336_huong_li_nguyen_warning_bootstrap.md
+++ b/vizro-core/changelog.d/20240109_183336_huong_li_nguyen_warning_bootstrap.md
@@ -22,11 +22,12 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 - A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
 
 -->
-
+<!--
 ### Changed
 
-- Add warning to docs about incompatibility with Dash Bootstrap Themes. ([#258](https://github.com/mckinsey/vizro/pull/258))
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
 
+-->
 <!--
 ### Deprecated
 

--- a/vizro-core/docs/pages/user_guides/assets.md
+++ b/vizro-core/docs/pages/user_guides/assets.md
@@ -19,6 +19,11 @@ The user-provided `assets` folder thus always takes precedence.
 │   ├── favicon.ico
 ```
 
+!!! warning "Dash Bootstrap Themes"
+
+    Please note that Vizro currently does not support Dash Bootstrap Themes. Adding a Bootstrap stylesheet will not work
+    accordingly inside the Vizro app.
+
 ## Changing the favicon
 To change the default favicon (website icon appearing in the browser tab), add a file named `favicon.ico` to your `assets` folder.
 For more information, see the [Dash documentation](https://dash.plotly.com/external-resources#changing-the-favicon).

--- a/vizro-core/docs/pages/user_guides/assets.md
+++ b/vizro-core/docs/pages/user_guides/assets.md
@@ -21,8 +21,8 @@ The user-provided `assets` folder thus always takes precedence.
 
 !!! warning "Dash Bootstrap Themes"
 
-    Please note that Vizro currently does not support Dash Bootstrap Themes. Adding a Bootstrap stylesheet will not work
-    accordingly inside the Vizro app.
+    Please note that Vizro currently does not support [Dash Bootstrap Themes](https://dash-bootstrap-components.opensource.faculty.ai/docs/themes/).
+    Adding a Bootstrap stylesheet will not work accordingly inside the Vizro app.
 
 ## Changing the favicon
 To change the default favicon (website icon appearing in the browser tab), add a file named `favicon.ico` to your `assets` folder.

--- a/vizro-core/docs/pages/user_guides/assets.md
+++ b/vizro-core/docs/pages/user_guides/assets.md
@@ -21,8 +21,8 @@ The user-provided `assets` folder thus always takes precedence.
 
 !!! warning "Dash Bootstrap Themes"
 
-    Please note that Vizro currently does not support [Dash Bootstrap Themes](https://dash-bootstrap-components.opensource.faculty.ai/docs/themes/).
-    Adding a Bootstrap stylesheet will not work accordingly inside the Vizro app.
+    Please note that Vizro is currently not compatible with [Dash Bootstrap Themes](https://dash-bootstrap-components.opensource.faculty.ai/docs/themes/).
+    Adding a Bootstrap stylesheet will not work properly inside the Vizro app.
 
 ## Changing the favicon
 To change the default favicon (website icon appearing in the browser tab), add a file named `favicon.ico` to your `assets` folder.

--- a/vizro-core/docs/pages/user_guides/custom_components.md
+++ b/vizro-core/docs/pages/user_guides/custom_components.md
@@ -11,10 +11,9 @@ In general, you can create a custom component based on any dash-compatible compo
 
 !!! warning "Adding a dash-bootstrap component"
 
-    Please note that Vizro currently does not embed a Bootstrap stylesheet by default.
-    A [dash-bootstrap component](https://dash-bootstrap-components.opensource.faculty.ai/) may not function as intended due to missing CSS classnames and media queries.
-    As such, the dbc.components revert to basic HTML elements.
-    If you create a custom component based on a dash-bootstrap component,  please ensure proper styling and functionality via custom CSS.
+    Please note that Vizro currently does not include a default Bootstrap stylesheet, which
+    can lead to issues when using [dash-bootstrap components](https://dash-bootstrap-components.opensource.faculty.ai/) as custom components.
+    To ensure proper styling and functionality, adding custom CSS is required.
 
 All our components are based on `Dash`, and they are shipped with a set of sensible defaults that can be modified. If you would like to overwrite one of those defaults,
 or if you would like to use additional `args` or `kwargs` of those components, then this is the correct way to include those. You can very easily use any existing attribute of any underlying Dash component with this method.

--- a/vizro-core/docs/pages/user_guides/custom_components.md
+++ b/vizro-core/docs/pages/user_guides/custom_components.md
@@ -11,8 +11,10 @@ In general, you can create a custom component based on any dash-compatible compo
 
 !!! warning "Adding a dash-bootstrap component"
 
-    By default, Vizro does not come with a Bootstrap stylesheet. A dash-bootstrap component might not work correctly if required CSS media queries are not in the assets folder.
-    If you create a custom component based on a dash-bootstrap component that requires CSS media queries,  please ensure these are in the assets folder.
+    Please note that Vizro currently does not embed a Bootstrap stylesheet by default.
+    A [dash-bootstrap component](https://dash-bootstrap-components.opensource.faculty.ai/) may not function as intended due to missing CSS classnames and media queries.
+    As such, the dbc.components revert to basic HTML elements.
+    If you create a custom component based on a dash-bootstrap component,  please ensure proper styling and functionality via custom CSS.
 
 All our components are based on `Dash`, and they are shipped with a set of sensible defaults that can be modified. If you would like to overwrite one of those defaults,
 or if you would like to use additional `args` or `kwargs` of those components, then this is the correct way to include those. You can very easily use any existing attribute of any underlying Dash component with this method.

--- a/vizro-core/docs/pages/user_guides/custom_components.md
+++ b/vizro-core/docs/pages/user_guides/custom_components.md
@@ -11,9 +11,8 @@ In general, you can create a custom component based on any dash-compatible compo
 
 !!! warning "Adding a dash-bootstrap component"
 
-    Please note that Vizro currently does not include a default Bootstrap stylesheet, which
-    can lead to issues when using [dash-bootstrap components](https://dash-bootstrap-components.opensource.faculty.ai/) as custom components.
-    To ensure proper styling and functionality, adding custom CSS is required.
+    When adding a custom component based on [dash-bootstrap components](https://dash-bootstrap-components.opensource.faculty.ai/)
+    it’s necessary to add custom CSS to ensure proper styling and functionality.
 
 All our components are based on `Dash`, and they are shipped with a set of sensible defaults that can be modified. If you would like to overwrite one of those defaults,
 or if you would like to use additional `args` or `kwargs` of those components, then this is the correct way to include those. You can very easily use any existing attribute of any underlying Dash component with this method.

--- a/vizro-core/docs/pages/user_guides/custom_components.md
+++ b/vizro-core/docs/pages/user_guides/custom_components.md
@@ -9,6 +9,11 @@ This guide shows you how to create custom components that are completely new, or
 In general, you can create a custom component based on any dash-compatible component (e.g. [dash-core-components](https://dash.plotly.com/dash-core-components),
 [dash-bootstrap-components](https://dash-bootstrap-components.opensource.faculty.ai/), [dash-html-components](https://github.com/plotly/dash/tree/dev/components/dash-html-components), etc.).
 
+!!! warning "Adding a dash-bootstrap component"
+
+    By default, Vizro does not come with a Bootstrap stylesheet. A dash-bootstrap component might not work correctly if required CSS media queries are not in the assets folder.
+    If you create a custom component based on a dash-bootstrap component that requires CSS media queries,  please ensure these are in the assets folder.
+
 All our components are based on `Dash`, and they are shipped with a set of sensible defaults that can be modified. If you would like to overwrite one of those defaults,
 or if you would like to use additional `args` or `kwargs` of those components, then this is the correct way to include those. You can very easily use any existing attribute of any underlying Dash component with this method.
 
@@ -274,4 +279,5 @@ vm.Page.add_type("components", Jumbotron)
     function or integration they write - especially with regard to leaking any sensitive information or exposing to
     any security threat during implementation.
 
-    By default, all Dash components in Vizro that persist client-side data set [`persistence_type="session"` to use `window.SessionStorage`](https://dash.plotly.com/persistence), which is cleared upon closing the browser. Be careful when using any custom components that persist data beyond this scope: it is your responsibility to ensure compliance with any legal requirements affecting jurisdictions in which your app operates.
+    By default, all Dash components in Vizro that persist client-side data set [`persistence_type="session"` to use `window.SessionStorage`](https://dash.plotly.com/persistence), which is cleared upon closing the browser.
+    Be careful when using any custom components that persist data beyond this scope: it is your responsibility to ensure compliance with any legal requirements affecting jurisdictions in which your app operates.


### PR DESCRIPTION
## Description
- Add warning about incompatibility with `dbc.themes`, see this issue: https://github.com/mckinsey/vizro/issues/235
- Add warning about using dbc components (if required CSS media queries are not inside assets folder)

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
