### PR TITLE
Remove pin and pyarrow dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
+# THIS IS NOT DESCRIBING A PACKAGE, but the DEV environment of this mono-repo
+# In order to install the packages of this mono-repo from source, refer to the pyproject.toml in the relevant folder
 [project]
 authors = [
   {name = "Vizro Team"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 # THIS IS NOT DESCRIBING A PACKAGE, but the DEV environment of this mono-repo
 # In order to install the packages of this mono-repo from source, refer to the pyproject.toml in the relevant folder
+
 [project]
 authors = [
   {name = "Vizro Team"}

--- a/vizro-ai/changelog.d/20240122_112645_antony.milne_enable_containers_AM.md
+++ b/vizro-ai/changelog.d/20240122_112645_antony.milne_enable_containers_AM.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-ai/pyproject.toml
+++ b/vizro-ai/pyproject.toml
@@ -52,5 +52,7 @@ source_pkgs = ["vizro_ai"]
 filterwarnings = [
   "error",
   # Ignore until pandas is made compatible with Python 3.12:
-  "ignore:.*utcfromtimestamp:DeprecationWarning"
+  "ignore:.*utcfromtimestamp:DeprecationWarning",
+  # Ignore until pandas 3 is released:
+  "ignore:(?s).*Pyarrow will become a required dependency of pandas:DeprecationWarning",
 ]

--- a/vizro-ai/pyproject.toml
+++ b/vizro-ai/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
 ]
 dependencies = [
   "pandas",
-  "pyarrow>=14.0.1",  # needed for pandas 3.0, version pinned by Snyk to avoid a vulnerability
   "tabulate",
   "openai>=0.27.8,<1.0.0",  # TODO add support for openai>=1.0.0
   "langchain==0.0.329",
@@ -52,6 +51,8 @@ source_pkgs = ["vizro_ai"]
 [tool.pytest.ini_options]
 filterwarnings = [
   "error",
-  # Ignore this warning here as it comes from pandas until pandas is made compatible with Python 3.12
-  'ignore:.*utcfromtimestamp.*:DeprecationWarning'
+ # Ignore until pandas is made compatible with Python 3.12:
+  "ignore:.*utcfromtimestamp:DeprecationWarning",
+  # Ignore until pandas 3 is released:
+  #"ignore:(?s).*Pyarrow will become a required dependency of pandas:DeprecationWarning",
 ]

--- a/vizro-ai/pyproject.toml
+++ b/vizro-ai/pyproject.toml
@@ -54,5 +54,5 @@ filterwarnings = [
   # Ignore until pandas is made compatible with Python 3.12:
   "ignore:.*utcfromtimestamp:DeprecationWarning",
   # Ignore until pandas 3 is released:
-  "ignore:(?s).*Pyarrow will become a required dependency of pandas:DeprecationWarning",
+  "ignore:(?s).*Pyarrow will become a required dependency of pandas:DeprecationWarning"
 ]

--- a/vizro-ai/pyproject.toml
+++ b/vizro-ai/pyproject.toml
@@ -51,8 +51,6 @@ source_pkgs = ["vizro_ai"]
 [tool.pytest.ini_options]
 filterwarnings = [
   "error",
- # Ignore until pandas is made compatible with Python 3.12:
-  "ignore:.*utcfromtimestamp:DeprecationWarning",
-  # Ignore until pandas 3 is released:
-  #"ignore:(?s).*Pyarrow will become a required dependency of pandas:DeprecationWarning",
+  # Ignore until pandas is made compatible with Python 3.12:
+  "ignore:.*utcfromtimestamp:DeprecationWarning"
 ]

--- a/vizro-ai/snyk/requirements.txt
+++ b/vizro-ai/snyk/requirements.txt
@@ -1,5 +1,4 @@
 pandas
-pyarrow>=14.0.1
 tabulate
 openai>=0.27.8,<1.0.0
 langchain==0.0.329

--- a/vizro-core/changelog.d/20240122_112645_antony.milne_enable_containers_AM.md
+++ b/vizro-core/changelog.d/20240122_112645_antony.milne_enable_containers_AM.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/pyproject.toml
+++ b/vizro-core/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
   "setuptools>=65.5.1",  # not directly required, pinned by Snyk to avoid a vulnerability: https://security.snyk.io/vuln/SNYK-PYTHON-SETUPTOOLS-3180412
   "werkzeug>=3.0.1"  # not directly required, pinned by Snyk to avoid a vulnerability: https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-6035177
 ]
-
 description = "Vizro is a package to facilitate visual analytics."
 dynamic = ["version"]
 license-files = {paths = ["LICENSE.txt"]}
@@ -38,8 +37,9 @@ kedro = [
   "kedro-datasets",  # no longer a dependency of kedro for kedro>=0.19.2
   "wheel>=0.38.0",  # not directly required, pinned by Snyk to avoid a vulnerability: https://security.snyk.io/vuln/SNYK-PYTHON-WHEEL-3180413,
   "ipython>=8.10.0",  # not directly required, pinned by Snyk to avoid a vulnerability: https://app.snyk.io/vuln/SNYK-PYTHON-IPYTHON-3318382
-  "tornado>=6.3.2",  # not directly required, pinned by Snyk to avoid a vulnerability: https://security.snyk.io/vuln/SNYK-PYTHON-TORNADO-5537286
+  "tornado>=6.3.2"  # not directly required, pinned by Snyk to avoid a vulnerability: https://security.snyk.io/vuln/SNYK-PYTHON-TORNADO-5537286
 ]
+
 [project.urls]
 Documentation = "https://github.com/mckinsey/vizro#readme"
 Issues = "https://github.com/mckinsey/vizro/issues"
@@ -75,8 +75,7 @@ filterwarnings = [
   # Ignore until pandas 3 is released:
   "ignore:(?s).*Pyarrow will become a required dependency of pandas:DeprecationWarning",
   # Ignore until plotly fixes so the warning is no longer raised:
-  "ignore:When grouping with a length-1 list-like, you will need to pass a length-1 tuple to get_group:FutureWarning",
-
+  "ignore:When grouping with a length-1 list-like, you will need to pass a length-1 tuple to get_group:FutureWarning"
 ]
 norecursedirs = ["tests/tests_utils", "tests/js"]
 pythonpath = ["tests/tests_utils"]

--- a/vizro-core/pyproject.toml
+++ b/vizro-core/pyproject.toml
@@ -1,6 +1,3 @@
-# THIS IS NOT DESCRIBING A PACKAGE, but the DEV environment of this mono-repo
-# In order to install the packages of this mono-repo from source, refer to the pyproject.toml in the relevant folder
-
 [build-system]
 build-backend = "hatchling.build"
 requires = ["hatchling"]
@@ -20,16 +17,14 @@ classifiers = [
 dependencies = [
   "dash>=2.14.1",  # 2.14.1 needed for compatibility with werkzeug
   "dash_bootstrap_components",
-  "pandas<2.2",
-  "pyarrow>=14.0.1",  # needed for pandas 3.0, version pinned by Snyk to avoid a vulnerability
+  "pandas",
   "pydantic>=1.10.13",  # must be synced with pre-commit mypy hook manually
   "dash_mantine_components",
-  "ipython>=8.10.0",  # not directly required, pinned by Snyk to avoid a vulnerability: https://app.snyk.io/vuln/SNYK-PYTHON-IPYTHON-3318382
   "numpy>=1.22.2",  # not directly required, pinned by Snyk to avoid a vulnerability: https://security.snyk.io/vuln/SNYK-PYTHON-NUMPY-2321970
-  "tornado>=6.3.2",  # not directly required, pinned by Snyk to avoid a vulnerability: https://security.snyk.io/vuln/SNYK-PYTHON-TORNADO-5537286
   "setuptools>=65.5.1",  # not directly required, pinned by Snyk to avoid a vulnerability: https://security.snyk.io/vuln/SNYK-PYTHON-SETUPTOOLS-3180412
   "werkzeug>=3.0.1"  # not directly required, pinned by Snyk to avoid a vulnerability: https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-6035177
 ]
+
 description = "Vizro is a package to facilitate visual analytics."
 dynamic = ["version"]
 license-files = {paths = ["LICENSE.txt"]}
@@ -39,10 +34,12 @@ requires-python = ">=3.8"
 
 [project.optional-dependencies]
 kedro = [
-  "kedro>=0.17.3, <0.19.2",
-  "wheel>=0.38.0"  # not directly required, pinned by Snyk to avoid a vulnerability: https://security.snyk.io/vuln/SNYK-PYTHON-WHEEL-3180413
+  "kedro>=0.17.3",
+  "kedro-datasets",  # no longer a dependency of kedro for kedro>=0.19.2
+  "wheel>=0.38.0",  # not directly required, pinned by Snyk to avoid a vulnerability: https://security.snyk.io/vuln/SNYK-PYTHON-WHEEL-3180413,
+  "ipython>=8.10.0",  # not directly required, pinned by Snyk to avoid a vulnerability: https://app.snyk.io/vuln/SNYK-PYTHON-IPYTHON-3318382
+  "tornado>=6.3.2",  # not directly required, pinned by Snyk to avoid a vulnerability: https://security.snyk.io/vuln/SNYK-PYTHON-TORNADO-5537286
 ]
-
 [project.urls]
 Documentation = "https://github.com/mckinsey/vizro#readme"
 Issues = "https://github.com/mckinsey/vizro/issues"
@@ -73,8 +70,13 @@ addopts = [
 ]
 filterwarnings = [
   "error",
-  # Ignore this warning here as it comes from pandas until pandas is made compatible with Python 3.12
-  "ignore:.*utcfromtimestamp:DeprecationWarning"
+  # Ignore until pandas is made compatible with Python 3.12:
+  "ignore:.*utcfromtimestamp:DeprecationWarning",
+  # Ignore until pandas 3 is released:
+  "ignore:(?s).*Pyarrow will become a required dependency of pandas:DeprecationWarning",
+  # Ignore until plotly fixes so the warning is no longer raised:
+  "ignore:When grouping with a length-1 list-like, you will need to pass a length-1 tuple to get_group:FutureWarning",
+
 ]
 norecursedirs = ["tests/tests_utils", "tests/js"]
 pythonpath = ["tests/tests_utils"]

--- a/vizro-core/snyk/requirements.txt
+++ b/vizro-core/snyk/requirements.txt
@@ -1,13 +1,13 @@
 dash>=2.14.1
 dash_bootstrap_components
-pandas<2.2
-pyarrow>=14.0.1
+pandas
 pydantic>=1.10.13
 dash_mantine_components
-ipython>=8.10.0
 numpy>=1.22.2
-tornado>=6.3.2
 setuptools>=65.5.1
 werkzeug>=3.0.1
-kedro>=0.17.3, <0.19.2
+kedro>=0.17.3
+kedro-datasets
 wheel>=0.38.0
+ipython>=8.10.0
+tornado>=6.3.2


### PR DESCRIPTION
## Description

A proper fix following https://github.com/mckinsey/vizro/pull/274:
* remove the `pyarrow` dependency - this is not something we want to specify as a dependency. Instead what we should do is ignore the deprecation warning from pandas (which was confusingly written so made it sound like we should add `pyarrow` as a dependency)
* remove upper pin for `kedro` and `pandas`. Our kedro test broke with the release of 0.19.2 due to https://github.com/kedro-org/kedro/pull/3451 and is fixed by adding `kedro-datasets` as a dependency

Also:
* moved some dependencies pinned by Snyk to optional ones since they only come about from `kedro`. These should never have been in the core dependencies, and actually it highlights a fundamental flaw in the use of Snyk that we shouldn't be responsible for transitive dependency versions at all really - to be discussed more another time

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
