### PR TITLE
Feature: load env automatically

### DIFF
--- a/vizro-ai/changelog.d/20240118_144903_anna_xiong_load_env_automatically.md
+++ b/vizro-ai/changelog.d/20240118_144903_anna_xiong_load_env_automatically.md
@@ -19,7 +19,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Added
 
-- Enable automatic loading of .env ([#270](https://github.com/mckinsey/vizro/pull/270))
+- Enable automatic loading of environment variables in a `.env` file ([#270](https://github.com/mckinsey/vizro/pull/270))
 
 <!--
 ### Changed

--- a/vizro-ai/changelog.d/20240118_144903_anna_xiong_load_env_automatically.md
+++ b/vizro-ai/changelog.d/20240118_144903_anna_xiong_load_env_automatically.md
@@ -1,0 +1,46 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+### Added
+
+- Enable feature automatically loading of .env ([#270](https://github.com/mckinsey/vizro/pull/270))
+
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-ai/changelog.d/20240118_144903_anna_xiong_load_env_automatically.md
+++ b/vizro-ai/changelog.d/20240118_144903_anna_xiong_load_env_automatically.md
@@ -16,6 +16,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 - A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
 
 -->
+
 ### Added
 
 - Enable feature automatically loading of .env ([#270](https://github.com/mckinsey/vizro/pull/270))

--- a/vizro-ai/changelog.d/20240118_144903_anna_xiong_load_env_automatically.md
+++ b/vizro-ai/changelog.d/20240118_144903_anna_xiong_load_env_automatically.md
@@ -19,7 +19,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Added
 
-- Enable feature automatically loading of .env ([#270](https://github.com/mckinsey/vizro/pull/270))
+- Enable automatic loading of .env ([#270](https://github.com/mckinsey/vizro/pull/270))
 
 <!--
 ### Changed

--- a/vizro-ai/docs/pages/tutorials/explore_vizro_ai.md
+++ b/vizro-ai/docs/pages/tutorials/explore_vizro_ai.md
@@ -13,7 +13,7 @@ Before proceeding, ensure the installation of the `vizro_ai` package by followin
 
 A prerequisite for this tutorial is access to one of the supported large language models. Please refer to the [api setup](../user_guides/api_setup.md) for instructions on setting up the API.
 
-Upon successful setup, your API key should be ready in the environment when you import `vizro_ai`
+Upon successful setup, your API key should be ready in the environment when you import `vizro_ai`.
 
 If you would like to customize the `.env` file location and name, you can set it manually.
 You can override the default import of the `.env` file by specifying the path and name of your custom `.env` file.

--- a/vizro-ai/docs/pages/tutorials/explore_vizro_ai.md
+++ b/vizro-ai/docs/pages/tutorials/explore_vizro_ai.md
@@ -15,7 +15,7 @@ A prerequisite for this tutorial is access to one of the supported large languag
 
 Upon successful setup, your API key should be ready in the environment when you import `vizro_ai`
 
-If you would like to customize the .env file location and name, you can set it manually.
+If you would like to customize the `.env` file location and name, you can set it manually.
 You can override the default import of the .env file by specifying the path and name of your custom .env file.
 Please refer to [api setup](../user_guides/api_setup.md) for instructions on customizing the `.env` file location and name.
 

--- a/vizro-ai/docs/pages/tutorials/explore_vizro_ai.md
+++ b/vizro-ai/docs/pages/tutorials/explore_vizro_ai.md
@@ -16,7 +16,7 @@ A prerequisite for this tutorial is access to one of the supported large languag
 Upon successful setup, your API key should be ready in the environment when you import `vizro_ai`
 
 If you would like to customize the `.env` file location and name, you can set it manually.
-You can override the default import of the .env file by specifying the path and name of your custom .env file.
+You can override the default import of the `.env` file by specifying the path and name of your custom `.env` file.
 Please refer to [api setup](../user_guides/api_setup.md) for instructions on customizing the `.env` file location and name.
 
 ### 2. Create your visualization using different languages

--- a/vizro-ai/docs/pages/tutorials/explore_vizro_ai.md
+++ b/vizro-ai/docs/pages/tutorials/explore_vizro_ai.md
@@ -17,7 +17,7 @@ Upon successful setup, your API key should be ready in the environment when you 
 
 If you would like to customize the `.env` file location and name, you can set it manually.
 You can override the default import of the `.env` file by specifying the path and name of your custom `.env` file.
-Please refer to [api setup](../user_guides/api_setup.md) for instructions on customizing the `.env` file location and name.
+Please refer to [API setup](../user_guides/api_setup.md) for instructions on customizing the `.env` file location and name.
 
 ### 2. Create your visualization using different languages
 

--- a/vizro-ai/docs/pages/tutorials/explore_vizro_ai.md
+++ b/vizro-ai/docs/pages/tutorials/explore_vizro_ai.md
@@ -17,7 +17,7 @@ Upon successful setup, your api key should be ready in the environment when you 
 
 If you would like to customize the .env file location and name, you can set it manually.
 You can override the default import of the .env file by specifying the path and name of your custom .env file.
-Please refer to [api setup](../user_guides/api_setup.md) for instructions on customizing the .env file location and name.
+Please refer to [api setup](../user_guides/api_setup.md) for instructions on customizing the `.env` file location and name.
 
 ### 2. Create your visualization using different languages
 

--- a/vizro-ai/docs/pages/tutorials/explore_vizro_ai.md
+++ b/vizro-ai/docs/pages/tutorials/explore_vizro_ai.md
@@ -13,7 +13,7 @@ Before proceeding, ensure the installation of the `vizro_ai` package by followin
 
 A prerequisite for this tutorial is access to one of the supported large language models. Please refer to the [api setup](../user_guides/api_setup.md) for instructions on setting up the API.
 
-Upon successful setup, your api key should be ready in the environment when you import `vizro_ai`
+Upon successful setup, your API key should be ready in the environment when you import `vizro_ai`
 
 If you would like to customize the .env file location and name, you can set it manually.
 You can override the default import of the .env file by specifying the path and name of your custom .env file.

--- a/vizro-ai/docs/pages/tutorials/explore_vizro_ai.md
+++ b/vizro-ai/docs/pages/tutorials/explore_vizro_ai.md
@@ -13,12 +13,11 @@ Before proceeding, ensure the installation of the `vizro_ai` package by followin
 
 A prerequisite for this tutorial is access to one of the supported large language models. Please refer to the [api setup](../user_guides/api_setup.md) for instructions on setting up the API.
 
-Upon successful setup, load your API key with the following two lines:
+Upon successful setup, your api key should be ready in the environment when you import `vizro_ai`
 
-```py
-from dotenv import load_dotenv
-load_dotenv()
-```
+If you would like to customize the .env file location and name, you can set it manually.
+You can override the default import of the .env file by specifying the path and name of your custom .env file.
+Please refer to [api setup](../user_guides/api_setup.md) for instructions on customizing the .env file location and name.
 
 ### 2. Create your visualization using different languages
 
@@ -30,10 +29,8 @@ Vizro-AI is versatile, supporting prompts and chart visualizations in multiple l
         from vizro_ai import VizroAI
         import vizro.plotly.express as px
 
-        from dotenv import load_dotenv
-        load_dotenv()
-
         df = px.data.gapminder()
+
         vizro_ai = VizroAI()
         vizro_ai.plot(df, "请画一个世界年均GDP的趋势图")
         ```
@@ -50,10 +47,8 @@ Subsequently, we'll switch to German and prompt the visualization of life expect
         from vizro_ai import VizroAI
         import vizro.plotly.express as px
 
-        from dotenv import load_dotenv
-        load_dotenv()
-
         df = px.data.gapminder()
+
         vizro_ai = VizroAI()
         vizro_ai.plot(df, "Visualiere den Trend von der Lebenserwartung in USA über die Jahre im Vergleich zur Veränderung der weltweiten Lebenserwartung über die Jahre und kreiere eine deutsche Visualisierung", explain=True)
         ```
@@ -73,10 +68,8 @@ To begin, we'll create an animated bar chart illustrating the population develop
         from vizro_ai import VizroAI
         import vizro.plotly.express as px
 
-        from dotenv import load_dotenv
-        load_dotenv()
-
         df = px.data.gapminder()
+
         vizro_ai = VizroAI()
         vizro_ai.plot(df, "The chart should be an animated stacked bar chart with popoluation on the y axis and continent on the x axis with all respective countries, allowing you to observe changes in the population over consecutive years.")
         ```
@@ -93,10 +86,8 @@ Having unveiled our animated bar chart showcasing population development per cou
         from vizro_ai import VizroAI
         import vizro.plotly.express as px
 
-        from dotenv import load_dotenv
-        load_dotenv()
-
         df = px.data.gapminder()
+
         vizro_ai = VizroAI()
         vizro_ai.plot(df, "The chart should be an animated stacked bar chart with popoluation on the y axis and continent on the x axis with all respective countries, allowing you to observe changes in the population over consecutive years. Please improve layout.")
         ```
@@ -116,10 +107,8 @@ Now, upon closer inspection, two challenges emerge. Firstly, the legend overlaps
         from vizro_ai import VizroAI
         import vizro.plotly.express as px
 
-        from dotenv import load_dotenv
-        load_dotenv()
-
         df = px.data.gapminder()
+
         vizro_ai = VizroAI()
         vizro_ai.plot(df, "The chart should be an animated stacked bar chart with population on the y axis and continent on the x axis with all respective countries, allowing you to observe changes in the population over consecutive years. Make sure that y axis range fits entire data. Please improve layout and optimize layout of legend.")
         ```

--- a/vizro-ai/docs/pages/tutorials/quickstart.md
+++ b/vizro-ai/docs/pages/tutorials/quickstart.md
@@ -41,13 +41,6 @@ You should see a return output of the version.
 
 A prerequisite to use Vizro-AI is access to one of the supported LLMs. Refer to the [user guide](../user_guides/api_setup.md) on how to set up the API.
 
-After successful setup, your API key is loaded in Jupyter with the following two lines:
-
-```py
-from dotenv import load_dotenv
-load_dotenv()
-```
-
 ### 4. Ask your first question using Vizro-AI
 
 For your first visualization, we will create a chart illustrating the GDP of various continents while including a reference line for the average.
@@ -62,10 +55,8 @@ By passing your prepared data and your written visualization request to this met
         from vizro_ai import VizroAI
         import vizro.plotly.express as px
 
-        from dotenv import load_dotenv
-        load_dotenv()
-
         df = px.data.gapminder()
+
         vizro_ai = VizroAI()
         vizro_ai.plot(df, "describe the composition of gdp in continent and color by continent, and add a horizontal line for avg gdp")
         ```

--- a/vizro-ai/docs/pages/user_guides/api_setup.md
+++ b/vizro-ai/docs/pages/user_guides/api_setup.md
@@ -18,7 +18,7 @@ file. Then, you can load the API key from the `.env` file in your development en
 Avoid committing the `.env` file if you are using a version control system such as Git.
 You can add `.env` to your `.gitignore` file to avoid committing it.
 
-By default, when vizro-ai is imported, it automatically loads the `.env` file.
+By default, when `vizro-ai` is imported, it automatically loads the `.env` file.
 This file is searched for in the current directory and, if not found, the search continues upwards through the directory hierarchy.
 
 !!! example "API key setup and usage"

--- a/vizro-ai/docs/pages/user_guides/api_setup.md
+++ b/vizro-ai/docs/pages/user_guides/api_setup.md
@@ -32,10 +32,10 @@ The default import of the `.env` file can be overridden by specifying the path a
 Here's how you can do it:
 ```py
 from dotenv import load_dotenv, find_dotenv
-from os.path import join, dirname
+from pathlib import Path
 
 # Specify the exact path to your .env file
-env_file = join(dirname(__file__), '.env')  # Adjust the path as needed
+env_file = Path.cwd() / ".env"  # Adjust the path as needed
 
 # Alternatively, specify a different .env file name
 env_file = find_dotenv(".env.dev")  # Replace ".env.dev" with your file name

--- a/vizro-ai/docs/pages/user_guides/api_setup.md
+++ b/vizro-ai/docs/pages/user_guides/api_setup.md
@@ -18,16 +18,33 @@ file. Then, you can load the API key from the `.env` file in your development en
 Avoid committing the `.env` file if you are using a version control system such as Git.
 You can add `.env` to your `.gitignore` file to avoid committing it.
 
+By default, when vizro-ai is imported, it automatically loads the `.env` file.
+This file is searched for in the current directory and, if not found, the search continues upwards through the directory hierarchy.
+
 !!! example "API key setup and usage"
     === ".env"
         ```text
         OPENAI_API_KEY=<your API key>
         ```
-    === "Jupyter Notebook"
-        ```python
-        from dotenv import load_dotenv
-        load_dotenv()
-        ```
+#### Customizing the .env file location and name
+If you would like to customize the .env file location and name, you can set it manually.
+The default import of the .env file can be overridden by specifying the path and name.
+Here's how you can do it:
+```py
+from dotenv import load_dotenv, find_dotenv
+from os.path import join, dirname
+
+# Specify the exact path to your .env file
+env_file = join(dirname(__file__), '.env')  # Adjust the path as needed
+
+# Alternatively, specify a different .env file name
+env_file = find_dotenv(".env.dev")  # Replace ".env.dev" with your file name
+
+# Load the specified .env file
+load_dotenv(env_file)
+```
+Note: Please refer to [python-dotenv documentation](https://saurabh-kumar.com/python-dotenv/reference/) for detailed information.
+
 
 __Method 2: Set up the API key as an environment variable for all projects__
 

--- a/vizro-ai/docs/pages/user_guides/api_setup.md
+++ b/vizro-ai/docs/pages/user_guides/api_setup.md
@@ -28,7 +28,7 @@ This file is searched for in the current directory and, if not found, the search
         ```
 #### Customizing the .env file location and name
 If you would like to customize the .env file location and name, you can set it manually.
-The default import of the .env file can be overridden by specifying the path and name.
+The default import of the `.env` file can be overridden by specifying the path and name.
 Here's how you can do it:
 ```py
 from dotenv import load_dotenv, find_dotenv

--- a/vizro-ai/docs/pages/user_guides/api_setup.md
+++ b/vizro-ai/docs/pages/user_guides/api_setup.md
@@ -27,7 +27,7 @@ This file is searched for in the current directory and, if not found, the search
         OPENAI_API_KEY=<your API key>
         ```
 #### Customizing the .env file location and name
-If you would like to customize the .env file location and name, you can set it manually.
+If you would like to customize the `.env` file location and name, you can set it manually.
 The default import of the `.env` file can be overridden by specifying the path and name.
 Here's how you can do it:
 ```py

--- a/vizro-ai/docs/pages/user_guides/run_vizro_ai.md
+++ b/vizro-ai/docs/pages/user_guides/run_vizro_ai.md
@@ -15,9 +15,6 @@ To run Vizro-AI in jupyter, create a new cell and execute the code below to rend
         import vizro.plotly.express as px
         from vizro_ai import VizroAI
 
-        from dotenv import load_dotenv
-        load_dotenv()
-
         vizro_ai = VizroAI()
 
         df = px.data.gapminder()

--- a/vizro-ai/src/vizro_ai/__init__.py
+++ b/vizro-ai/src/vizro_ai/__init__.py
@@ -1,6 +1,10 @@
 import logging
 import os
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 from ._vizro_ai import VizroAI
 
 __all__ = ["VizroAI"]


### PR DESCRIPTION
## Description

**Fearure: when vizro-ai is imported, we load `.env` in the same directory where the program is run.** 

limitation: 
- The load_dotenv function, by default, searches for .env files starting from the current directory and moving upwards, as detailed in the [python-dotenv documentation](https://saurabh-kumar.com/python-dotenv/reference/). This search behavior is typically sufficient for most projects.

-  User can overwrite the default import of .env manually as below:
```
env_file = join(dirname(__file__), '.env')
# or with different name
env_file = find_dotenv(".env.dev")
load_dotenv(env_file)
```


## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
