### PR TITLE
Make kedro unit test always run

### DIFF
--- a/vizro-core/changelog.d/20240110_171937_alexey_snigir_make_kedro_test_run.md
+++ b/vizro-core/changelog.d/20240110_171937_alexey_snigir_make_kedro_test_run.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -25,7 +25,8 @@ dependencies = [
   "chromedriver-autoinstaller-fix",
   "toml",
   "pyyaml",
-  "openpyxl"
+  "openpyxl",
+  "kedro>=0.17.3"  # added to run test_get_action_callback_mapping.py::test_datasets_from_catalog unit test
 ]
 
 [envs.default.env-vars]

--- a/vizro-core/tests/unit/vizro/actions/_callback_mapping/test_get_action_callback_mapping.py
+++ b/vizro-core/tests/unit/vizro/actions/_callback_mapping/test_get_action_callback_mapping.py
@@ -16,14 +16,14 @@ from vizro.models.types import capture
 
 @capture("action")
 def custom_action_example():
-    pass
+    pass  # pragma: no cov
 
 
 # custom action with same name as some predefined action
 def get_custom_action_with_known_name():
     @capture("action")
     def export_data():
-        pass
+        pass  # pragma: no cov
 
     return export_data()
 

--- a/vizro-core/tests/unit/vizro/models/test_layout.py
+++ b/vizro-core/tests/unit/vizro/models/test_layout.py
@@ -144,7 +144,7 @@ class TestWorkingGrid:
     def test_working_grid(self, grid):
         try:
             vm.Layout(grid=grid)
-        except ValidationError as ve:
+        except ValidationError as ve:  # pragma: no cov
             assert False, f"{grid} raised a value error {ve}."
 
 

--- a/vizro-core/tests/unit/vizro/models/test_types.py
+++ b/vizro-core/tests/unit/vizro/models/test_types.py
@@ -15,11 +15,11 @@ from vizro.models.types import CapturedCallable, capture
 
 
 def positional_only_function(a, /):
-    pass
+    pass  # pragma: no cov
 
 
 def var_positional_function(*args):
-    pass
+    pass  # pragma: no cov
 
 
 @pytest.mark.parametrize("function", [positional_only_function, var_positional_function])
@@ -179,7 +179,7 @@ def decorated_graph_function_px(data_frame):
 
 @capture("graph")
 def invalid_decorated_graph_function():
-    return go.Figure()
+    return go.Figure()  # pragma: no cov
 
 
 class Model(VizroBaseModel):


### PR DESCRIPTION
## Description

`test_get_action_callback_mapping.py::test_datasets_from_catalog` unit test was skipped from running because kedro was not installed.
Added kedro to the hatch env requirements.
Also to make things identical I've added `# pragma: no cov` to the problematic lines in tests found by the `coverage` lib

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
