### PR TITLE
Tidy trailing commas

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,6 @@ repos:
     rev: 23.12.1
     hooks:
       - id: black
-        args: [--skip-magic-trailing-comma]
 
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,7 @@ repos:
     rev: 23.12.1
     hooks:
       - id: black
+        args: [--skip-magic-trailing-comma]
 
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.6

--- a/vizro-ai/changelog.d/20240126_180009_huong_li_nguyen_apply_black_c.md
+++ b/vizro-ai/changelog.d/20240126_180009_huong_li_nguyen_apply_black_c.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-ai/src/vizro_ai/_vizro_ai.py
+++ b/vizro-ai/src/vizro_ai/_vizro_ai.py
@@ -6,10 +6,7 @@ import pandas as pd
 
 from vizro_ai.chains import ModelConstructor
 from vizro_ai.chains._llm_models import LLM_MODELS
-from vizro_ai.components import (
-    GetCodeExplanation,
-    GetDebugger,
-)
+from vizro_ai.components import GetCodeExplanation, GetDebugger
 from vizro_ai.task_pipeline._pipeline_manager import PipelineManager
 from vizro_ai.utils import _safeguard_check
 

--- a/vizro-ai/src/vizro_ai/chains/_llm_chain.py
+++ b/vizro-ai/src/vizro_ai/chains/_llm_chain.py
@@ -53,11 +53,7 @@ class FunctionCallChain(VizroBaseChain, ABC):
 
     def _construct_prompt(self, raw_prompt, partial_vars_map) -> str:
         """Construct the prompt from partial variables input."""
-        prompt = PromptTemplate(
-            input_variables=["input"],
-            template=raw_prompt,
-            partial_variables=partial_vars_map,
-        )
+        prompt = PromptTemplate(input_variables=["input"], template=raw_prompt, partial_variables=partial_vars_map)
 
         vars_set = set(re.findall(r"\{([^}]*)\}", raw_prompt))
         vars_set -= {"input"}

--- a/vizro-ai/src/vizro_ai/chains/_llm_models.py
+++ b/vizro-ai/src/vizro_ai/chains/_llm_models.py
@@ -12,26 +12,10 @@ LLM_MODELS = Union[ChatOpenAI]
 
 # TODO constant of model inventory, can be converted to yaml and link to docs
 PREDEFINED_MODELS: List[Dict[str, any]] = [
-    {
-        "name": "gpt-3.5-turbo-0613",
-        "max_tokens": 4096,
-        "wrapper": ChatOpenAI,
-    },
-    {
-        "name": "gpt-4-0613",
-        "max_tokens": 8192,
-        "wrapper": ChatOpenAI,
-    },
-    {
-        "name": "gpt-3.5-turbo-1106",
-        "max_tokens": 16385,
-        "wrapper": ChatOpenAI,
-    },
-    {
-        "name": "gpt-4-1106-preview",
-        "max_tokens": 128000,
-        "wrapper": ChatOpenAI,
-    },
+    {"name": "gpt-3.5-turbo-0613", "max_tokens": 4096, "wrapper": ChatOpenAI},
+    {"name": "gpt-4-0613", "max_tokens": 8192, "wrapper": ChatOpenAI},
+    {"name": "gpt-3.5-turbo-1106", "max_tokens": 16385, "wrapper": ChatOpenAI},
+    {"name": "gpt-4-1106-preview", "max_tokens": 128000, "wrapper": ChatOpenAI},
 ]
 
 

--- a/vizro-ai/src/vizro_ai/chains/_llm_models.py
+++ b/vizro-ai/src/vizro_ai/chains/_llm_models.py
@@ -12,10 +12,26 @@ LLM_MODELS = Union[ChatOpenAI]
 
 # TODO constant of model inventory, can be converted to yaml and link to docs
 PREDEFINED_MODELS: List[Dict[str, any]] = [
-    {"name": "gpt-3.5-turbo-0613", "max_tokens": 4096, "wrapper": ChatOpenAI},
-    {"name": "gpt-4-0613", "max_tokens": 8192, "wrapper": ChatOpenAI},
-    {"name": "gpt-3.5-turbo-1106", "max_tokens": 16385, "wrapper": ChatOpenAI},
-    {"name": "gpt-4-1106-preview", "max_tokens": 128000, "wrapper": ChatOpenAI},
+    {
+        "name": "gpt-3.5-turbo-0613",
+        "max_tokens": 4096,
+        "wrapper": ChatOpenAI,
+    },
+    {
+        "name": "gpt-4-0613",
+        "max_tokens": 8192,
+        "wrapper": ChatOpenAI,
+    },
+    {
+        "name": "gpt-3.5-turbo-1106",
+        "max_tokens": 16385,
+        "wrapper": ChatOpenAI,
+    },
+    {
+        "name": "gpt-4-1106-preview",
+        "max_tokens": 128000,
+        "wrapper": ChatOpenAI,
+    },
 ]
 
 

--- a/vizro-ai/src/vizro_ai/components/_base.py
+++ b/vizro-ai/src/vizro_ai/components/_base.py
@@ -57,10 +57,7 @@ class VizroAiComponentBase(ABC):
         llm_kwargs_to_use, partial_vars = self._pre_process(*args, **kwargs)
 
         function_call_chain = FunctionCallChain(
-            llm=self.llm,
-            raw_prompt=self.prompt,
-            partial_vars_map=partial_vars,
-            llm_kwargs=llm_kwargs_to_use,
+            llm=self.llm, raw_prompt=self.prompt, partial_vars_map=partial_vars, llm_kwargs=llm_kwargs_to_use
         )
 
         response = function_call_chain.execute_chain(input_str=chain_input)

--- a/vizro-ai/src/vizro_ai/components/code_validation.py
+++ b/vizro-ai/src/vizro_ai/components/code_validation.py
@@ -101,8 +101,5 @@ if __name__ == "__main__":
 
     test = GetDebugger(llm=llm_to_use)
 
-    res = test.run(
-        chain_input=error_msg,
-        code_snippet=test_code_snippet,
-    )
+    res = test.run(chain_input=error_msg, code_snippet=test_code_snippet)
     print(res)  # noqa: T201

--- a/vizro-ai/src/vizro_ai/components/custom_chart_wrap.py
+++ b/vizro-ai/src/vizro_ai/components/custom_chart_wrap.py
@@ -121,7 +121,5 @@ if __name__ == "__main__":
 
     test_custom_chart = GetCustomChart(llm=llm_to_use)
 
-    res = test_custom_chart.run(
-        chain_input=outcome_visual_tool,
-    )
+    res = test_custom_chart.run(chain_input=outcome_visual_tool)
     print(res)  # noqa: T201

--- a/vizro-ai/src/vizro_ai/task_pipeline/_pipeline_manager.py
+++ b/vizro-ai/src/vizro_ai/task_pipeline/_pipeline_manager.py
@@ -1,11 +1,6 @@
 """Pipeline Manager."""
 from vizro_ai.chains._llm_models import LLM_MODELS
-from vizro_ai.components import (
-    GetChartSelection,
-    GetCustomChart,
-    GetDataFrameCraft,
-    GetVisualCode,
-)
+from vizro_ai.components import GetChartSelection, GetCustomChart, GetDataFrameCraft, GetVisualCode
 from vizro_ai.task_pipeline._pipeline import Pipeline
 
 

--- a/vizro-ai/src/vizro_ai/utils/_constants.py
+++ b/vizro-ai/src/vizro_ai/utils/_constants.py
@@ -1,15 +1,5 @@
 """File to store all constants."""
-WHITELISTED_PACKAGES = [
-    "pandas",
-    "numpy",
-    "vizro",
-    "plotly",
-    "datetime",
-    "matplotlib",
-    "dash",
-    "scipy",
-    "sklearn",
-]
+WHITELISTED_PACKAGES = ["pandas", "numpy", "vizro", "plotly", "datetime", "matplotlib", "dash", "scipy", "sklearn"]
 
 WHITELISTED_BUILTINS = [
     # '__name__',

--- a/vizro-ai/src/vizro_ai/utils/safeguard.py
+++ b/vizro-ai/src/vizro_ai/utils/safeguard.py
@@ -4,12 +4,7 @@ import builtins
 import re
 from typing import Union
 
-from ._constants import (
-    REDLISTED_CLASS_METHODS,
-    REDLISTED_DATA_HANDLING,
-    WHITELISTED_BUILTINS,
-    WHITELISTED_PACKAGES,
-)
+from ._constants import REDLISTED_CLASS_METHODS, REDLISTED_DATA_HANDLING, WHITELISTED_BUILTINS, WHITELISTED_PACKAGES
 
 
 def _check_imports(node: Union[ast.Import, ast.ImportFrom]):

--- a/vizro-ai/tests/integration/test_example.py
+++ b/vizro-ai/tests/integration/test_example.py
@@ -11,11 +11,7 @@ def test_chart():
     resp = vizro_ai.plot(df, "describe the composition of scatter chart with gdp in continent")
     assert_that(
         resp["code_string"],
-        all_of(
-            contains_string("px.scatter"),
-            contains_string("x='continent'"),
-            contains_string("y='gdpPercap'"),
-        ),
+        all_of(contains_string("px.scatter"), contains_string("x='continent'"), contains_string("y='gdpPercap'")),
     )
     assert_that(resp["business_insights"], equal_to(None))
     assert_that(resp["code_explanation"], equal_to(None))
@@ -23,29 +19,15 @@ def test_chart():
 
 def test_chart_with_explanation():
     vizro_ai._return_all_text = True
-    resp = vizro_ai.plot(
-        df,
-        "describe the composition of gdp in US",
-        explain=True,
-    )
+    resp = vizro_ai.plot(df, "describe the composition of gdp in US", explain=True)
     assert_that(
         resp["code_string"],
-        all_of(
-            contains_string("px.bar"),
-            contains_string("x='year'"),
-            contains_string("y='gdpPercap'"),
-        ),
+        all_of(contains_string("px.bar"), contains_string("x='year'"), contains_string("y='gdpPercap'")),
     )
     assert_that(
-        resp["business_insights"],
-        any_of(
-            contains_string("GDP in the United States"),
-            contains_string("GDP in the US"),
-        ),
+        resp["business_insights"], any_of(contains_string("GDP in the United States"), contains_string("GDP in the US"))
     )
     assert_that(
         resp["code_explanation"],
-        all_of(
-            contains_string("https://vizro.readthedocs.io/en/stable/pages/user_guides/custom_charts/"),
-        ),
+        all_of(contains_string("https://vizro.readthedocs.io/en/stable/pages/user_guides/custom_charts/")),
     )

--- a/vizro-core/changelog.d/20240126_175831_huong_li_nguyen_apply_black_c.md
+++ b/vizro-core/changelog.d/20240126_175831_huong_li_nguyen_apply_black_c.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/examples/_dev/app.py
+++ b/vizro-core/examples/_dev/app.py
@@ -15,11 +15,7 @@ table_and_container = vm.Page(
             components=[
                 vm.Table(
                     title="Table Title",
-                    figure=dash_data_table(
-                        id="dash_data_table_country",
-                        data_frame=df,
-                        page_size=30,
-                    ),
+                    figure=dash_data_table(id="dash_data_table_country", data_frame=df, page_size=30),
                 )
             ],
         ),
@@ -27,15 +23,8 @@ table_and_container = vm.Page(
             title="Another Container",
             components=[
                 vm.Graph(
-                    figure=px.scatter(
-                        df,
-                        title="Graph_2",
-                        x="gdpPercap",
-                        y="lifeExp",
-                        size="pop",
-                        color="continent",
-                    ),
-                ),
+                    figure=px.scatter(df, title="Graph_2", x="gdpPercap", y="lifeExp", size="pop", color="continent")
+                )
             ],
         ),
     ],
@@ -43,12 +32,7 @@ table_and_container = vm.Page(
 )
 
 
-dashboard = vm.Dashboard(
-    title="Dashboard Title",
-    pages=[
-        table_and_container,
-    ],
-)
+dashboard = vm.Dashboard(title="Dashboard Title", pages=[table_and_container])
 
 if __name__ == "__main__":
     Vizro().build(dashboard).run()

--- a/vizro-core/examples/_dev/app.py
+++ b/vizro-core/examples/_dev/app.py
@@ -15,7 +15,11 @@ table_and_container = vm.Page(
             components=[
                 vm.Table(
                     title="Table Title",
-                    figure=dash_data_table(id="dash_data_table_country", data_frame=df, page_size=30),
+                    figure=dash_data_table(
+                        id="dash_data_table_country",
+                        data_frame=df,
+                        page_size=30,
+                    ),
                 )
             ],
         ),

--- a/vizro-core/examples/_dev/app.py
+++ b/vizro-core/examples/_dev/app.py
@@ -23,7 +23,14 @@ table_and_container = vm.Page(
             title="Another Container",
             components=[
                 vm.Graph(
-                    figure=px.scatter(df, title="Graph_2", x="gdpPercap", y="lifeExp", size="pop", color="continent")
+                    figure=px.scatter(
+                        df,
+                        title="Graph_2",
+                        x="gdpPercap",
+                        y="lifeExp",
+                        size="pop",
+                        color="continent",
+                    )
                 )
             ],
         ),

--- a/vizro-core/examples/demo/app.py
+++ b/vizro-core/examples/demo/app.py
@@ -344,7 +344,7 @@ def create_continent_summary():
                     However, Africa has shown notable improvements in life expectancy over time, reaching 55 years in
                     2007. Despite these economic disparities, Africa's population has been steadily increasing,
                     reflecting its significant potential for development.
-                """,
+                """
             ),
             vm.Card(
                 text="""
@@ -359,7 +359,7 @@ def create_continent_summary():
                     maintained similar levels to Asia, reflecting its economic significance. With North America
                     generally reporting higher life expectancy compared to South America, America remains a region of
                     opportunities and challenges.
-                """,
+                """
             ),
             vm.Card(
                 text="""
@@ -373,7 +373,7 @@ def create_continent_summary():
                     Despite facing various socio-economic challenges, Asia's increasing life expectancy from 46 years
                     to 70 over the years reflects advancements in healthcare and overall well-being, making it a vital
                     region driving global progress and development.
-                """,
+                """
             ),
             vm.Card(
                 text="""
@@ -388,7 +388,7 @@ def create_continent_summary():
                     quality of life, Europe continues to be a leading force in the global economy. Between 1952 and
                     2007, Europe's population experienced moderate growth, with a factor of approximately 1.5,
                     notably lower compared to other continents like Asia and America.
-                """,
+                """
             ),
             vm.Card(
                 text="""
@@ -401,7 +401,7 @@ def create_continent_summary():
 
                     Despite a relatively smaller population size, Oceania's strong economic growth has contributed
                     to improved living standards and overall well-being of its population.
-                """,
+                """
             ),
         ],
     )
@@ -475,16 +475,7 @@ def create_benchmark_analysis():
                     hover_name="country",
                 ),
             ),
-            vm.Button(
-                text="Export data",
-                actions=[
-                    vm.Action(
-                        function=export_data(
-                            targets=["line_country"],
-                        )
-                    ),
-                ],
-            ),
+            vm.Button(text="Export data", actions=[vm.Action(function=export_data(targets=["line_country"]))]),
         ],
         controls=[
             vm.Filter(column="continent", selector=vm.Dropdown(value="Europe", multi=False, title="Select continent")),
@@ -573,7 +564,7 @@ dashboard = vm.Dashboard(
                 ),
                 vm.NavLink(label="Summary", pages=["Continent Summary"], icon="Globe"),
             ]
-        ),
+        )
     ),
 )
 

--- a/vizro-core/examples/features/app.py
+++ b/vizro-core/examples/features/app.py
@@ -237,12 +237,21 @@ filters = vm.Page(
         ),
         vm.Graph(
             id="scatter_chart2",
-            figure=px.scatter(iris, x="petal_length", y="sepal_width", color="species,"),
+            figure=px.scatter(
+                iris,
+                x="petal_length",
+                y="sepal_width",
+                color="species",
+            ),
         ),
     ],
     controls=[
         vm.Filter(column="species"),
-        vm.Filter(column="petal_length", targets=["scatter_chart2"], selector=vm.RangeSlider()),
+        vm.Filter(
+            column="petal_length",
+            targets=["scatter_chart2"],
+            selector=vm.RangeSlider(),
+        ),
     ],
 )
 
@@ -374,7 +383,9 @@ custom_charts = vm.Page(
     controls=[
         vm.Filter(column="petal_width", targets=["custom_scatter"]),
         vm.Filter(
-            column="x", targets=["custom_waterfall"], selector=vm.Dropdown(title="Financial categories", multi=True)
+            column="x",
+            targets=["custom_waterfall"],
+            selector=vm.Dropdown(title="Financial categories", multi=True),
         ),
     ],
 )
@@ -412,7 +423,11 @@ custom_tables = vm.Page(
     controls=[
         vm.Parameter(
             targets=["custom_table.chosen_columns"],
-            selector=vm.Dropdown(title="Choose columns", options=gapminder_2007.columns.to_list(), multi=True),
+            selector=vm.Dropdown(
+                title="Choose columns",
+                options=gapminder_2007.columns.to_list(),
+                multi=True,
+            ),
         )
     ],
 )
@@ -462,7 +477,13 @@ custom_components = vm.Page(
         ),
         vm.Graph(
             id="for_custom_chart",
-            figure=px.scatter(iris, title="Iris Dataset", x="sepal_length", y="petal_width", color="sepal_width"),
+            figure=px.scatter(
+                iris,
+                title="Iris Dataset",
+                x="sepal_length",
+                y="petal_width",
+                color="sepal_width",
+            ),
         ),
     ],
     controls=[
@@ -485,7 +506,14 @@ def my_custom_action(t: int):
 custom_actions = vm.Page(
     title="Custom Actions",
     components=[
-        vm.Graph(figure=px.scatter(iris, x="sepal_length", y="petal_width", color="species")),
+        vm.Graph(
+            figure=px.scatter(
+                iris,
+                x="sepal_length",
+                y="petal_width",
+                color="species",
+            )
+        ),
         vm.Button(
             text="Export data",
             actions=[

--- a/vizro-core/examples/features/app.py
+++ b/vizro-core/examples/features/app.py
@@ -80,7 +80,9 @@ graphs = vm.Page(
     components=[
         vm.Graph(
             figure=px.scatter_matrix(
-                iris, dimensions=["sepal_length", "sepal_width", "petal_length", "petal_width"], color="species"
+                iris,
+                dimensions=["sepal_length", "sepal_width", "petal_length", "petal_width"],
+                color="species",
             )
         )
     ],
@@ -89,7 +91,12 @@ graphs = vm.Page(
 
 table = vm.Page(
     title="Table",
-    components=[vm.Table(title="Dash DataTable", figure=dash_data_table(data_frame=gapminder_2007))],
+    components=[
+        vm.Table(
+            title="Dash DataTable",
+            figure=dash_data_table(data_frame=gapminder_2007),
+        )
+    ],
     controls=[vm.Filter(column="continent")],
 )
 
@@ -157,7 +164,13 @@ button = vm.Page(
     layout=vm.Layout(grid=[[0], [0], [0], [0], [1]]),
     components=[
         vm.Graph(
-            figure=px.scatter(iris, x="sepal_width", y="sepal_length", color="species", size="petal_length"),
+            figure=px.scatter(
+                iris,
+                x="sepal_width",
+                y="sepal_length",
+                color="species",
+                size="petal_length",
+            ),
         ),
         vm.Button(text="Export data", actions=[vm.Action(function=export_data())]),
     ],
@@ -222,7 +235,10 @@ filters = vm.Page(
                 color="species",
             )
         ),
-        vm.Graph(id="scatter_chart2", figure=px.scatter(iris, x="petal_length", y="sepal_width", color="species,")),
+        vm.Graph(
+            id="scatter_chart2",
+            figure=px.scatter(iris, x="petal_length", y="sepal_width", color="species,"),
+        ),
     ],
     controls=[
         vm.Filter(column="species"),

--- a/vizro-core/examples/features/app.py
+++ b/vizro-core/examples/features/app.py
@@ -156,7 +156,9 @@ button = vm.Page(
     title="Button",
     layout=vm.Layout(grid=[[0], [0], [0], [0], [1]]),
     components=[
-        vm.Graph(figure=px.scatter(iris, x="sepal_width", y="sepal_length", color="species", size="petal_length")),
+        vm.Graph(
+            figure=px.scatter(iris, x="sepal_width", y="sepal_length", color="species", size="petal_length"),
+        ),
         vm.Button(text="Export data", actions=[vm.Action(function=export_data())]),
     ],
     controls=[vm.Filter(column="species", selector=vm.Dropdown(title="Species"))],
@@ -171,11 +173,21 @@ containers = vm.Page(
             components=[
                 vm.Graph(
                     figure=px.scatter(
-                        iris, x="sepal_length", y="petal_width", color="species", title="Container I - Scatter"
+                        iris,
+                        x="sepal_length",
+                        y="petal_width",
+                        color="species",
+                        title="Container I - Scatter",
                     )
                 ),
                 vm.Graph(
-                    figure=px.bar(iris, x="sepal_length", y="sepal_width", color="species", title="Container I - Bar")
+                    figure=px.bar(
+                        iris,
+                        x="sepal_length",
+                        y="sepal_width",
+                        color="species",
+                        title="Container I - Bar",
+                    )
                 ),
             ],
         ),
@@ -202,8 +214,15 @@ containers = vm.Page(
 filters = vm.Page(
     title="Filters",
     components=[
-        vm.Graph(figure=px.scatter(iris, x="sepal_length", y="petal_width", color="species")),
-        vm.Graph(id="scatter_chart2", figure=px.scatter(iris, x="petal_length", y="sepal_width", color="species")),
+        vm.Graph(
+            figure=px.scatter(
+                iris,
+                x="sepal_length",
+                y="petal_width",
+                color="species",
+            )
+        ),
+        vm.Graph(id="scatter_chart2", figure=px.scatter(iris, x="petal_length", y="sepal_width", color="species,")),
     ],
     controls=[
         vm.Filter(column="species"),
@@ -260,12 +279,24 @@ chart_interaction = vm.Page(
     title="Chart interaction",
     components=[
         vm.Graph(
-            figure=px.box(gapminder_2007, x="continent", y="lifeExp", color="continent", custom_data=["continent"]),
+            figure=px.box(
+                gapminder_2007,
+                x="continent",
+                y="lifeExp",
+                color="continent",
+                custom_data=["continent"],
+            ),
             actions=[vm.Action(function=filter_interaction(targets=["scatter_relation_2007"]))],
         ),
         vm.Graph(
             id="scatter_relation_2007",
-            figure=px.scatter(gapminder_2007, x="gdpPercap", y="lifeExp", size="pop", color="continent"),
+            figure=px.scatter(
+                gapminder_2007,
+                x="gdpPercap",
+                y="lifeExp",
+                size="pop",
+                color="continent",
+            ),
         ),
     ],
 )
@@ -305,13 +336,22 @@ custom_charts = vm.Page(
         vm.Graph(
             id="custom_scatter",
             figure=scatter_with_line(
-                x="sepal_length", y="sepal_width", hline=3.5, data_frame=iris, title="Custom px chart"
+                x="sepal_length",
+                y="sepal_width",
+                hline=3.5,
+                data_frame=iris,
+                title="Custom px chart",
             ),
         ),
         vm.Graph(
             id="custom_waterfall",
             figure=waterfall(
-                data_frame=waterfall_df, measure="measure", x="x", y="y", text="text", title="Custom go chart"
+                data_frame=waterfall_df,
+                measure="measure",
+                x="x",
+                y="y",
+                text="text",
+                title="Custom go chart",
             ),
         ),
     ],
@@ -348,7 +388,8 @@ custom_tables = vm.Page(
             id="custom_table",
             title="Custom Dash DataTable",
             figure=my_custom_table(
-                data_frame=gapminder_2007, chosen_columns=["country", "continent", "lifeExp", "pop", "gdpPercap"]
+                data_frame=gapminder_2007,
+                chosen_columns=["country", "continent", "lifeExp", "pop", "gdpPercap"],
             ),
         )
     ],

--- a/vizro-core/examples/features/app.py
+++ b/vizro-core/examples/features/app.py
@@ -81,17 +81,15 @@ graphs = vm.Page(
         vm.Graph(
             figure=px.scatter_matrix(
                 iris, dimensions=["sepal_length", "sepal_width", "petal_length", "petal_width"], color="species"
-            ),
-        ),
+            )
+        )
     ],
     controls=[vm.Filter(column="species", selector=vm.Dropdown(title="Species"))],
 )
 
 table = vm.Page(
     title="Table",
-    components=[
-        vm.Table(title="Dash DataTable", figure=dash_data_table(data_frame=gapminder_2007)),
-    ],
+    components=[vm.Table(title="Dash DataTable", figure=dash_data_table(data_frame=gapminder_2007))],
     controls=[vm.Filter(column="continent")],
 )
 
@@ -107,7 +105,7 @@ cards = vm.Page(
                 ### Header level 3 <h3>
 
                 #### Header level 4 <h4>
-            """,
+            """
         ),
         vm.Card(
             text="""
@@ -119,7 +117,7 @@ cards = vm.Page(
                  Obcaecati tenetur iure eius earum ut molestias architecto voluptate aliquam nihil, eveniet aliquid.
 
                  Culpa officia aut! Impedit sit sunt quaerat, odit, tenetur error, harum nesciunt ipsum debitis quas.
-            """,
+            """
         ),
         vm.Card(
             text="""
@@ -128,7 +126,7 @@ cards = vm.Page(
                 >
                 > A block quote is a long quotation, indented to create a separate block of text.
                 >
-            """,
+            """
         ),
         vm.Card(
             text="""
@@ -138,7 +136,7 @@ cards = vm.Page(
                     * Sub Item 1
                     * Sub Item 2
                 * Item B
-            """,
+            """
         ),
         vm.Card(
             text="""
@@ -149,7 +147,7 @@ cards = vm.Page(
                 This word will be **bold**
 
                 This word will be _**bold and italic**_
-            """,
+            """
         ),
     ],
 )
@@ -158,19 +156,8 @@ button = vm.Page(
     title="Button",
     layout=vm.Layout(grid=[[0], [0], [0], [0], [1]]),
     components=[
-        vm.Graph(
-            figure=px.scatter(
-                iris,
-                x="sepal_width",
-                y="sepal_length",
-                color="species",
-                size="petal_length",
-            ),
-        ),
-        vm.Button(
-            text="Export data",
-            actions=[vm.Action(function=export_data())],
-        ),
+        vm.Graph(figure=px.scatter(iris, x="sepal_width", y="sepal_length", color="species", size="petal_length")),
+        vm.Button(text="Export data", actions=[vm.Action(function=export_data())]),
     ],
     controls=[vm.Filter(column="species", selector=vm.Dropdown(title="Species"))],
 )
@@ -205,7 +192,7 @@ containers = vm.Page(
                         marginal_x="box",
                         title="Container II - Scatter",
                     )
-                ),
+                )
             ],
         ),
     ],
@@ -252,12 +239,8 @@ parameters = vm.Page(
     controls=[
         vm.Parameter(
             targets=["scatter_chart_pm.color_discrete_map.virginica", "bar_chart_pm.color_discrete_map.virginica"],
-            selector=vm.Dropdown(
-                options=["#ff5267", "#3949ab"],
-                multi=False,
-                value="#3949ab",
-            ),
-        ),
+            selector=vm.Dropdown(options=["#ff5267", "#3949ab"], multi=False, value="#3949ab"),
+        )
     ],
 )
 
@@ -265,20 +248,11 @@ parameters = vm.Page(
 export_data_action = vm.Page(
     title="Export data",
     components=[
-        vm.Graph(
-            figure=px.scatter(iris, x="petal_length", y="sepal_length", color="species"),
-        ),
-        vm.Graph(
-            figure=px.histogram(iris, x="petal_length", color="species"),
-        ),
-        vm.Button(
-            text="Export data",
-            actions=[vm.Action(function=export_data())],
-        ),
+        vm.Graph(figure=px.scatter(iris, x="petal_length", y="sepal_length", color="species")),
+        vm.Graph(figure=px.histogram(iris, x="petal_length", color="species")),
+        vm.Button(text="Export data", actions=[vm.Action(function=export_data())]),
     ],
-    controls=[
-        vm.Filter(column="species"),
-    ],
+    controls=[vm.Filter(column="species")],
 )
 
 
@@ -286,24 +260,12 @@ chart_interaction = vm.Page(
     title="Chart interaction",
     components=[
         vm.Graph(
-            figure=px.box(
-                gapminder_2007,
-                x="continent",
-                y="lifeExp",
-                color="continent",
-                custom_data=["continent"],
-            ),
+            figure=px.box(gapminder_2007, x="continent", y="lifeExp", color="continent", custom_data=["continent"]),
             actions=[vm.Action(function=filter_interaction(targets=["scatter_relation_2007"]))],
         ),
         vm.Graph(
             id="scatter_relation_2007",
-            figure=px.scatter(
-                gapminder_2007,
-                x="gdpPercap",
-                y="lifeExp",
-                size="pop",
-                color="continent",
-            ),
+            figure=px.scatter(gapminder_2007, x="gdpPercap", y="lifeExp", size="pop", color="continent"),
         ),
     ],
 )
@@ -331,7 +293,7 @@ def waterfall(data_frame, measure, x, y, text, title=None):
             decreasing={"marker": {"color": "#ff5267"}},
             increasing={"marker": {"color": "#08bdba"}},
             totals={"marker": {"color": "#00b4ff"}},
-        ),
+        )
     )
     fig.update_layout(title=title)
     return fig
@@ -343,11 +305,7 @@ custom_charts = vm.Page(
         vm.Graph(
             id="custom_scatter",
             figure=scatter_with_line(
-                x="sepal_length",
-                y="sepal_width",
-                hline=3.5,
-                data_frame=iris,
-                title="Custom px chart",
+                x="sepal_length", y="sepal_width", hline=3.5, data_frame=iris, title="Custom px chart"
             ),
         ),
         vm.Graph(
@@ -392,7 +350,7 @@ custom_tables = vm.Page(
             figure=my_custom_table(
                 data_frame=gapminder_2007, chosen_columns=["country", "continent", "lifeExp", "pop", "gdpPercap"]
             ),
-        ),
+        )
     ],
     controls=[
         vm.Parameter(
@@ -432,13 +390,7 @@ class Jumbotron(vm.VizroBaseModel):
 
     def build(self):
         """Build the new component based on Dash components."""
-        return html.Div(
-            [
-                html.H2(self.title),
-                html.H3(self.subtitle),
-                html.P(self.text),
-            ]
-        )
+        return html.Div([html.H2(self.title), html.H3(self.subtitle), html.P(self.text)])
 
 
 vm.Page.add_type("components", Jumbotron)
@@ -476,9 +428,7 @@ def my_custom_action(t: int):
 custom_actions = vm.Page(
     title="Custom Actions",
     components=[
-        vm.Graph(
-            figure=px.scatter(iris, x="sepal_length", y="petal_width", color="species"),
-        ),
+        vm.Graph(figure=px.scatter(iris, x="sepal_length", y="petal_width", color="species")),
         vm.Button(
             text="Export data",
             actions=[

--- a/vizro-core/src/vizro/_themes/_templates/template_dark.py
+++ b/vizro-core/src/vizro/_themes/_templates/template_dark.py
@@ -99,12 +99,7 @@ def create_template_dark() -> Template:
             totals={"marker": {"color": COLORS["GREY_55"]}},
             textfont_color=template_dark.layout.title.font.color,
             textposition="outside",
-            connector={
-                "line": {
-                    "color": template_dark.layout.xaxis.tickcolor,
-                    "width": 1,
-                }
-            },
+            connector={"line": {"color": template_dark.layout.xaxis.tickcolor, "width": 1}},
         )
     ]
     return template_dark

--- a/vizro-core/src/vizro/actions/_action_loop/_build_action_loop_callbacks.py
+++ b/vizro-core/src/vizro/actions/_action_loop/_build_action_loop_callbacks.py
@@ -48,10 +48,7 @@ def _build_action_loop_callbacks() -> None:
         )
 
         gateway_inputs.append(
-            Input(
-                component_id={"type": "gateway_input", "trigger_id": actions_chain.id},
-                component_property="data",
-            )
+            Input(component_id={"type": "gateway_input", "trigger_id": actions_chain.id}, component_property="data")
         )
 
     # Determines the final sequence of actions to be triggered.

--- a/vizro-core/src/vizro/actions/_action_loop/_build_action_loop_callbacks.py
+++ b/vizro-core/src/vizro/actions/_action_loop/_build_action_loop_callbacks.py
@@ -48,7 +48,10 @@ def _build_action_loop_callbacks() -> None:
         )
 
         gateway_inputs.append(
-            Input(component_id={"type": "gateway_input", "trigger_id": actions_chain.id}, component_property="data")
+            Input(
+                component_id={"type": "gateway_input", "trigger_id": actions_chain.id},
+                component_property="data",
+            )
         )
 
     # Determines the final sequence of actions to be triggered.

--- a/vizro-core/src/vizro/actions/_action_loop/_get_action_loop_components.py
+++ b/vizro-core/src/vizro/actions/_action_loop/_get_action_loop_components.py
@@ -33,7 +33,10 @@ def _get_action_loop_components() -> html.Div:
     # Required to avoid the "Unknown callback Input" issue for multiple page app examples.
     components.extend(
         [
-            dcc.Store(id={"type": "gateway_input", "trigger_id": actions_chain.id}, data=f"{actions_chain.id}")
+            dcc.Store(
+                id={"type": "gateway_input", "trigger_id": actions_chain.id},
+                data=f"{actions_chain.id}",
+            )
             for actions_chain in actions_chains
         ]
     )

--- a/vizro-core/src/vizro/actions/_action_loop/_get_action_loop_components.py
+++ b/vizro-core/src/vizro/actions/_action_loop/_get_action_loop_components.py
@@ -33,10 +33,7 @@ def _get_action_loop_components() -> html.Div:
     # Required to avoid the "Unknown callback Input" issue for multiple page app examples.
     components.extend(
         [
-            dcc.Store(
-                id={"type": "gateway_input", "trigger_id": actions_chain.id},
-                data=f"{actions_chain.id}",
-            )
+            dcc.Store(id={"type": "gateway_input", "trigger_id": actions_chain.id}, data=f"{actions_chain.id}")
             for actions_chain in actions_chains
         ]
     )
@@ -47,12 +44,7 @@ def _get_action_loop_components() -> html.Div:
     components.extend([dcc.Store(id={"type": "action_trigger", "action_name": action.id}) for action in actions])
 
     # Additional store with all action_triggers ids.
-    components.append(
-        dcc.Store(
-            id="action_trigger_actions_id",
-            data=[action.id for action in actions],
-        )
-    )
+    components.append(dcc.Store(id="action_trigger_actions_id", data=[action.id for action in actions]))
 
     # Additional store that maps the actions chain trigger id and the list of action ids that should be executed.
     components.append(

--- a/vizro-core/src/vizro/actions/_actions_utils.py
+++ b/vizro-core/src/vizro/actions/_actions_utils.py
@@ -46,11 +46,7 @@ def _get_component_actions(component) -> List[Action]:
     )
 
 
-def _apply_filters(
-    data_frame: pd.DataFrame,
-    ctds_filters: List[CallbackTriggerDict],
-    target: str,
-) -> pd.DataFrame:
+def _apply_filters(data_frame: pd.DataFrame, ctds_filters: List[CallbackTriggerDict], target: str) -> pd.DataFrame:
     for ctd in ctds_filters:
         selector_value = ctd["value"]
         selector_value = selector_value if isinstance(selector_value, list) else [selector_value]
@@ -134,23 +130,17 @@ def _apply_table_filter_interaction(
 
 
 def _apply_filter_interaction(
-    data_frame: pd.DataFrame,
-    ctds_filter_interaction: List[Dict[str, CallbackTriggerDict]],
-    target: str,
+    data_frame: pd.DataFrame, ctds_filter_interaction: List[Dict[str, CallbackTriggerDict]], target: str
 ) -> pd.DataFrame:
     for ctd_filter_interaction in ctds_filter_interaction:
         if "clickData" in ctd_filter_interaction:
             data_frame = _apply_graph_filter_interaction(
-                data_frame=data_frame,
-                target=target,
-                ctd_filter_interaction=ctd_filter_interaction,
+                data_frame=data_frame, target=target, ctd_filter_interaction=ctd_filter_interaction
             )
 
         if "active_cell" in ctd_filter_interaction and "derived_viewport_data" in ctd_filter_interaction:
             data_frame = _apply_table_filter_interaction(
-                data_frame=data_frame,
-                target=target,
-                ctd_filter_interaction=ctd_filter_interaction,
+                data_frame=data_frame, target=target, ctd_filter_interaction=ctd_filter_interaction
             )
 
     return data_frame
@@ -234,15 +224,9 @@ def _get_filtered_data(
     for target in targets:
         data_frame = data_manager._get_component_data(target)
 
-        data_frame = _apply_filters(
-            data_frame=data_frame,
-            ctds_filters=ctds_filters,
-            target=target,
-        )
+        data_frame = _apply_filters(data_frame=data_frame, ctds_filters=ctds_filters, target=target)
         data_frame = _apply_filter_interaction(
-            data_frame=data_frame,
-            ctds_filter_interaction=ctds_filter_interaction,
-            target=target,
+            data_frame=data_frame, ctds_filter_interaction=ctds_filter_interaction, target=target
         )
 
         filtered_data[target] = data_frame
@@ -259,15 +243,10 @@ def _get_modified_page_figures(
     if not targets:
         targets = []
     filtered_data = _get_filtered_data(
-        targets=targets,
-        ctds_filters=ctds_filter,
-        ctds_filter_interaction=ctds_filter_interaction,
+        targets=targets, ctds_filters=ctds_filter, ctds_filter_interaction=ctds_filter_interaction
     )
 
-    parameterized_config = _get_parametrized_config(
-        targets=targets,
-        parameters=ctds_parameters,
-    )
+    parameterized_config = _get_parametrized_config(targets=targets, parameters=ctds_parameters)
 
     outputs: Dict[str, Any] = {}
     for target in targets:

--- a/vizro-core/src/vizro/actions/_callback_mapping/_callback_mapping_utils.py
+++ b/vizro-core/src/vizro/actions/_callback_mapping/_callback_mapping_utils.py
@@ -31,10 +31,7 @@ def _get_matching_actions_by_function(
 def _get_inputs_of_controls(page: Page, control_type: ControlType) -> List[State]:
     """Gets list of `States` for selected `control_type` of triggered `Page`."""
     return [
-        State(
-            component_id=control.selector.id,
-            component_property=control.selector._input_property,
-        )
+        State(component_id=control.selector.id, component_property=control.selector._input_property)
         for control in page.controls
         if isinstance(control, control_type)
     ]
@@ -45,8 +42,7 @@ def _get_inputs_of_figure_interactions(
 ) -> List[Dict[str, State]]:
     """Gets list of `States` for selected chart interaction `action_function` of triggered `Page`."""
     figure_interactions_on_page = _get_matching_actions_by_function(
-        page_id=ModelID(str(page.id)),
-        action_function=action_function,
+        page_id=ModelID(str(page.id)), action_function=action_function
     )
     inputs = []
     for action in figure_interactions_on_page:
@@ -58,17 +54,12 @@ def _get_inputs_of_figure_interactions(
                         component_id=triggered_model._callable_object_id, component_property="active_cell"
                     ),
                     "derived_viewport_data": State(
-                        component_id=triggered_model._callable_object_id,
-                        component_property="derived_viewport_data",
+                        component_id=triggered_model._callable_object_id, component_property="derived_viewport_data"
                     ),
                 }
             )
         else:
-            inputs.append(
-                {
-                    "clickData": State(component_id=triggered_model.id, component_property="clickData"),
-                }
-            )
+            inputs.append({"clickData": State(component_id=triggered_model.id, component_property="clickData")})
 
     return inputs
 
@@ -120,9 +111,7 @@ def _get_action_callback_outputs(action_id: ModelID) -> Dict[str, Output]:
 
     return {
         target: Output(
-            component_id=target,
-            component_property=model_manager[target]._output_property,
-            allow_duplicate=True,
+            component_id=target, component_property=model_manager[target]._output_property, allow_duplicate=True
         )
         for target in targets
     }
@@ -144,11 +133,7 @@ def _get_export_data_callback_outputs(action_id: ModelID) -> Dict[str, Output]:
 
     return {
         f"download_dataframe_{target}": Output(
-            component_id={
-                "type": "download_dataframe",
-                "action_id": action_id,
-                "target_id": target,
-            },
+            component_id={"type": "download_dataframe", "action_id": action_id, "target_id": target},
             component_property="data",
         )
         for target in targets
@@ -171,12 +156,6 @@ def _get_export_data_callback_components(action_id: ModelID) -> List[dcc.Downloa
         )
 
     return [
-        dcc.Download(
-            id={
-                "type": "download_dataframe",
-                "action_id": action_id,
-                "target_id": target,
-            },
-        )
+        dcc.Download(id={"type": "download_dataframe", "action_id": action_id, "target_id": target})
         for target in targets
     ]

--- a/vizro-core/src/vizro/actions/_callback_mapping/_get_action_callback_mapping.py
+++ b/vizro-core/src/vizro/actions/_callback_mapping/_get_action_callback_mapping.py
@@ -31,13 +31,22 @@ def _get_action_callback_mapping(
             "components": _get_export_data_callback_components,
             "outputs": _get_export_data_callback_outputs,
         },
-        _filter.__wrapped__: {"inputs": _get_action_callback_inputs, "outputs": _get_action_callback_outputs},
+        _filter.__wrapped__: {
+            "inputs": _get_action_callback_inputs,
+            "outputs": _get_action_callback_outputs,
+        },
         filter_interaction.__wrapped__: {
             "inputs": _get_action_callback_inputs,
             "outputs": _get_action_callback_outputs,
         },
-        _parameter.__wrapped__: {"inputs": _get_action_callback_inputs, "outputs": _get_action_callback_outputs},
-        _on_page_load.__wrapped__: {"inputs": _get_action_callback_inputs, "outputs": _get_action_callback_outputs},
+        _parameter.__wrapped__: {
+            "inputs": _get_action_callback_inputs,
+            "outputs": _get_action_callback_outputs,
+        },
+        _on_page_load.__wrapped__: {
+            "inputs": _get_action_callback_inputs,
+            "outputs": _get_action_callback_outputs,
+        },
     }
     action_call = action_callback_mapping.get(action_function, {}).get(argument)
     default_value: Union[List[dcc.Download], Dict[str, DashDependency]] = [] if argument == "components" else {}

--- a/vizro-core/src/vizro/actions/_callback_mapping/_get_action_callback_mapping.py
+++ b/vizro-core/src/vizro/actions/_callback_mapping/_get_action_callback_mapping.py
@@ -31,18 +31,12 @@ def _get_action_callback_mapping(
             "components": _get_export_data_callback_components,
             "outputs": _get_export_data_callback_outputs,
         },
-        _filter.__wrapped__: {
-            "inputs": _get_action_callback_inputs,
-            "outputs": _get_action_callback_outputs,
-        },
+        _filter.__wrapped__: {"inputs": _get_action_callback_inputs, "outputs": _get_action_callback_outputs},
         filter_interaction.__wrapped__: {
             "inputs": _get_action_callback_inputs,
             "outputs": _get_action_callback_outputs,
         },
-        _parameter.__wrapped__: {
-            "inputs": _get_action_callback_inputs,
-            "outputs": _get_action_callback_outputs,
-        },
+        _parameter.__wrapped__: {"inputs": _get_action_callback_inputs, "outputs": _get_action_callback_outputs},
         _on_page_load.__wrapped__: {"inputs": _get_action_callback_inputs, "outputs": _get_action_callback_outputs},
     }
     action_call = action_callback_mapping.get(action_function, {}).get(argument)

--- a/vizro-core/src/vizro/actions/_filter_action.py
+++ b/vizro-core/src/vizro/actions/_filter_action.py
@@ -5,9 +5,7 @@ from typing import Any, Callable, Dict, List
 import pandas as pd
 from dash import ctx
 
-from vizro.actions._actions_utils import (
-    _get_modified_page_figures,
-)
+from vizro.actions._actions_utils import _get_modified_page_figures
 from vizro.managers._model_manager import ModelID
 from vizro.models.types import capture
 

--- a/vizro-core/src/vizro/actions/_on_page_load_action.py
+++ b/vizro-core/src/vizro/actions/_on_page_load_action.py
@@ -4,9 +4,7 @@ from typing import Any, Dict, List
 
 from dash import ctx
 
-from vizro.actions._actions_utils import (
-    _get_modified_page_figures,
-)
+from vizro.actions._actions_utils import _get_modified_page_figures
 from vizro.managers._model_manager import ModelID
 from vizro.models.types import capture
 

--- a/vizro-core/src/vizro/actions/_parameter_action.py
+++ b/vizro-core/src/vizro/actions/_parameter_action.py
@@ -4,9 +4,7 @@ from typing import Any, Dict, List
 
 from dash import ctx
 
-from vizro.actions._actions_utils import (
-    _get_modified_page_figures,
-)
+from vizro.actions._actions_utils import _get_modified_page_figures
 from vizro.managers._model_manager import ModelID
 from vizro.models.types import capture
 

--- a/vizro-core/src/vizro/actions/export_data_action.py
+++ b/vizro-core/src/vizro/actions/export_data_action.py
@@ -5,9 +5,7 @@ from typing import Any, Dict, List, Optional
 from dash import ctx, dcc
 from typing_extensions import Literal
 
-from vizro.actions._actions_utils import (
-    _get_filtered_data,
-)
+from vizro.actions._actions_utils import _get_filtered_data
 from vizro.managers import model_manager
 from vizro.managers._model_manager import ModelID
 from vizro.models.types import capture
@@ -15,9 +13,7 @@ from vizro.models.types import capture
 
 @capture("action")
 def export_data(
-    targets: Optional[List[ModelID]] = None,
-    file_format: Literal["csv", "xlsx"] = "csv",
-    **inputs: Dict[str, Any],
+    targets: Optional[List[ModelID]] = None, file_format: Literal["csv", "xlsx"] = "csv", **inputs: Dict[str, Any]
 ) -> Dict[str, Any]:
     """Exports visible data of target charts/components on page after being triggered.
 

--- a/vizro-core/src/vizro/actions/filter_interaction_action.py
+++ b/vizro-core/src/vizro/actions/filter_interaction_action.py
@@ -4,18 +4,13 @@ from typing import Any, Dict, List, Optional
 
 from dash import ctx
 
-from vizro.actions._actions_utils import (
-    _get_modified_page_figures,
-)
+from vizro.actions._actions_utils import _get_modified_page_figures
 from vizro.managers._model_manager import ModelID
 from vizro.models.types import capture
 
 
 @capture("action")
-def filter_interaction(
-    targets: Optional[List[ModelID]] = None,
-    **inputs: Dict[str, Any],
-) -> Dict[str, Any]:
+def filter_interaction(targets: Optional[List[ModelID]] = None, **inputs: Dict[str, Any]) -> Dict[str, Any]:
     """Filters targeted charts/components on page by clicking on data points or table cells of the source chart.
 
     To set up filtering on specific columns of the target graph(s), include these columns in the 'custom_data'

--- a/vizro-core/src/vizro/models/_action/_action.py
+++ b/vizro-core/src/vizro/models/_action/_action.py
@@ -98,7 +98,9 @@ class Action(VizroBaseModel):
         return callback_inputs, callback_outputs, action_components
 
     def _action_callback_function(
-        self, inputs: Union[Dict[str, Any], List[Any]], outputs: Union[Dict[str, Output], List[Output], Output, None]
+        self,
+        inputs: Union[Dict[str, Any], List[Any]],
+        outputs: Union[Dict[str, Output], List[Output], Output, None],
     ) -> Any:
         logger.debug("===== Running action with id %s, function %s =====", self.id, self.function._function.__name__)
         if logger.isEnabledFor(logging.DEBUG):
@@ -153,7 +155,9 @@ class Action(VizroBaseModel):
             "external": external_callback_inputs,
             "internal": {"trigger": Input({"type": "action_trigger", "action_name": self.id}, "data")},
         }
-        callback_outputs = {"internal": {"action_finished": Output("action_finished", "data", allow_duplicate=True)}}
+        callback_outputs = {
+            "internal": {"action_finished": Output("action_finished", "data", allow_duplicate=True)},
+        }
 
         # If there are no outputs then we don't want the external part of callback_outputs to exist at all.
         # This allows the action function to return None and match correctly on to the callback_outputs dictionary

--- a/vizro-core/src/vizro/models/_action/_action.py
+++ b/vizro-core/src/vizro/models/_action/_action.py
@@ -98,15 +98,9 @@ class Action(VizroBaseModel):
         return callback_inputs, callback_outputs, action_components
 
     def _action_callback_function(
-        self,
-        inputs: Union[Dict[str, Any], List[Any]],
-        outputs: Union[Dict[str, Output], List[Output], Output, None],
+        self, inputs: Union[Dict[str, Any], List[Any]], outputs: Union[Dict[str, Output], List[Output], Output, None]
     ) -> Any:
-        logger.debug(
-            "===== Running action with id %s, function %s =====",
-            self.id,
-            self.function._function.__name__,
-        )
+        logger.debug("===== Running action with id %s, function %s =====", self.id, self.function._function.__name__)
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug("Action inputs:\n%s", pformat(inputs, depth=2, width=200))
             logger.debug("Action outputs:\n%s", pformat(outputs, width=200))
@@ -159,9 +153,7 @@ class Action(VizroBaseModel):
             "external": external_callback_inputs,
             "internal": {"trigger": Input({"type": "action_trigger", "action_name": self.id}, "data")},
         }
-        callback_outputs = {
-            "internal": {"action_finished": Output("action_finished", "data", allow_duplicate=True)},
-        }
+        callback_outputs = {"internal": {"action_finished": Output("action_finished", "data", allow_duplicate=True)}}
 
         # If there are no outputs then we don't want the external part of callback_outputs to exist at all.
         # This allows the action function to return None and match correctly on to the callback_outputs dictionary

--- a/vizro-core/src/vizro/models/_action/_actions_chain.py
+++ b/vizro-core/src/vizro/models/_action/_actions_chain.py
@@ -22,7 +22,10 @@ class ActionsChain(VizroBaseModel):
 # Validators for reuse in other models to convert to ActionsChain
 def _set_actions(actions: List[Action], values: Dict[str, Any], trigger_property: str) -> List[ActionsChain]:
     return [
-        ActionsChain(trigger=Trigger(component_id=values["id"], component_property=trigger_property), actions=actions),
+        ActionsChain(
+            trigger=Trigger(component_id=values["id"], component_property=trigger_property),
+            actions=actions,
+        )
     ]
 
 

--- a/vizro-core/src/vizro/models/_action/_actions_chain.py
+++ b/vizro-core/src/vizro/models/_action/_actions_chain.py
@@ -22,13 +22,7 @@ class ActionsChain(VizroBaseModel):
 # Validators for reuse in other models to convert to ActionsChain
 def _set_actions(actions: List[Action], values: Dict[str, Any], trigger_property: str) -> List[ActionsChain]:
     return [
-        ActionsChain(
-            trigger=Trigger(
-                component_id=values["id"],
-                component_property=trigger_property,
-            ),
-            actions=actions,
-        )
+        ActionsChain(trigger=Trigger(component_id=values["id"], component_property=trigger_property), actions=actions)
     ]
 
 

--- a/vizro-core/src/vizro/models/_action/_actions_chain.py
+++ b/vizro-core/src/vizro/models/_action/_actions_chain.py
@@ -22,7 +22,7 @@ class ActionsChain(VizroBaseModel):
 # Validators for reuse in other models to convert to ActionsChain
 def _set_actions(actions: List[Action], values: Dict[str, Any], trigger_property: str) -> List[ActionsChain]:
     return [
-        ActionsChain(trigger=Trigger(component_id=values["id"], component_property=trigger_property), actions=actions)
+        ActionsChain(trigger=Trigger(component_id=values["id"], component_property=trigger_property), actions=actions),
     ]
 
 

--- a/vizro-core/src/vizro/models/_components/_form.py
+++ b/vizro-core/src/vizro/models/_components/_form.py
@@ -10,13 +10,7 @@ except ImportError:  # pragma: no cov
     from pydantic import validator
 
 from vizro.models import VizroBaseModel
-from vizro.models._components.form import (
-    Checklist,
-    Dropdown,
-    RadioItems,
-    RangeSlider,
-    Slider,
-)
+from vizro.models._components.form import Checklist, Dropdown, RadioItems, RangeSlider, Slider
 from vizro.models._layout import set_layout
 from vizro.models._models_utils import _log_call, set_components
 from vizro.models.types import _FormComponentType

--- a/vizro-core/src/vizro/models/_components/card.py
+++ b/vizro-core/src/vizro/models/_components/card.py
@@ -36,8 +36,7 @@ class Card(VizroBaseModel):
         text = dcc.Markdown(self.text, className="card_text", dangerously_allow_html=False, id=self.id)
         button = html.Div(
             dbc.Button(
-                href=get_relative_path(self.href) if self.href.startswith("/") else self.href,
-                className="card_button",
+                href=get_relative_path(self.href) if self.href.startswith("/") else self.href, className="card_button"
             ),
             className="button_container",
         )

--- a/vizro-core/src/vizro/models/_components/form/__init__.py
+++ b/vizro-core/src/vizro/models/_components/form/__init__.py
@@ -6,11 +6,4 @@ from vizro.models._components.form.range_slider import RangeSlider
 from vizro.models._components.form.slider import Slider
 
 # Please keep alphabetically ordered
-__all__ = [
-    "Button",
-    "Checklist",
-    "Dropdown",
-    "RadioItems",
-    "RangeSlider",
-    "Slider",
-]
+__all__ = ["Button", "Checklist", "Dropdown", "RadioItems", "RangeSlider", "Slider"]

--- a/vizro-core/src/vizro/models/_components/form/_alert.py
+++ b/vizro-core/src/vizro/models/_components/form/_alert.py
@@ -39,7 +39,7 @@ class Alert(VizroBaseModel):
                     duration=self.duration,
                     is_open=self.is_open,
                     className="alert",
-                ),
+                )
             ],
             className="alert_container",
         )

--- a/vizro-core/src/vizro/models/_components/form/range_slider.py
+++ b/vizro-core/src/vizro/models/_components/form/range_slider.py
@@ -83,14 +83,7 @@ class RangeSlider(VizroBaseModel):
 
         return html.Div(
             [
-                dcc.Store(
-                    f"{self.id}_callback_data",
-                    data={
-                        "id": self.id,
-                        "min": self.min,
-                        "max": self.max,
-                    },
-                ),
+                dcc.Store(f"{self.id}_callback_data", data={"id": self.id, "min": self.min, "max": self.max}),
                 html.P(self.title) if self.title else None,
                 html.Div(
                     [
@@ -136,11 +129,7 @@ class RangeSlider(VizroBaseModel):
                                     if self.step
                                     else "slider_input_field_no_space_right",
                                 ),
-                                dcc.Store(
-                                    id=f"{self.id}_input_store",
-                                    storage_type="session",
-                                    data=init_value,
-                                ),
+                                dcc.Store(id=f"{self.id}_input_store", storage_type="session", data=init_value),
                             ],
                             className="slider_input_container",
                         ),

--- a/vizro-core/src/vizro/models/_components/form/slider.py
+++ b/vizro-core/src/vizro/models/_components/form/slider.py
@@ -79,14 +79,7 @@ class Slider(VizroBaseModel):
 
         return html.Div(
             [
-                dcc.Store(
-                    f"{self.id}_callback_data",
-                    data={
-                        "id": self.id,
-                        "min": self.min,
-                        "max": self.max,
-                    },
-                ),
+                dcc.Store(f"{self.id}_callback_data", data={"id": self.id, "min": self.min, "max": self.max}),
                 html.P(self.title) if self.title else None,
                 html.Div(
                     [

--- a/vizro-core/src/vizro/models/_components/graph.py
+++ b/vizro-core/src/vizro/models/_components/graph.py
@@ -87,11 +87,7 @@ class Graph(VizroBaseModel):
                         "yaxis": {"visible": False},
                     }
                 ),
-                config={
-                    "autosizable": True,
-                    "frameMargins": 0,
-                    "responsive": True,
-                },
+                config={"autosizable": True, "frameMargins": 0, "responsive": True},
                 className="chart_container",
             ),
             color="grey",

--- a/vizro-core/src/vizro/models/_controls/filter.py
+++ b/vizro-core/src/vizro/models/_controls/filter.py
@@ -15,13 +15,7 @@ from vizro.actions import _filter
 from vizro.managers import data_manager, model_manager
 from vizro.managers._model_manager import ModelID
 from vizro.models import Action, VizroBaseModel
-from vizro.models._components.form import (
-    Checklist,
-    Dropdown,
-    RadioItems,
-    RangeSlider,
-    Slider,
-)
+from vizro.models._components.form import Checklist, Dropdown, RadioItems, RangeSlider, Slider
 from vizro.models._models_utils import _log_call
 from vizro.models.types import MultiValueType, SelectorType
 
@@ -143,11 +137,7 @@ class Filter(VizroBaseModel):
             filter_function = _filter_between if isinstance(self.selector, RangeSlider) else _filter_isin
             self.selector.actions = [
                 Action(
-                    function=_filter(
-                        filter_column=self.column,
-                        targets=self.targets,
-                        filter_function=filter_function,
-                    ),
+                    function=_filter(filter_column=self.column, targets=self.targets, filter_function=filter_function),
                     id=f"{FILTER_ACTION_PREFIX}_{self.id}",
                 )
             ]

--- a/vizro-core/src/vizro/models/_controls/parameter.py
+++ b/vizro-core/src/vizro/models/_controls/parameter.py
@@ -9,13 +9,7 @@ from vizro._constants import PARAMETER_ACTION_PREFIX
 from vizro.actions import _parameter
 from vizro.managers import model_manager
 from vizro.models import Action, VizroBaseModel
-from vizro.models._components.form import (
-    Checklist,
-    Dropdown,
-    RadioItems,
-    RangeSlider,
-    Slider,
-)
+from vizro.models._components.form import Checklist, Dropdown, RadioItems, RangeSlider, Slider
 from vizro.models._models_utils import _log_call
 from vizro.models.types import SelectorType
 
@@ -93,10 +87,5 @@ class Parameter(VizroBaseModel):
     def _set_actions(self):
         if not self.selector.actions:
             self.selector.actions = [
-                Action(
-                    id=f"{PARAMETER_ACTION_PREFIX}_{self.id}",
-                    function=_parameter(
-                        targets=self.targets,
-                    ),
-                )
+                Action(id=f"{PARAMETER_ACTION_PREFIX}_{self.id}", function=_parameter(targets=self.targets))
             ]

--- a/vizro-core/src/vizro/models/_dashboard.py
+++ b/vizro-core/src/vizro/models/_dashboard.py
@@ -180,10 +180,7 @@ class Dashboard(VizroBaseModel):
         logo_title = [page_divs["logo"], page_divs["dashboard-title"]]
         page_header_divs = [html.Div(logo_title, id="logo-and-title", hidden=_all_hidden(logo_title))]
         left_sidebar_divs = [page_divs["nav-bar"]]
-        left_main_divs = [
-            page_divs["nav-panel"],
-            page_divs["control-panel"],
-        ]
+        left_main_divs = [page_divs["nav-panel"], page_divs["control-panel"]]
         right_header_divs = [page_divs["page-title"]]
 
         # Apply different container position logic based on condition
@@ -194,11 +191,7 @@ class Dashboard(VizroBaseModel):
 
         collapsable_icon = (
             dmc.Tooltip(
-                html.Span(
-                    "keyboard_double_arrow_left",
-                    className="material-symbols-outlined",
-                    id="collapse-icon",
-                ),
+                html.Span("keyboard_double_arrow_left", className="material-symbols-outlined", id="collapse-icon"),
                 id="collapse-tooltip",
                 label="Hide Menu",
                 offset=24,
@@ -215,12 +208,7 @@ class Dashboard(VizroBaseModel):
         left_main = html.Div(left_main_divs, id="left-main", hidden=_all_hidden(left_main_divs))
         left_side = html.Div([left_sidebar, left_main], id="left-side")
 
-        collapsable_left_side = dbc.Collapse(
-            left_side,
-            id="collapsable-left-side",
-            is_open=True,
-            dimension="width",
-        )
+        collapsable_left_side = dbc.Collapse(left_side, id="collapsable-left-side", is_open=True, dimension="width")
 
         right_header = html.Div(right_header_divs, id="right-header")
         right_main = page_divs["page-components"]

--- a/vizro-core/src/vizro/models/_navigation/accordion.py
+++ b/vizro-core/src/vizro/models/_navigation/accordion.py
@@ -71,7 +71,7 @@ class Accordion(VizroBaseModel):
                     persistence_type="session",
                     always_open=True,
                     active_item=active_item,
-                ),
+                )
             ],
             id="nav-panel",
         )

--- a/vizro-core/src/vizro/models/_page.py
+++ b/vizro-core/src/vizro/models/_page.py
@@ -95,13 +95,11 @@ class Page(VizroBaseModel):
                 ActionsChain(
                     id=f"{ON_PAGE_LOAD_ACTION_PREFIX}_{self.id}",
                     trigger=Trigger(
-                        component_id=f"{ON_PAGE_LOAD_ACTION_PREFIX}_trigger_{self.id}",
-                        component_property="data",
+                        component_id=f"{ON_PAGE_LOAD_ACTION_PREFIX}_trigger_{self.id}", component_property="data"
                     ),
                     actions=[
                         Action(
-                            id=f"{ON_PAGE_LOAD_ACTION_PREFIX}_action_{self.id}",
-                            function=_on_page_load(targets=targets),
+                            id=f"{ON_PAGE_LOAD_ACTION_PREFIX}_action_{self.id}", function=_on_page_load(targets=targets)
                         )
                     ],
                 )

--- a/vizro-core/src/vizro/models/types.py
+++ b/vizro-core/src/vizro/models/types.py
@@ -157,9 +157,7 @@ class CapturedCallable:
 
     @classmethod
     def _parse_json(
-        cls,
-        callable_config: Union[_SupportsCapturedCallable, CapturedCallable, Dict[str, Any]],
-        field: ModelField,
+        cls, callable_config: Union[_SupportsCapturedCallable, CapturedCallable, Dict[str, Any]], field: ModelField
     ) -> CapturedCallable:
         """Parses callable_config specification from JSON/YAML to a CapturedCallable.
 
@@ -334,10 +332,7 @@ OptionsType = Union[List[StrictBool], List[float], List[str], List[OptionsDictTy
 # All the below types rely on models and so must use ForwardRef (i.e. "Checklist" rather than actual Checklist class).
 SelectorType = Annotated[
     Union["Checklist", "Dropdown", "RadioItems", "RangeSlider", "Slider"],
-    Field(
-        discriminator="type",
-        description="Selectors to be used inside a control.",
-    ),
+    Field(discriminator="type", description="Selectors to be used inside a control."),
 ]
 """Discriminated union. Type of selector to be used inside a control: [`Checklist`][vizro.models.Checklist],
 [`Dropdown`][vizro.models.Dropdown], [`RadioItems`][vizro.models.RadioItems],
@@ -345,28 +340,19 @@ SelectorType = Annotated[
 
 _FormComponentType = Annotated[
     Union[SelectorType, "Button", "UserInput"],
-    Field(
-        discriminator="type",
-        description="Components that can be used to receive user input within a form.",
-    ),
+    Field(discriminator="type", description="Components that can be used to receive user input within a form."),
 ]
 
 ControlType = Annotated[
     Union["Filter", "Parameter"],
-    Field(
-        discriminator="type",
-        description="Control that affects components on the page.",
-    ),
+    Field(discriminator="type", description="Control that affects components on the page."),
 ]
 """Discriminated union. Type of control that affects components on the page: [`Filter`][vizro.models.Filter] or
 [`Parameter`][vizro.models.Parameter]."""
 
 ComponentType = Annotated[
     Union["Button", "Card", "Container", "Graph", "Table"],
-    Field(
-        discriminator="type",
-        description="Component that makes up part of the layout on the page.",
-    ),
+    Field(discriminator="type", description="Component that makes up part of the layout on the page."),
 ]
 """Discriminated union. Type of component that makes up part of the layout on the page:
 [`Button`][vizro.models.Button], [`Card`][vizro.models.Card], [`Table`][vizro.models.Table] or
@@ -376,8 +362,7 @@ NavPagesType = Union[List[str], Dict[str, List[str]]]
 "List of page IDs or a mapping from name of a group to a list of page IDs (for hierarchical sub-navigation)."
 
 NavSelectorType = Annotated[
-    Union["Accordion", "NavBar"],
-    Field(discriminator="type", description="Component for rendering navigation."),
+    Union["Accordion", "NavBar"], Field(discriminator="type", description="Component for rendering navigation.")
 ]
 """Discriminated union. Type of component for rendering navigation:
 [`Accordion`][vizro.models.Accordion] or [`NavBar`][vizro.models.NavBar]."""

--- a/vizro-core/src/vizro/static/css/selectors.css
+++ b/vizro-core/src/vizro/static/css/selectors.css
@@ -13,10 +13,10 @@
 .selector_dropdown_container {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-03);
+  gap: var(--spacing-05);
   width: 100%;
 }
 
 .selector_dropdown_container {
-  gap: var(--spacing-02);
+  gap: var(--spacing-04);
 }

--- a/vizro-core/tests/integration/test_navigation.py
+++ b/vizro-core/tests/integration/test_navigation.py
@@ -10,10 +10,7 @@ from vizro.managers import model_manager
 def dashboard_result(request):
     # Inject the navigation into the dashboard. Note we need to call request.param since they are all lambda functions.
     dashboard = vm.Dashboard(
-        pages=[
-            vm.Page(title="Page 1", components=[vm.Button()]),
-            vm.Page(title="Page 2", components=[vm.Button()]),
-        ],
+        pages=[vm.Page(title="Page 1", components=[vm.Button()]), vm.Page(title="Page 2", components=[vm.Button()])],
         navigation=request.param(),
     )
     Vizro()._pre_build()
@@ -87,11 +84,7 @@ navbar_flat_cases = [
     (
         lambda: vm.Navigation(pages=["Page 1"], nav_selector=vm.NavBar()),
         lambda: vm.Navigation(
-            nav_selector=vm.NavBar(
-                items=[
-                    vm.NavLink(label="Page 1", pages=["Page 1"], icon="filter_1"),
-                ]
-            )
+            nav_selector=vm.NavBar(items=[vm.NavLink(label="Page 1", pages=["Page 1"], icon="filter_1")])
         ),
     ),
 ]
@@ -144,9 +137,7 @@ navbar_grouped_cases = label_cases(navbar_grouped_cases, "navbar_grouped")
 
 
 @pytest.mark.parametrize(
-    "dashboard_result, dashboard_expected",
-    accordion_cases + navbar_flat_cases + navbar_grouped_cases,
-    indirect=True,
+    "dashboard_result, dashboard_expected", accordion_cases + navbar_flat_cases + navbar_grouped_cases, indirect=True
 )
 def test_navigation_build(dashboard_result, dashboard_expected):
     result = dashboard_result.navigation.build()

--- a/vizro-core/tests/integration/test_navigation.py
+++ b/vizro-core/tests/integration/test_navigation.py
@@ -10,7 +10,10 @@ from vizro.managers import model_manager
 def dashboard_result(request):
     # Inject the navigation into the dashboard. Note we need to call request.param since they are all lambda functions.
     dashboard = vm.Dashboard(
-        pages=[vm.Page(title="Page 1", components=[vm.Button()]), vm.Page(title="Page 2", components=[vm.Button()])],
+        pages=[
+            vm.Page(title="Page 1", components=[vm.Button()]),
+            vm.Page(title="Page 2", components=[vm.Button()]),
+        ],
         navigation=request.param(),
     )
     Vizro()._pre_build()

--- a/vizro-core/tests/unit/vizro/actions/_action_loop/test_get_action_loop_components.py
+++ b/vizro-core/tests/unit/vizro/actions/_action_loop/test_get_action_loop_components.py
@@ -105,7 +105,17 @@ def managers_one_page_two_components_two_controls(vizro_app, dash_data_table_wit
 @pytest.fixture
 def managers_one_page_no_actions(vizro_app):
     """Instantiates managers with one "empty" page."""
-    vm.Dashboard(pages=[vm.Page(id="test_page_no_actions", title="Second page", components=[vm.Card(text="")])])
+    vm.Dashboard(
+        pages=[
+            vm.Page(
+                id="test_page_no_actions",
+                title="Second page",
+                components=[
+                    vm.Card(text=""),
+                ],
+            ),
+        ]
+    )
 
     Vizro._pre_build()
 

--- a/vizro-core/tests/unit/vizro/actions/_action_loop/test_get_action_loop_components.py
+++ b/vizro-core/tests/unit/vizro/actions/_action_loop/test_get_action_loop_components.py
@@ -29,10 +29,7 @@ def gateway_components(request):
     components = request.param
     actions_chain_ids = [model_manager[component].actions[0].id for component in components]
     return [
-        dcc.Store(
-            id={"type": "gateway_input", "trigger_id": actions_chain_id},
-            data=f"{actions_chain_id}",
-        )
+        dcc.Store(id={"type": "gateway_input", "trigger_id": actions_chain_id}, data=f"{actions_chain_id}")
         for actions_chain_id in actions_chain_ids
     ]
 
@@ -48,10 +45,7 @@ def action_trigger_components(request):
 def action_trigger_actions_id_component(request):
     components = request.param
     actions_ids = [model_manager[component].actions[0].actions[0].id for component in components]
-    return dcc.Store(
-        id="action_trigger_actions_id",
-        data=actions_ids,
-    )
+    return dcc.Store(id="action_trigger_actions_id", data=actions_ids)
 
 
 @pytest.fixture
@@ -86,13 +80,9 @@ def managers_one_page_two_components_two_controls(vizro_app, dash_data_table_wit
                             )
                         ],
                     ),
-                    vm.Graph(
-                        id="scatter_chart",
-                        figure=px.scatter(px.data.gapminder(), x="lifeExp", y="gdpPercap"),
-                    ),
+                    vm.Graph(id="scatter_chart", figure=px.scatter(px.data.gapminder(), x="lifeExp", y="gdpPercap")),
                     vm.Button(
-                        id="export_data_button",
-                        actions=[vm.Action(id="export_data_action", function=export_data())],
+                        id="export_data_button", actions=[vm.Action(id="export_data_action", function=export_data())]
                     ),
                 ],
                 controls=[
@@ -102,10 +92,7 @@ def managers_one_page_two_components_two_controls(vizro_app, dash_data_table_wit
                     vm.Parameter(
                         id="parameter_x",
                         targets=["scatter_chart.x"],
-                        selector=vm.Dropdown(
-                            id="parameter_x_selector",
-                            options=["lifeExp", "gdpPercap", "pop"],
-                        ),
+                        selector=vm.Dropdown(id="parameter_x_selector", options=["lifeExp", "gdpPercap", "pop"]),
                     ),
                 ],
             )
@@ -118,15 +105,7 @@ def managers_one_page_two_components_two_controls(vizro_app, dash_data_table_wit
 @pytest.fixture
 def managers_one_page_no_actions(vizro_app):
     """Instantiates managers with one "empty" page."""
-    vm.Dashboard(
-        pages=[
-            vm.Page(
-                id="test_page_no_actions",
-                title="Second page",
-                components=[vm.Card(text="")],
-            )
-        ]
-    )
+    vm.Dashboard(pages=[vm.Page(id="test_page_no_actions", title="Second page", components=[vm.Card(text="")])])
 
     Vizro._pre_build()
 

--- a/vizro-core/tests/unit/vizro/actions/_callback_mapping/test_get_action_callback_mapping.py
+++ b/vizro-core/tests/unit/vizro/actions/_callback_mapping/test_get_action_callback_mapping.py
@@ -89,30 +89,21 @@ def managers_one_page_four_controls_three_figures_filter_interaction(request, da
                 id="parameter_x",
                 targets=["scatter_chart.x", "scatter_chart_2.x"],
                 selector=vm.Dropdown(
-                    id="parameter_x_selector",
-                    options=["lifeExp", "gdpPercap", "pop"],
-                    multi=False,
-                    value="gdpPercap",
+                    id="parameter_x_selector", options=["lifeExp", "gdpPercap", "pop"], multi=False, value="gdpPercap"
                 ),
             ),
             vm.Parameter(
                 id="parameter_y",
                 targets=["scatter_chart.y", "scatter_chart_2.y"],
                 selector=vm.Dropdown(
-                    id="parameter_y_selector",
-                    options=["lifeExp", "gdpPercap", "pop"],
-                    multi=False,
-                    value="lifeExp",
+                    id="parameter_y_selector", options=["lifeExp", "gdpPercap", "pop"], multi=False, value="lifeExp"
                 ),
             ),
             vm.Parameter(
                 id="vizro_table_row_selectable",
                 targets=["vizro_table.row_selectable"],
                 selector=vm.Dropdown(
-                    id="parameter_table_row_selectable",
-                    options=["multi", "single"],
-                    multi=False,
-                    value="single",
+                    id="parameter_table_row_selectable", options=["multi", "single"], multi=False, value="single"
                 ),
             ),
         ],
@@ -123,19 +114,14 @@ def managers_one_page_four_controls_three_figures_filter_interaction(request, da
 @pytest.fixture
 def action_callback_inputs_expected():
     return {
-        "filters": [
-            dash.State("filter_continent_selector", "value"),
-            dash.State("filter_country_selector", "value"),
-        ],
+        "filters": [dash.State("filter_continent_selector", "value"), dash.State("filter_country_selector", "value")],
         "parameters": [
             dash.State("parameter_x_selector", "value"),
             dash.State("parameter_y_selector", "value"),
             dash.State("parameter_table_row_selectable", "value"),
         ],
         "filter_interaction": [
-            {
-                "clickData": dash.State("scatter_chart", "clickData"),
-            },
+            {"clickData": dash.State("scatter_chart", "clickData")},
             {
                 "active_cell": dash.State("underlying_table_id", "active_cell"),
                 "derived_viewport_data": dash.State("underlying_table_id", "derived_viewport_data"),
@@ -156,15 +142,10 @@ def action_callback_outputs_expected(request):
 @pytest.fixture
 def export_data_inputs_expected():
     return {
-        "filters": [
-            dash.State("filter_continent_selector", "value"),
-            dash.State("filter_country_selector", "value"),
-        ],
+        "filters": [dash.State("filter_continent_selector", "value"), dash.State("filter_country_selector", "value")],
         "parameters": [],
         "filter_interaction": [
-            {
-                "clickData": dash.State("scatter_chart", "clickData"),
-            },
+            {"clickData": dash.State("scatter_chart", "clickData")},
             {
                 "active_cell": dash.State("underlying_table_id", "active_cell"),
                 "derived_viewport_data": dash.State("underlying_table_id", "derived_viewport_data"),
@@ -207,10 +188,7 @@ class TestCallbackMapping:
         ],
     )
     def test_action_callback_mapping_inputs(self, action_id, callback_mapping_inputs_expected, request):
-        result = _get_action_callback_mapping(
-            action_id=action_id,
-            argument="inputs",
-        )
+        result = _get_action_callback_mapping(action_id=action_id, argument="inputs")
 
         callback_mapping_inputs_expected = request.getfixturevalue(callback_mapping_inputs_expected)
         assert result == callback_mapping_inputs_expected
@@ -258,30 +236,20 @@ class TestCallbackMapping:
             ),
             (
                 "parameter_action_vizro_table_row_selectable",
-                [
-                    {"component_id": "vizro_table", "component_property": "children"},
-                ],
+                [{"component_id": "vizro_table", "component_property": "children"}],
             ),
         ],
         indirect=["action_callback_outputs_expected"],
     )
     def test_action_callback_mapping_outputs(self, action_id, action_callback_outputs_expected):
-        result = _get_action_callback_mapping(
-            action_id=action_id,
-            argument="outputs",
-        )
+        result = _get_action_callback_mapping(action_id=action_id, argument="outputs")
         assert result == action_callback_outputs_expected
 
     @pytest.mark.parametrize(
-        "export_data_outputs_expected",
-        [("scatter_chart", "scatter_chart_2", "vizro_table")],
-        indirect=True,
+        "export_data_outputs_expected", [("scatter_chart", "scatter_chart_2", "vizro_table")], indirect=True
     )
     def test_export_data_no_targets_set_mapping_outputs(self, export_data_outputs_expected):
-        result = _get_action_callback_mapping(
-            action_id="export_data_action",
-            argument="outputs",
-        )
+        result = _get_action_callback_mapping(action_id="export_data_action", argument="outputs")
 
         assert result == export_data_outputs_expected
 
@@ -298,23 +266,15 @@ class TestCallbackMapping:
     def test_export_data_targets_set_mapping_outputs(
         self, managers_one_page_four_controls_three_figures_filter_interaction, export_data_outputs_expected
     ):
-        result = _get_action_callback_mapping(
-            action_id="export_data_action",
-            argument="outputs",
-        )
+        result = _get_action_callback_mapping(action_id="export_data_action", argument="outputs")
 
         assert result == export_data_outputs_expected
 
     @pytest.mark.parametrize(
-        "export_data_components_expected",
-        [("scatter_chart", "scatter_chart_2", "vizro_table")],
-        indirect=True,
+        "export_data_components_expected", [("scatter_chart", "scatter_chart_2", "vizro_table")], indirect=True
     )
     def test_export_data_no_targets_set_mapping_components(self, export_data_components_expected):
-        result_components = _get_action_callback_mapping(
-            action_id="export_data_action",
-            argument="components",
-        )
+        result_components = _get_action_callback_mapping(action_id="export_data_action", argument="components")
 
         result = json.dumps(result_components, cls=plotly.utils.PlotlyJSONEncoder)
         expected = json.dumps(export_data_components_expected, cls=plotly.utils.PlotlyJSONEncoder)
@@ -333,19 +293,13 @@ class TestCallbackMapping:
     def test_export_data_targets_set_mapping_components(
         self, managers_one_page_four_controls_three_figures_filter_interaction, export_data_components_expected
     ):
-        result_components = _get_action_callback_mapping(
-            action_id="export_data_action",
-            argument="components",
-        )
+        result_components = _get_action_callback_mapping(action_id="export_data_action", argument="components")
         result = json.dumps(result_components, cls=plotly.utils.PlotlyJSONEncoder)
         expected = json.dumps(export_data_components_expected, cls=plotly.utils.PlotlyJSONEncoder)
         assert result == expected
 
     def test_known_action_unknown_argument(self):
-        result = _get_action_callback_mapping(
-            action_id="export_data_action",
-            argument="unknown-argument",
-        )
+        result = _get_action_callback_mapping(action_id="export_data_action", argument="unknown-argument")
         assert result == {}
 
     # "export_data_custom_action" represents a unique scenario within custom actions, where the function's name
@@ -353,17 +307,8 @@ class TestCallbackMapping:
     # It requires handling them as conventional custom actions.
     @pytest.mark.parametrize("action_id", ["custom_action", "export_data_custom_action"])
     @pytest.mark.parametrize(
-        "argument, expected",
-        [
-            ("inputs", {}),
-            ("outputs", {}),
-            ("components", []),
-            ("unknown-argument", {}),
-        ],
+        "argument, expected", [("inputs", {}), ("outputs", {}), ("components", []), ("unknown-argument", {})]
     )
     def test_custom_action_mapping(self, action_id, argument, expected):
-        result = _get_action_callback_mapping(
-            action_id=action_id,
-            argument=argument,
-        )
+        result = _get_action_callback_mapping(action_id=action_id, argument=argument)
         assert result == expected

--- a/vizro-core/tests/unit/vizro/actions/_callback_mapping/test_get_action_callback_mapping.py
+++ b/vizro-core/tests/unit/vizro/actions/_callback_mapping/test_get_action_callback_mapping.py
@@ -89,21 +89,30 @@ def managers_one_page_four_controls_three_figures_filter_interaction(request, da
                 id="parameter_x",
                 targets=["scatter_chart.x", "scatter_chart_2.x"],
                 selector=vm.Dropdown(
-                    id="parameter_x_selector", options=["lifeExp", "gdpPercap", "pop"], multi=False, value="gdpPercap"
+                    id="parameter_x_selector",
+                    options=["lifeExp", "gdpPercap", "pop"],
+                    multi=False,
+                    value="gdpPercap",
                 ),
             ),
             vm.Parameter(
                 id="parameter_y",
                 targets=["scatter_chart.y", "scatter_chart_2.y"],
                 selector=vm.Dropdown(
-                    id="parameter_y_selector", options=["lifeExp", "gdpPercap", "pop"], multi=False, value="lifeExp"
+                    id="parameter_y_selector",
+                    options=["lifeExp", "gdpPercap", "pop"],
+                    multi=False,
+                    value="lifeExp",
                 ),
             ),
             vm.Parameter(
                 id="vizro_table_row_selectable",
                 targets=["vizro_table.row_selectable"],
                 selector=vm.Dropdown(
-                    id="parameter_table_row_selectable", options=["multi", "single"], multi=False, value="single"
+                    id="parameter_table_row_selectable",
+                    options=["multi", "single"],
+                    multi=False,
+                    value="single",
                 ),
             ),
         ],

--- a/vizro-core/tests/unit/vizro/actions/_callback_mapping/test_get_action_callback_mapping.py
+++ b/vizro-core/tests/unit/vizro/actions/_callback_mapping/test_get_action_callback_mapping.py
@@ -123,7 +123,10 @@ def managers_one_page_four_controls_three_figures_filter_interaction(request, da
 @pytest.fixture
 def action_callback_inputs_expected():
     return {
-        "filters": [dash.State("filter_continent_selector", "value"), dash.State("filter_country_selector", "value")],
+        "filters": [
+            dash.State("filter_continent_selector", "value"),
+            dash.State("filter_country_selector", "value"),
+        ],
         "parameters": [
             dash.State("parameter_x_selector", "value"),
             dash.State("parameter_y_selector", "value"),
@@ -151,7 +154,10 @@ def action_callback_outputs_expected(request):
 @pytest.fixture
 def export_data_inputs_expected():
     return {
-        "filters": [dash.State("filter_continent_selector", "value"), dash.State("filter_country_selector", "value")],
+        "filters": [
+            dash.State("filter_continent_selector", "value"),
+            dash.State("filter_country_selector", "value"),
+        ],
         "parameters": [],
         "filter_interaction": [
             {"clickData": dash.State("scatter_chart", "clickData")},
@@ -213,7 +219,12 @@ class TestCallbackMapping:
                     {"component_id": "vizro_table", "component_property": "children"},
                 ],
             ),
-            ("filter_interaction_action", [{"component_id": "scatter_chart_2", "component_property": "figure"}]),
+            (
+                "filter_interaction_action",
+                [
+                    {"component_id": "scatter_chart_2", "component_property": "figure"},
+                ],
+            ),
             (
                 "table_filter_interaction_action",
                 [

--- a/vizro-core/tests/unit/vizro/actions/test_export_data_action.py
+++ b/vizro-core/tests/unit/vizro/actions/test_export_data_action.py
@@ -5,9 +5,7 @@ from dash._utils import AttributeDict
 import vizro.models as vm
 from vizro import Vizro
 from vizro.actions import export_data, filter_interaction
-from vizro.actions._actions_utils import (
-    CallbackTriggerDict,
-)
+from vizro.actions._actions_utils import CallbackTriggerDict
 from vizro.managers import model_manager
 
 
@@ -36,11 +34,7 @@ def target_box_filtered_pop(request, gapminder_2007):
 @pytest.fixture
 def managers_one_page_without_graphs_one_button():
     """Instantiates a simple model_manager and data_manager with a page, and no graphs."""
-    vm.Page(
-        id="test_page",
-        title="My first dashboard",
-        components=[vm.Button(id="button")],
-    )
+    vm.Page(id="test_page", title="My first dashboard", components=[vm.Button(id="button")])
     Vizro._pre_build()
 
 
@@ -55,13 +49,7 @@ def ctx_export_data(request):
                 "clickData": CallbackTriggerDict(
                     id="box_chart",
                     property="clickData",
-                    value={
-                        "points": [
-                            {
-                                "customdata": [continent_filter_interaction],
-                            }
-                        ]
-                    },
+                    value={"points": [{"customdata": [continent_filter_interaction]}]},
                     str_id="box_chart",
                     triggered=False,
                 )
@@ -81,16 +69,8 @@ def ctx_export_data(request):
                     id="underlying_table_id",
                     property="derived_viewport_data",
                     value=[
-                        {
-                            "country": "Algeria",
-                            "continent": "Africa",
-                            "year": 2007,
-                        },
-                        {
-                            "country": "Egypt",
-                            "continent": "Africa",
-                            "year": 2007,
-                        },
+                        {"country": "Algeria", "continent": "Africa", "year": 2007},
+                        {"country": "Egypt", "continent": "Africa", "year": 2007},
                     ],
                     str_id="underlying_table_id",
                     triggered=False,
@@ -102,23 +82,16 @@ def ctx_export_data(request):
             "external": {
                 "filters": [
                     CallbackTriggerDict(
-                        id="pop_filter",
-                        property="value",
-                        value=pop_filter,
-                        str_id="pop_filter",
-                        triggered=False,
+                        id="pop_filter", property="value", value=pop_filter, str_id="pop_filter", triggered=False
                     )
                 ]
                 if pop_filter
                 else [],
                 "filter_interaction": args_grouping_filter_interaction,
-            },
+            }
         },
         "outputs_list": [
-            {
-                "id": {"action_id": "test_action", "target_id": target, "type": "download_dataframe"},
-                "property": "data",
-            }
+            {"id": {"action_id": "test_action", "target_id": target, "type": "download_dataframe"}, "property": "data"}
             for target in targets
         ],
     }
@@ -211,7 +184,7 @@ class TestExportData:
                 "content": gapminder_2007.to_csv(index=False),
                 "type": None,
                 "base64": False,
-            },
+            }
         }
 
         assert result == expected
@@ -245,10 +218,7 @@ class TestExportData:
 
     @pytest.mark.usefixtures("managers_one_page_two_graphs_one_button")
     @pytest.mark.parametrize("ctx_export_data", [(["invalid_target_id"], None, None, None)], indirect=True)
-    def test_invalid_target(
-        self,
-        ctx_export_data,
-    ):
+    def test_invalid_target(self, ctx_export_data):
         # Add action to relevant component
         model_manager["button"].actions = [
             vm.Action(id="test_action", function=export_data(targets=["invalid_target_id"]))
@@ -277,10 +247,7 @@ class TestExportData:
         indirect=True,
     )
     def test_multiple_targets_with_filter_and_filter_interaction(
-        self,
-        ctx_export_data,
-        target_scatter_filter_and_filter_interaction,
-        target_box_filtered_pop,
+        self, ctx_export_data, target_scatter_filter_and_filter_interaction, target_box_filtered_pop
     ):
         # Creating and adding a Filter object to the existing Page
         pop_filter = vm.Filter(column="pop", selector=vm.RangeSlider(id="pop_filter"))
@@ -336,10 +303,7 @@ class TestExportData:
         indirect=True,
     )
     def test_multiple_targets_with_filter_and_filter_interaction_and_table(
-        self,
-        ctx_export_data,
-        target_scatter_filter_and_filter_interaction,
-        target_box_filtered_pop,
+        self, ctx_export_data, target_scatter_filter_and_filter_interaction, target_box_filtered_pop
     ):
         # Creating and adding a Filter object to the existing Page
         pop_filter = vm.Filter(column="pop", selector=vm.RangeSlider(id="pop_filter"))

--- a/vizro-core/tests/unit/vizro/actions/test_filter_action.py
+++ b/vizro-core/tests/unit/vizro/actions/test_filter_action.py
@@ -46,7 +46,11 @@ def ctx_filter_continent(request):
                 ],
                 "parameters": [],
                 "theme_selector": CallbackTriggerDict(
-                    id="theme_selector", property="checked", value=False, str_id="theme_selector", triggered=False
+                    id="theme_selector",
+                    property="checked",
+                    value=False,
+                    str_id="theme_selector",
+                    triggered=False,
                 ),
             }
         }
@@ -72,12 +76,20 @@ def ctx_filter_continent_and_pop(request):
                         triggered=False,
                     ),
                     CallbackTriggerDict(
-                        id="pop_filter", property="value", value=pop, str_id="pop_filter", triggered=False
+                        id="pop_filter",
+                        property="value",
+                        value=pop,
+                        str_id="pop_filter",
+                        triggered=False,
                     ),
                 ],
                 "parameters": [],
                 "theme_selector": CallbackTriggerDict(
-                    id="theme_selector", property="checked", value=False, str_id="theme_selector", triggered=False
+                    id="theme_selector",
+                    property="checked",
+                    value=False,
+                    str_id="theme_selector",
+                    triggered=False,
                 ),
             }
         }

--- a/vizro-core/tests/unit/vizro/actions/test_filter_action.py
+++ b/vizro-core/tests/unit/vizro/actions/test_filter_action.py
@@ -5,9 +5,7 @@ from dash._utils import AttributeDict
 import vizro.models as vm
 import vizro.plotly.express as px
 from vizro._constants import FILTER_ACTION_PREFIX
-from vizro.actions._actions_utils import (
-    CallbackTriggerDict,
-)
+from vizro.actions._actions_utils import CallbackTriggerDict
 from vizro.managers import model_manager
 
 
@@ -48,11 +46,7 @@ def ctx_filter_continent(request):
                 ],
                 "parameters": [],
                 "theme_selector": CallbackTriggerDict(
-                    id="theme_selector",
-                    property="checked",
-                    value=False,
-                    str_id="theme_selector",
-                    triggered=False,
+                    id="theme_selector", property="checked", value=False, str_id="theme_selector", triggered=False
                 ),
             }
         }
@@ -78,20 +72,12 @@ def ctx_filter_continent_and_pop(request):
                         triggered=False,
                     ),
                     CallbackTriggerDict(
-                        id="pop_filter",
-                        property="value",
-                        value=pop,
-                        str_id="pop_filter",
-                        triggered=False,
+                        id="pop_filter", property="value", value=pop, str_id="pop_filter", triggered=False
                     ),
                 ],
                 "parameters": [],
                 "theme_selector": CallbackTriggerDict(
-                    id="theme_selector",
-                    property="checked",
-                    value=False,
-                    str_id="theme_selector",
-                    triggered=False,
+                    id="theme_selector", property="checked", value=False, str_id="theme_selector", triggered=False
                 ),
             }
         }
@@ -108,10 +94,7 @@ class TestFilter:
         indirect=True,
     )
     def test_one_filter_no_targets(
-        self,
-        ctx_filter_continent,
-        target_scatter_filtered_continent,
-        target_box_filtered_continent,
+        self, ctx_filter_continent, target_scatter_filtered_continent, target_box_filtered_continent
     ):
         # Creating and adding a Filter object to the existing Page
         continent_filter = vm.Filter(id="test_filter", column="continent", selector=vm.Dropdown(id="continent_filter"))
@@ -122,10 +105,7 @@ class TestFilter:
 
         # Run action by picking the above added action function and executing it with ()
         result = model_manager[f"{FILTER_ACTION_PREFIX}_test_filter"].function()
-        expected = {
-            "scatter_chart": target_scatter_filtered_continent,
-            "box_chart": target_box_filtered_continent,
-        }
+        expected = {"scatter_chart": target_scatter_filtered_continent, "box_chart": target_box_filtered_continent}
 
         assert result == expected
 
@@ -134,11 +114,7 @@ class TestFilter:
         [(["Africa"], ["Africa"]), (["Africa", "Europe"], ["Africa", "Europe"])],
         indirect=True,
     )
-    def test_one_filter_one_target(
-        self,
-        ctx_filter_continent,
-        target_scatter_filtered_continent,
-    ):
+    def test_one_filter_one_target(self, ctx_filter_continent, target_scatter_filtered_continent):
         # Creating and adding a Filter object to the existing Page
         continent_filter = vm.Filter(
             id="test_filter", column="continent", targets=["scatter_chart"], selector=vm.Dropdown(id="continent_filter")
@@ -150,9 +126,7 @@ class TestFilter:
 
         # Run action by picking the above added action function and executing it with ()
         result = model_manager[f"{FILTER_ACTION_PREFIX}_test_filter"].function()
-        expected = {
-            "scatter_chart": target_scatter_filtered_continent,
-        }
+        expected = {"scatter_chart": target_scatter_filtered_continent}
 
         assert result == expected
 
@@ -162,10 +136,7 @@ class TestFilter:
         indirect=True,
     )
     def test_one_filter_multiple_targets(
-        self,
-        ctx_filter_continent,
-        target_scatter_filtered_continent,
-        target_box_filtered_continent,
+        self, ctx_filter_continent, target_scatter_filtered_continent, target_box_filtered_continent
     ):
         # Creating and adding a Filter object to the existing Page
         continent_filter = vm.Filter(
@@ -181,10 +152,7 @@ class TestFilter:
 
         # Run action by picking the above added action function and executing it with ()
         result = model_manager[f"{FILTER_ACTION_PREFIX}_test_filter"].function()
-        expected = {
-            "scatter_chart": target_scatter_filtered_continent,
-            "box_chart": target_box_filtered_continent,
-        }
+        expected = {"scatter_chart": target_scatter_filtered_continent, "box_chart": target_box_filtered_continent}
 
         assert result == expected
 
@@ -234,11 +202,7 @@ class TestFilter:
         ],
         indirect=True,
     )
-    def test_multiple_filters_one_target(
-        self,
-        ctx_filter_continent_and_pop,
-        target_scatter_filtered_continent_and_pop,
-    ):
+    def test_multiple_filters_one_target(self, ctx_filter_continent_and_pop, target_scatter_filtered_continent_and_pop):
         # Creating and adding a Filter objects to the existing Page
         continent_filter = vm.Filter(
             id="test_filter_continent",
@@ -255,9 +219,7 @@ class TestFilter:
 
         # Run action by picking the above added action function and executing it with ()
         result = model_manager[f"{FILTER_ACTION_PREFIX}_test_filter_continent"].function()
-        expected = {
-            "scatter_chart": target_scatter_filtered_continent_and_pop,
-        }
+        expected = {"scatter_chart": target_scatter_filtered_continent_and_pop}
 
         assert result == expected
 

--- a/vizro-core/tests/unit/vizro/actions/test_filter_interaction_action.py
+++ b/vizro-core/tests/unit/vizro/actions/test_filter_interaction_action.py
@@ -5,9 +5,7 @@ from dash._utils import AttributeDict
 
 import vizro.models as vm
 from vizro.actions import filter_interaction
-from vizro.actions._actions_utils import (
-    CallbackTriggerDict,
-)
+from vizro.actions._actions_utils import CallbackTriggerDict
 from vizro.managers import model_manager
 
 
@@ -23,13 +21,7 @@ def ctx_filter_interaction(request):
                 "clickData": CallbackTriggerDict(
                     id="box_chart",
                     property="clickData",
-                    value={
-                        "points": [
-                            {
-                                "customdata": [continent_filter_interaction],
-                            }
-                        ]
-                    },
+                    value={"points": [{"customdata": [continent_filter_interaction]}]},
                     str_id="box_chart",
                     triggered=False,
                 )
@@ -49,16 +41,8 @@ def ctx_filter_interaction(request):
                     id="underlying_table_id",
                     property="derived_viewport_data",
                     value=[
-                        {
-                            "country": country_table_filter_interaction,
-                            "continent": "Africa",
-                            "year": 2007,
-                        },
-                        {
-                            "country": "Egypt",
-                            "continent": "Africa",
-                            "year": 2007,
-                        },
+                        {"country": country_table_filter_interaction, "continent": "Africa", "year": 2007},
+                        {"country": "Egypt", "continent": "Africa", "year": 2007},
                     ],
                     str_id="underlying_table_id",
                     triggered=False,
@@ -73,11 +57,7 @@ def ctx_filter_interaction(request):
                 "filter_interaction": args_grouping_filter_interaction,
                 "parameters": [],
                 "theme_selector": CallbackTriggerDict(
-                    id="theme_selector",
-                    property="checked",
-                    value=False,
-                    str_id="theme_selector",
-                    triggered=False,
+                    id="theme_selector", property="checked", value=False, str_id="theme_selector", triggered=False
                 ),
             }
         }
@@ -116,8 +96,7 @@ def target_box_filtered_continent(request, gapminder_2007, box_params):
 class TestFilterInteraction:
     @pytest.mark.parametrize("ctx_filter_interaction", [("Africa", None), ("Europe", None)], indirect=True)
     def test_filter_interaction_without_targets_temporary_behavior(  # temporary fix, see below test
-        self,
-        ctx_filter_interaction,
+        self, ctx_filter_interaction
     ):
         # Add action to relevant component - here component[0] is the source_chart
         model_manager["box_chart"].actions = [vm.Action(id="test_action", function=filter_interaction())]
@@ -139,20 +118,14 @@ class TestFilterInteraction:
         indirect=True,
     )
     def test_filter_interaction_without_targets_desired_behavior(
-        self,
-        ctx_filter_interaction,
-        target_scatter_filtered_continent,
-        target_box_filtered_continent,
+        self, ctx_filter_interaction, target_scatter_filtered_continent, target_box_filtered_continent
     ):
         # Add action to relevant component - here component[0] is the source_chart
         model_manager["box_chart"].actions = [vm.Action(id="test_action", function=filter_interaction())]
 
         # Run action by picking the above added action function and executing it with ()
         result = model_manager["test_action"].function()
-        expected = {
-            "scatter_chart": target_scatter_filtered_continent,
-            "box_chart": target_box_filtered_continent,
-        }
+        expected = {"scatter_chart": target_scatter_filtered_continent, "box_chart": target_box_filtered_continent}
 
         assert result == expected
 
@@ -165,11 +138,7 @@ class TestFilterInteraction:
         ],
         indirect=True,
     )
-    def test_filter_interaction_with_one_target(
-        self,
-        ctx_filter_interaction,
-        target_scatter_filtered_continent,
-    ):
+    def test_filter_interaction_with_one_target(self, ctx_filter_interaction, target_scatter_filtered_continent):
         # Add action to relevant component - here component[0] is the source_chart
         model_manager["box_chart"].actions = [
             vm.Action(id="test_action", function=filter_interaction(targets=["scatter_chart"]))
@@ -177,9 +146,7 @@ class TestFilterInteraction:
 
         # Run action by picking the above added action function and executing it with ()
         result = model_manager["test_action"].function()
-        expected = {
-            "scatter_chart": target_scatter_filtered_continent,
-        }
+        expected = {"scatter_chart": target_scatter_filtered_continent}
 
         assert result == expected
 
@@ -193,10 +160,7 @@ class TestFilterInteraction:
         indirect=True,
     )
     def test_filter_interaction_with_two_target(
-        self,
-        ctx_filter_interaction,
-        target_scatter_filtered_continent,
-        target_box_filtered_continent,
+        self, ctx_filter_interaction, target_scatter_filtered_continent, target_box_filtered_continent
     ):
         # Add action to relevant component - here component[0] is the source_chart
         model_manager["box_chart"].actions = [
@@ -205,21 +169,14 @@ class TestFilterInteraction:
 
         # Run action by picking the above added action function and executing it with ()
         result = model_manager["test_action"].function()
-        expected = {
-            "scatter_chart": target_scatter_filtered_continent,
-            "box_chart": target_box_filtered_continent,
-        }
+        expected = {"scatter_chart": target_scatter_filtered_continent, "box_chart": target_box_filtered_continent}
 
         assert result == expected
 
     @pytest.mark.xfail  # This (or similar code) should raise a Value/Validation error explaining next steps
     @pytest.mark.parametrize("target", ["scatter_chart", ["scatter_chart"]])
     @pytest.mark.parametrize("ctx_filter_interaction", [("Africa", None), ("Europe", None)], indirect=True)
-    def test_filter_interaction_with_invalid_targets(
-        self,
-        target,
-        ctx_filter_interaction,
-    ):
+    def test_filter_interaction_with_invalid_targets(self, target, ctx_filter_interaction):
         with pytest.raises(ValueError, match="Target invalid_target not found in model_manager."):
             # Add action to relevant component - here component[0] is the source_chart
             model_manager["box_chart"].actions = [
@@ -235,11 +192,7 @@ class TestFilterInteraction:
         ],
         indirect=True,
     )
-    def test_table_filter_interaction_with_one_target(
-        self,
-        ctx_filter_interaction,
-        target_scatter_filtered_continent,
-    ):
+    def test_table_filter_interaction_with_one_target(self, ctx_filter_interaction, target_scatter_filtered_continent):
         model_manager["box_chart"].actions = [
             vm.Action(id="test_action", function=filter_interaction(targets=["scatter_chart"]))
         ]
@@ -249,9 +202,7 @@ class TestFilterInteraction:
 
         # Run action by picking the above added action function and executing it with ()
         result = model_manager["test_action"].function()
-        expected = {
-            "scatter_chart": target_scatter_filtered_continent,
-        }
+        expected = {"scatter_chart": target_scatter_filtered_continent}
 
         assert result == expected
 
@@ -265,10 +216,7 @@ class TestFilterInteraction:
         indirect=True,
     )
     def test_table_filter_interaction_with_two_targets(
-        self,
-        ctx_filter_interaction,
-        target_scatter_filtered_continent,
-        target_box_filtered_continent,
+        self, ctx_filter_interaction, target_scatter_filtered_continent, target_box_filtered_continent
     ):
         model_manager["box_chart"].actions = [
             vm.Action(id="test_action", function=filter_interaction(targets=["scatter_chart", "box_chart"]))
@@ -281,10 +229,7 @@ class TestFilterInteraction:
 
         # Run action by picking the above added action function and executing it with ()
         result = model_manager["test_action"].function()
-        expected = {
-            "scatter_chart": target_scatter_filtered_continent,
-            "box_chart": target_box_filtered_continent,
-        }
+        expected = {"scatter_chart": target_scatter_filtered_continent, "box_chart": target_box_filtered_continent}
 
         assert result == expected
 
@@ -298,10 +243,7 @@ class TestFilterInteraction:
         indirect=True,
     )
     def test_mixed_chart_and_table_filter_interaction_with_two_targets(
-        self,
-        ctx_filter_interaction,
-        target_scatter_filtered_continent,
-        target_box_filtered_continent,
+        self, ctx_filter_interaction, target_scatter_filtered_continent, target_box_filtered_continent
     ):
         model_manager["box_chart"].actions = [
             vm.Action(id="test_action", function=filter_interaction(targets=["scatter_chart", "box_chart"]))
@@ -314,10 +256,7 @@ class TestFilterInteraction:
 
         # Run action by picking the above added action function and executing it with ()
         result = model_manager["test_action"].function()
-        expected = {
-            "scatter_chart": target_scatter_filtered_continent,
-            "box_chart": target_box_filtered_continent,
-        }
+        expected = {"scatter_chart": target_scatter_filtered_continent, "box_chart": target_box_filtered_continent}
 
         assert result == expected
 

--- a/vizro-core/tests/unit/vizro/actions/test_on_page_load_action.py
+++ b/vizro-core/tests/unit/vizro/actions/test_on_page_load_action.py
@@ -53,15 +53,27 @@ def ctx_on_page_load(request):
                         triggered=False,
                     ),
                     CallbackTriggerDict(
-                        id="pop_filter", property="value", value=pop, str_id="pop_filter", triggered=False
+                        id="pop_filter",
+                        property="value",
+                        value=pop,
+                        str_id="pop_filter",
+                        triggered=False,
                     ),
                 ],
                 "parameters": [
                     CallbackTriggerDict(
-                        id="y_parameter", property="value", value=y, str_id="y_parameter", triggered=False
+                        id="y_parameter",
+                        property="value",
+                        value=y,
+                        str_id="y_parameter",
+                        triggered=False,
                     ),
                     CallbackTriggerDict(
-                        id="x_parameter", property="value", value=x, str_id="x_parameter", triggered=False
+                        id="x_parameter",
+                        property="value",
+                        value=x,
+                        str_id="x_parameter",
+                        triggered=False,
                     ),
                 ],
                 "theme_selector": CallbackTriggerDict(

--- a/vizro-core/tests/unit/vizro/actions/test_on_page_load_action.py
+++ b/vizro-core/tests/unit/vizro/actions/test_on_page_load_action.py
@@ -6,9 +6,7 @@ import vizro.models as vm
 import vizro.plotly.express as px
 from vizro._constants import ON_PAGE_LOAD_ACTION_PREFIX
 from vizro._themes import dark, light
-from vizro.actions._actions_utils import (
-    CallbackTriggerDict,
-)
+from vizro.actions._actions_utils import CallbackTriggerDict
 from vizro.managers import model_manager
 
 
@@ -55,27 +53,15 @@ def ctx_on_page_load(request):
                         triggered=False,
                     ),
                     CallbackTriggerDict(
-                        id="pop_filter",
-                        property="value",
-                        value=pop,
-                        str_id="pop_filter",
-                        triggered=False,
+                        id="pop_filter", property="value", value=pop, str_id="pop_filter", triggered=False
                     ),
                 ],
                 "parameters": [
                     CallbackTriggerDict(
-                        id="y_parameter",
-                        property="value",
-                        value=y,
-                        str_id="y_parameter",
-                        triggered=False,
+                        id="y_parameter", property="value", value=y, str_id="y_parameter", triggered=False
                     ),
                     CallbackTriggerDict(
-                        id="x_parameter",
-                        property="value",
-                        value=x,
-                        str_id="x_parameter",
-                        triggered=False,
+                        id="x_parameter", property="value", value=x, str_id="x_parameter", triggered=False
                     ),
                 ],
                 "theme_selector": CallbackTriggerDict(
@@ -111,11 +97,7 @@ class TestOnPageLoad:
         indirect=["ctx_on_page_load", "target_scatter_filtered_continent_and_pop_parameter_y_and_x"],
     )
     def test_multiple_controls_one_target(
-        self,
-        ctx_on_page_load,
-        target_scatter_filtered_continent_and_pop_parameter_y_and_x,
-        template,
-        box_chart,
+        self, ctx_on_page_load, target_scatter_filtered_continent_and_pop_parameter_y_and_x, template, box_chart
     ):
         # Creating and adding a Filter objects to the existing Page
         continent_filter = vm.Filter(

--- a/vizro-core/tests/unit/vizro/actions/test_parameter_action.py
+++ b/vizro-core/tests/unit/vizro/actions/test_parameter_action.py
@@ -57,11 +57,19 @@ def ctx_parameter_y(request):
                 "filters": [],
                 "parameters": [
                     CallbackTriggerDict(
-                        id="y_parameter", property="value", value=y, str_id="y_parameter", triggered=False
+                        id="y_parameter",
+                        property="value",
+                        value=y,
+                        str_id="y_parameter",
+                        triggered=False,
                     )
                 ],
                 "theme_selector": CallbackTriggerDict(
-                    id="theme_selector", property="checked", value=False, str_id="theme_selector", triggered=False
+                    id="theme_selector",
+                    property="checked",
+                    value=False,
+                    str_id="theme_selector",
+                    triggered=False,
                 ),
             }
         }
@@ -89,7 +97,11 @@ def ctx_parameter_hover_data(request):
                     )
                 ],
                 "theme_selector": CallbackTriggerDict(
-                    id="theme_selector", property="checked", value=False, str_id="theme_selector", triggered=False
+                    id="theme_selector",
+                    property="checked",
+                    value=False,
+                    str_id="theme_selector",
+                    triggered=False,
                 ),
             }
         }
@@ -109,14 +121,26 @@ def ctx_parameter_y_and_x(request):
                 "filters": [],
                 "parameters": [
                     CallbackTriggerDict(
-                        id="y_parameter", property="value", value=y, str_id="y_parameter", triggered=False
+                        id="y_parameter",
+                        property="value",
+                        value=y,
+                        str_id="y_parameter",
+                        triggered=False,
                     ),
                     CallbackTriggerDict(
-                        id="x_parameter", property="value", value=x, str_id="x_parameter", triggered=False
+                        id="x_parameter",
+                        property="value",
+                        value=x,
+                        str_id="x_parameter",
+                        triggered=False,
                     ),
                 ],
                 "theme_selector": CallbackTriggerDict(
-                    id="theme_selector", property="checked", value=False, str_id="theme_selector", triggered=False
+                    id="theme_selector",
+                    property="checked",
+                    value=False,
+                    str_id="theme_selector",
+                    triggered=False,
                 ),
             }
         }

--- a/vizro-core/tests/unit/vizro/actions/test_parameter_action.py
+++ b/vizro-core/tests/unit/vizro/actions/test_parameter_action.py
@@ -5,9 +5,7 @@ from dash._utils import AttributeDict
 import vizro.models as vm
 import vizro.plotly.express as px
 from vizro._constants import PARAMETER_ACTION_PREFIX
-from vizro.actions._actions_utils import (
-    CallbackTriggerDict,
-)
+from vizro.actions._actions_utils import CallbackTriggerDict
 from vizro.managers import model_manager
 
 
@@ -59,19 +57,11 @@ def ctx_parameter_y(request):
                 "filters": [],
                 "parameters": [
                     CallbackTriggerDict(
-                        id="y_parameter",
-                        property="value",
-                        value=y,
-                        str_id="y_parameter",
-                        triggered=False,
+                        id="y_parameter", property="value", value=y, str_id="y_parameter", triggered=False
                     )
                 ],
                 "theme_selector": CallbackTriggerDict(
-                    id="theme_selector",
-                    property="checked",
-                    value=False,
-                    str_id="theme_selector",
-                    triggered=False,
+                    id="theme_selector", property="checked", value=False, str_id="theme_selector", triggered=False
                 ),
             }
         }
@@ -99,11 +89,7 @@ def ctx_parameter_hover_data(request):
                     )
                 ],
                 "theme_selector": CallbackTriggerDict(
-                    id="theme_selector",
-                    property="checked",
-                    value=False,
-                    str_id="theme_selector",
-                    triggered=False,
+                    id="theme_selector", property="checked", value=False, str_id="theme_selector", triggered=False
                 ),
             }
         }
@@ -123,26 +109,14 @@ def ctx_parameter_y_and_x(request):
                 "filters": [],
                 "parameters": [
                     CallbackTriggerDict(
-                        id="y_parameter",
-                        property="value",
-                        value=y,
-                        str_id="y_parameter",
-                        triggered=False,
+                        id="y_parameter", property="value", value=y, str_id="y_parameter", triggered=False
                     ),
                     CallbackTriggerDict(
-                        id="x_parameter",
-                        property="value",
-                        value=x,
-                        str_id="x_parameter",
-                        triggered=False,
+                        id="x_parameter", property="value", value=x, str_id="x_parameter", triggered=False
                     ),
                 ],
                 "theme_selector": CallbackTriggerDict(
-                    id="theme_selector",
-                    property="checked",
-                    value=False,
-                    str_id="theme_selector",
-                    triggered=False,
+                    id="theme_selector", property="checked", value=False, str_id="theme_selector", triggered=False
                 ),
             }
         }
@@ -158,11 +132,7 @@ class TestParameter:
         [("pop", "pop"), ("gdpPercap", "gdpPercap"), ("NONE", None)],
         indirect=True,
     )
-    def test_one_parameter_one_target(
-        self,
-        ctx_parameter_y,
-        target_scatter_parameter_y,
-    ):
+    def test_one_parameter_one_target(self, ctx_parameter_y, target_scatter_parameter_y):
         # Creating and adding a Parameter object to the existing Page
         y_parameter = vm.Parameter(
             id="test_parameter",
@@ -176,9 +146,7 @@ class TestParameter:
 
         # Run action by picking the above added action function and executing it with ()
         result = model_manager[f"{PARAMETER_ACTION_PREFIX}_test_parameter"].function()
-        expected = {
-            "scatter_chart": target_scatter_parameter_y,
-        }
+        expected = {"scatter_chart": target_scatter_parameter_y}
 
         assert result == expected
 
@@ -194,11 +162,7 @@ class TestParameter:
         ],
         indirect=True,
     )
-    def test_one_parameter_one_target_NONE_list(
-        self,
-        ctx_parameter_hover_data,
-        target_scatter_parameter_hover_data,
-    ):
+    def test_one_parameter_one_target_NONE_list(self, ctx_parameter_hover_data, target_scatter_parameter_hover_data):
         # Creating and adding a Parameter object to the existing Page
         y_parameter = vm.Parameter(
             id="test_parameter",
@@ -214,9 +178,7 @@ class TestParameter:
 
         # Run action by picking the above added action function and executing it with ()
         result = model_manager[f"{PARAMETER_ACTION_PREFIX}_test_parameter"].function()
-        expected = {
-            "scatter_chart": target_scatter_parameter_hover_data,
-        }
+        expected = {"scatter_chart": target_scatter_parameter_hover_data}
 
         assert result == expected
 
@@ -225,12 +187,7 @@ class TestParameter:
         [("pop", "pop", "pop"), ("gdpPercap", "gdpPercap", "gdpPercap")],
         indirect=True,
     )
-    def test_one_parameter_multiple_targets(
-        self,
-        ctx_parameter_y,
-        target_scatter_parameter_y,
-        target_box_parameter_y,
-    ):
+    def test_one_parameter_multiple_targets(self, ctx_parameter_y, target_scatter_parameter_y, target_box_parameter_y):
         # Creating and adding a Parameter object to the existing Page
         y_parameter = vm.Parameter(
             id="test_parameter",
@@ -244,10 +201,7 @@ class TestParameter:
 
         # Run action by picking the above added action function and executing it with ()
         result = model_manager[f"{PARAMETER_ACTION_PREFIX}_test_parameter"].function()
-        expected = {
-            "scatter_chart": target_scatter_parameter_y,
-            "box_chart": target_box_parameter_y,
-        }
+        expected = {"scatter_chart": target_scatter_parameter_y, "box_chart": target_box_parameter_y}
 
         assert result == expected
 
@@ -256,11 +210,7 @@ class TestParameter:
         [(["pop", "continent"], ["pop", "continent"]), (["gdpPercap", "country"], ["gdpPercap", "country"])],
         indirect=True,
     )
-    def test_multiple_parameters_one_target(
-        self,
-        ctx_parameter_y_and_x,
-        target_scatter_parameter_y_and_x,
-    ):
+    def test_multiple_parameters_one_target(self, ctx_parameter_y_and_x, target_scatter_parameter_y_and_x):
         # Creating and adding a Parameter object to the existing Page
         y_parameter = vm.Parameter(
             id="test_parameter_x",
@@ -280,9 +230,7 @@ class TestParameter:
 
         # Run action by picking the above added action function and executing it with ()
         result = model_manager[f"{PARAMETER_ACTION_PREFIX}_test_parameter_x"].function()
-        expected = {
-            "scatter_chart": target_scatter_parameter_y_and_x,
-        }
+        expected = {"scatter_chart": target_scatter_parameter_y_and_x}
 
         assert result == expected
 
@@ -295,10 +243,7 @@ class TestParameter:
         indirect=True,
     )
     def test_multiple_parameters_multiple_targets(
-        self,
-        ctx_parameter_y_and_x,
-        target_scatter_parameter_y_and_x,
-        target_box_parameter_y_and_x,
+        self, ctx_parameter_y_and_x, target_scatter_parameter_y_and_x, target_box_parameter_y_and_x
     ):
         # Creating and adding a Parameter object to the existing Page
         y_parameter = vm.Parameter(
@@ -319,10 +264,7 @@ class TestParameter:
 
         # Run action by picking the above added action function and executing it with ()
         result = model_manager[f"{PARAMETER_ACTION_PREFIX}_test_parameter_x"].function()
-        expected = {
-            "scatter_chart": target_scatter_parameter_y_and_x,
-            "box_chart": target_box_parameter_y_and_x,
-        }
+        expected = {"scatter_chart": target_scatter_parameter_y_and_x, "box_chart": target_box_parameter_y_and_x}
 
         assert result == expected
 
@@ -335,10 +277,7 @@ class TestParameter:
         indirect=True,
     )
     def test_one_parameter_per_target_multiple_attributes(
-        self,
-        ctx_parameter_y_and_x,
-        target_scatter_parameter_y_and_x,
-        target_box_parameter_y_and_x,
+        self, ctx_parameter_y_and_x, target_scatter_parameter_y_and_x, target_box_parameter_y_and_x
     ):
         # Creating and adding a Parameter object to the existing Page
         scatter_parameter = vm.Parameter(
@@ -359,15 +298,11 @@ class TestParameter:
 
         # Run action by picking the above added action function and executing it with ()
         result = model_manager[f"{PARAMETER_ACTION_PREFIX}_test_parameter_scatter"].function()
-        expected = {
-            "scatter_chart": target_scatter_parameter_y_and_x,
-        }
+        expected = {"scatter_chart": target_scatter_parameter_y_and_x}
 
         assert result == expected
 
         result = model_manager[f"{PARAMETER_ACTION_PREFIX}_test_parameter_box"].function()
-        expected = {
-            "box_chart": target_box_parameter_y_and_x,
-        }
+        expected = {"box_chart": target_box_parameter_y_and_x}
 
         assert result == expected

--- a/vizro-core/tests/unit/vizro/models/_action/test_action.py
+++ b/vizro-core/tests/unit/vizro/models/_action/test_action.py
@@ -33,11 +33,7 @@ def custom_action_function_mock_return(request):
 
 @pytest.fixture
 def custom_action_build_expected():
-    return html.Div(
-        children=[],
-        id="action_test_action_model_components_div",
-        hidden=True,
-    )
+    return html.Div(children=[], id="action_test_action_model_components_div", hidden=True)
 
 
 @pytest.fixture
@@ -87,28 +83,12 @@ class TestActionInstantiation:
         assert action.inputs == inputs
         assert action.outputs == outputs
 
-    @pytest.mark.parametrize(
-        "inputs",
-        [
-            [""],
-            ["component"],
-            ["component_property"],
-            ["component.property.property"],
-        ],
-    )
+    @pytest.mark.parametrize("inputs", [[""], ["component"], ["component_property"], ["component.property.property"]])
     def test_inputs_invalid(self, inputs, identity_action_function):
         with pytest.raises(ValidationError, match="string does not match regex"):
             Action(function=identity_action_function(), inputs=inputs, outputs=[])
 
-    @pytest.mark.parametrize(
-        "outputs",
-        [
-            [""],
-            ["component"],
-            ["component_property"],
-            ["component.property.property"],
-        ],
-    )
+    @pytest.mark.parametrize("outputs", [[""], ["component"], ["component_property"], ["component.property.property"]])
     def test_outputs_invalid(self, outputs, identity_action_function):
         with pytest.raises(ValidationError, match="string does not match regex"):
             Action(function=identity_action_function(), inputs=[], outputs=outputs)
@@ -182,11 +162,7 @@ class TestActionPrivateMethods:
     @pytest.mark.parametrize(
         "inputs_and_outputs, expected_get_callback_mapping_inputs, expected_get_callback_mapping_outputs",
         [
-            (
-                ["component.property"],
-                [State("component", "property")],
-                Output("component", "property"),
-            ),
+            (["component.property"], [State("component", "property")], Output("component", "property")),
             (
                 ["component_1.property", "component_2.property"],
                 [State("component_1", "property"), State("component_2", "property")],
@@ -232,10 +208,7 @@ class TestActionPrivateMethods:
                 [Output("component", "property"), Output("component_2", "property")],
             ),
             # multiple dict outputs
-            (
-                {"component_1": "value_1"},
-                {"component_1": Output("component", "property")},
-            ),
+            ({"component_1": "value_1"}, {"component_1": Output("component", "property")}),
             (
                 {"component_1": "value_1", "component_2": "value_2"},
                 {"component_1": Output("component_1", "property"), "component_2": Output("component_2", "property")},
@@ -253,25 +226,18 @@ class TestActionPrivateMethods:
         )
 
     @pytest.mark.parametrize("callback_outputs", [[], {}, None])
-    @pytest.mark.parametrize(
-        "custom_action_function_mock_return",
-        [False, 0, "", [], (), {}],
-        indirect=True,
-    )
+    @pytest.mark.parametrize("custom_action_function_mock_return", [False, 0, "", [], (), {}], indirect=True)
     def test_action_callback_function_no_outputs_return_value_not_None(
         self, custom_action_function_mock_return, callback_outputs
     ):
         action = Action(function=custom_action_function_mock_return())
         with pytest.raises(
-            ValueError,
-            match="Action function has returned a value but the action has no defined outputs.",
+            ValueError, match="Action function has returned a value but the action has no defined outputs."
         ):
             action._action_callback_function(inputs={}, outputs=callback_outputs)
 
     @pytest.mark.parametrize(
-        "custom_action_function_mock_return",
-        [None, False, 0, 123],
-        indirect=["custom_action_function_mock_return"],
+        "custom_action_function_mock_return", [None, False, 0, 123], indirect=["custom_action_function_mock_return"]
     )
     def test_action_callback_function_outputs_list_return_value_not_collection(
         self, custom_action_function_mock_return
@@ -330,7 +296,6 @@ class TestActionPrivateMethods:
     ):
         action = Action(function=custom_action_function_mock_return())
         with pytest.raises(
-            ValueError,
-            match="Keys of action's returned value .+ do not match the action's defined outputs {'output'}.",
+            ValueError, match="Keys of action's returned value .+ do not match the action's defined outputs {'output'}."
         ):
             action._action_callback_function(inputs={}, outputs={"output": Output("component", "property")})

--- a/vizro-core/tests/unit/vizro/models/_action/test_action.py
+++ b/vizro-core/tests/unit/vizro/models/_action/test_action.py
@@ -83,12 +83,28 @@ class TestActionInstantiation:
         assert action.inputs == inputs
         assert action.outputs == outputs
 
-    @pytest.mark.parametrize("inputs", [[""], ["component"], ["component_property"], ["component.property.property"]])
+    @pytest.mark.parametrize(
+        "inputs",
+        [
+            [""],
+            ["component"],
+            ["component_property"],
+            ["component.property.property"],
+        ],
+    )
     def test_inputs_invalid(self, inputs, identity_action_function):
         with pytest.raises(ValidationError, match="string does not match regex"):
             Action(function=identity_action_function(), inputs=inputs, outputs=[])
 
-    @pytest.mark.parametrize("outputs", [[""], ["component"], ["component_property"], ["component.property.property"]])
+    @pytest.mark.parametrize(
+        "outputs",
+        [
+            [""],
+            ["component"],
+            ["component_property"],
+            ["component.property.property"],
+        ],
+    )
     def test_outputs_invalid(self, outputs, identity_action_function):
         with pytest.raises(ValidationError, match="string does not match regex"):
             Action(function=identity_action_function(), inputs=[], outputs=outputs)

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_checklist.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_checklist.py
@@ -95,8 +95,7 @@ class TestChecklistInstantiation:
 
     def test_create_checklist_invalid_options_dict(self):
         with pytest.raises(
-            ValidationError,
-            match="Invalid argument `options` passed. Expected a dict with keys `label` and `value`.",
+            ValidationError, match="Invalid argument `options` passed. Expected a dict with keys `label` and `value`."
         ):
             Checklist(options=[{"hello": "A", "world": "A"}, {"hello": "B", "world": "B"}])
 

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_dropdown.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_dropdown.py
@@ -119,8 +119,7 @@ class TestDropdownInstantiation:
 
     def test_create_dropdown_invalid_options_dict(self):
         with pytest.raises(
-            ValidationError,
-            match="Invalid argument `options` passed. Expected a dict with keys `label` and `value`.",
+            ValidationError, match="Invalid argument `options` passed. Expected a dict with keys `label` and `value`."
         ):
             Dropdown(options=[{"hello": "A", "world": "A"}, {"hello": "B", "world": "B"}])
 

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_dropdown.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_dropdown.py
@@ -147,11 +147,7 @@ class TestDropdownBuild:
     """Tests model build method."""
 
     def test_dropdown_with_all_option(self):
-        dropdown = Dropdown(
-            options=["A", "B", "C"],
-            title="Title",
-            id="dropdown_id",
-        ).build()
+        dropdown = Dropdown(options=["A", "B", "C"], title="Title", id="dropdown_id").build()
         expected_dropdown = html.Div(
             [
                 html.P("Title"),

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_radioitems.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_radioitems.py
@@ -95,8 +95,7 @@ class TestRadioItemsInstantiation:
 
     def test_create_radio_items_invalid_options_dict(self):
         with pytest.raises(
-            ValidationError,
-            match="Invalid argument `options` passed. Expected a dict with keys `label` and `value`.",
+            ValidationError, match="Invalid argument `options` passed. Expected a dict with keys `label` and `value`."
         ):
             RadioItems(options=[{"hello": "A", "world": "A"}, {"hello": "B", "world": "B"}])
 

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_range_slider.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_range_slider.py
@@ -17,14 +17,7 @@ import vizro.models as vm
 def expected_range_slider_default():
     return html.Div(
         [
-            dcc.Store(
-                "range_slider_callback_data",
-                data={
-                    "id": "range_slider",
-                    "min": None,
-                    "max": None,
-                },
-            ),
+            dcc.Store("range_slider_callback_data", data={"id": "range_slider", "min": None, "max": None}),
             None,
             html.Div(
                 [
@@ -83,14 +76,7 @@ def expected_range_slider_default():
 def expected_range_slider_with_optional():
     return html.Div(
         [
-            dcc.Store(
-                "range_slider_with_all_callback_data",
-                data={
-                    "id": "range_slider_with_all",
-                    "min": 0,
-                    "max": 10,
-                },
-            ),
+            dcc.Store("range_slider_with_all_callback_data", data={"id": "range_slider_with_all", "min": 0, "max": 10}),
             html.P("Title"),
             html.Div(
                 [
@@ -230,10 +216,7 @@ class TestRangeSliderInstantiation:
         with pytest.raises(ValidationError, match=match):
             vm.RangeSlider(min=0, max=10, value=value)
 
-    @pytest.mark.parametrize(
-        "step, expected",
-        [(1, 1), (2.5, 2.5), (10, 10), (None, None), ("1", 1.0)],
-    )
+    @pytest.mark.parametrize("step, expected", [(1, 1), (2.5, 2.5), (10, 10), (None, None), ("1", 1.0)])
     def test_validate_step_valid(self, step, expected):
         range_slider = vm.RangeSlider(min=0, max=10, step=step)
 
@@ -261,10 +244,7 @@ class TestRangeSliderInstantiation:
         assert range_slider.marks == expected
 
     def test_invalid_marks(self):
-        with pytest.raises(
-            ValidationError,
-            match="2 validation errors for RangeSlider",
-        ):
+        with pytest.raises(ValidationError, match="2 validation errors for RangeSlider"):
             vm.RangeSlider(min=1, max=10, marks={"start": 0, "end": 10})
 
     @pytest.mark.parametrize("step, expected", [(1, {}), (None, None)])
@@ -285,16 +265,7 @@ class TestRangeSliderInstantiation:
         slider = vm.RangeSlider(min=0, max=10, step=step, marks=marks)
         assert slider.marks == expected
 
-    @pytest.mark.parametrize(
-        "title",
-        [
-            "test",
-            1,
-            1.0,
-            """## Test header""",
-            "",
-        ],
-    )
+    @pytest.mark.parametrize("title", ["test", 1, 1.0, """## Test header""", ""])
     def test_valid_title(self, title):
         slider = vm.RangeSlider(title=title)
 

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_slider.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_slider.py
@@ -17,14 +17,7 @@ import vizro.models as vm
 def expected_slider():
     return html.Div(
         [
-            dcc.Store(
-                "slider_id_callback_data",
-                data={
-                    "id": "slider_id",
-                    "min": 0,
-                    "max": 10,
-                },
-            ),
+            dcc.Store("slider_id_callback_data", data={"id": "slider_id", "min": 0, "max": 10}),
             html.P("Test title"),
             html.Div(
                 [
@@ -78,14 +71,7 @@ class TestSliderInstantiation:
         assert slider.title == ""
         assert slider.actions == []
 
-    @pytest.mark.parametrize(
-        "min, max",
-        [
-            (0, None),
-            (None, 10),
-            (0, 10),
-        ],
-    )
+    @pytest.mark.parametrize("min, max", [(0, None), (None, 10), (0, 10)])
     def test_valid_min_max(self, min, max):
         slider = vm.Slider(min=min, max=max)
 
@@ -94,45 +80,22 @@ class TestSliderInstantiation:
 
     def test_validate_max_invalid(self):
         with pytest.raises(
-            ValidationError,
-            match="Maximum value of slider is required to be larger than minimum value.",
+            ValidationError, match="Maximum value of slider is required to be larger than minimum value."
         ):
             vm.Slider(min=10, max=0)
 
-    @pytest.mark.parametrize(
-        "value",
-        [
-            5,
-            -5,
-            0,
-            6.5,
-            -10,
-            10,
-        ],
-    )
+    @pytest.mark.parametrize("value", [5, -5, 0, 6.5, -10, 10])
     def test_validate_slider_value_valid(self, value):
         slider = vm.Slider(min=-10, max=10, value=value)
 
         assert slider.value == value
 
-    @pytest.mark.parametrize(
-        "value",
-        [
-            11,
-            -1,
-        ],
-    )
+    @pytest.mark.parametrize("value", [11, -1])
     def test_validate_slider_value_invalid(self, value):
-        with pytest.raises(
-            ValidationError,
-            match="Please provide a valid value between the min and max value.",
-        ):
+        with pytest.raises(ValidationError, match="Please provide a valid value between the min and max value."):
             vm.Slider(min=0, max=10, value=value)
 
-    @pytest.mark.parametrize(
-        "step, expected",
-        [(1, 1), (2.5, 2.5), (10, 10), (None, None), ("1", 1.0)],
-    )
+    @pytest.mark.parametrize("step, expected", [(1, 1), (2.5, 2.5), (10, 10), (None, None), ("1", 1.0)])
     def test_validate_step_valid(self, step, expected):
         slider = vm.Slider(min=0, max=10, step=step)
 
@@ -165,10 +128,7 @@ class TestSliderInstantiation:
         assert slider.marks == expected
 
     def test_invalid_marks(self):
-        with pytest.raises(
-            ValidationError,
-            match="2 validation errors for Slider",
-        ):
+        with pytest.raises(ValidationError, match="2 validation errors for Slider"):
             vm.Slider(min=1, max=10, marks={"start": 0, "end": 10})
 
     @pytest.mark.parametrize("step, expected", [(1, {}), (None, None)])
@@ -189,16 +149,7 @@ class TestSliderInstantiation:
         slider = vm.Slider(min=0, max=10, step=step, marks=marks)
         assert slider.marks == expected
 
-    @pytest.mark.parametrize(
-        "title",
-        [
-            "test",
-            1,
-            1.0,
-            """## Test header""",
-            "",
-        ],
-    )
+    @pytest.mark.parametrize("title", ["test", 1, 1.0, """## Test header""", ""])
     def test_valid_title(self, title):
         slider = vm.Slider(title=title)
 

--- a/vizro-core/tests/unit/vizro/models/_components/test_button.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_button.py
@@ -19,10 +19,7 @@ class TestButtonInstantiation:
         assert button.text == "Click me!"
         assert button.actions == []
 
-    @pytest.mark.parametrize(
-        "text",
-        ["Test", 123, 1.23, True, """# Header""", """<p>Hello </p>"""],
-    )
+    @pytest.mark.parametrize("text", ["Test", 123, 1.23, True, """# Header""", """<p>Hello </p>"""])
     def test_create_button_with_optional(self, text):
         button = vm.Button(text=text)
         assert hasattr(button, "id")

--- a/vizro-core/tests/unit/vizro/models/_components/test_card.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_card.py
@@ -17,13 +17,7 @@ import vizro.models as vm
 @pytest.fixture
 def expected_card():
     text = dcc.Markdown("Hello", className="card_text", dangerously_allow_html=False, id="card_id")
-    button = html.Div(
-        dbc.Button(
-            href="https://www.google.com",
-            className="card_button",
-        ),
-        className="button_container",
-    )
+    button = html.Div(dbc.Button(href="https://www.google.com", className="card_button"), className="button_container")
 
     return html.Div([text, button], className="nav_card_container", id="card_id_outer")
 

--- a/vizro-core/tests/unit/vizro/models/_components/test_container.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_container.py
@@ -23,10 +23,7 @@ class TestContainerInstantiation:
 
     def test_create_container_mandatory_and_optional(self):
         container = vm.Container(
-            title="Title",
-            components=[vm.Button(), vm.Button()],
-            id="my-id",
-            layout=vm.Layout(grid=[[0, 1]]),
+            title="Title", components=[vm.Button(), vm.Button()], id="my-id", layout=vm.Layout(grid=[[0, 1]])
         )
         assert isinstance(container.components[0], vm.Button) and isinstance(container.components[1], vm.Button)
         assert container.layout.grid == [[0, 1]]

--- a/vizro-core/tests/unit/vizro/models/_components/test_graph.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_graph.py
@@ -46,11 +46,7 @@ def expected_graph():
                     "yaxis": {"visible": False},
                 }
             ),
-            config={
-                "autosizable": True,
-                "frameMargins": 0,
-                "responsive": True,
-            },
+            config={"autosizable": True, "frameMargins": 0, "responsive": True},
             className="chart_container",
         ),
         color="grey",

--- a/vizro-core/tests/unit/vizro/models/_components/test_table.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_table.py
@@ -32,10 +32,7 @@ def dash_table_with_str_dataframe():
 def expected_table():
     return dcc.Loading(
         html.Div(
-            [
-                None,
-                html.Div(dash_table.DataTable(), id="text_table"),
-            ],
+            [None, html.Div(dash_table.DataTable(), id="text_table")],
             className="table-container",
             id="text_table_outer",
         ),
@@ -48,10 +45,7 @@ def expected_table():
 def expected_table_with_id():
     return dcc.Loading(
         html.Div(
-            [
-                None,
-                html.Div(dash_table.DataTable(id="underlying_table_id"), id="text_table"),
-            ],
+            [None, html.Div(dash_table.DataTable(id="underlying_table_id"), id="text_table")],
             className="table-container",
             id="text_table_outer",
         ),
@@ -76,11 +70,7 @@ class TestDunderMethodsTable:
 
     @pytest.mark.parametrize("id", ["id_1", "id_2"])
     def test_create_table_mandatory_and_optional(self, standard_dash_table, id):
-        table = vm.Table(
-            figure=standard_dash_table,
-            id=id,
-            actions=[],
-        )
+        table = vm.Table(figure=standard_dash_table, id=id, actions=[])
 
         assert table.id == id
         assert table.type == "table"
@@ -92,16 +82,12 @@ class TestDunderMethodsTable:
 
     def test_failed_table_with_no_captured_callable(self, standard_go_chart):
         with pytest.raises(ValidationError, match="must provide a valid CapturedCallable object"):
-            vm.Table(
-                figure=standard_go_chart,
-            )
+            vm.Table(figure=standard_go_chart)
 
     @pytest.mark.xfail(reason="This test is failing as we are not yet detecting different types of captured callables")
     def test_failed_table_with_wrong_captured_callable(self, standard_px_chart):
         with pytest.raises(ValidationError, match="must provide a valid table function vm.Table"):
-            vm.Table(
-                figure=standard_px_chart,
-            )
+            vm.Table(figure=standard_px_chart)
 
     def test_getitem_known_args(self, dash_table_with_arguments):
         table = vm.Table(figure=dash_table_with_arguments)
@@ -122,18 +108,12 @@ class TestDunderMethodsTable:
 class TestProcessTableDataFrame:
     def test_process_figure_data_frame_str_df(self, dash_table_with_str_dataframe, gapminder):
         data_manager["gapminder"] = gapminder
-        table_with_str_df = vm.Table(
-            id="table",
-            figure=dash_table_with_str_dataframe,
-        )
+        table_with_str_df = vm.Table(id="table", figure=dash_table_with_str_dataframe)
         assert data_manager._get_component_data("table").equals(gapminder)
         assert table_with_str_df["data_frame"] == "gapminder"
 
     def test_process_figure_data_frame_df(self, standard_dash_table, gapminder):
-        table_with_str_df = vm.Table(
-            id="table",
-            figure=standard_dash_table,
-        )
+        table_with_str_df = vm.Table(id="table", figure=standard_dash_table)
         assert data_manager._get_component_data("table").equals(gapminder)
         with pytest.raises(KeyError, match="'data_frame'"):
             table_with_str_df.figure["data_frame"]
@@ -141,29 +121,18 @@ class TestProcessTableDataFrame:
 
 class TestPreBuildTable:
     def test_pre_build_no_actions_no_underlying_table_id(self, standard_dash_table):
-        table = vm.Table(
-            id="text_table",
-            figure=standard_dash_table,
-        )
+        table = vm.Table(id="text_table", figure=standard_dash_table)
         table.pre_build()
 
         assert hasattr(table, "_callable_object_id") is False
 
     def test_pre_build_actions_no_underlying_table_id_exception(self, standard_dash_table, filter_interaction_action):
-        table = vm.Table(
-            id="text_table",
-            figure=standard_dash_table,
-            actions=[filter_interaction_action],
-        )
+        table = vm.Table(id="text_table", figure=standard_dash_table, actions=[filter_interaction_action])
         with pytest.raises(ValueError, match="Underlying `Table` callable has no attribute 'id'"):
             table.pre_build()
 
     def test_pre_build_actions_underlying_table_id(self, dash_data_table_with_id, filter_interaction_action):
-        table = vm.Table(
-            id="text_table",
-            figure=dash_data_table_with_id,
-            actions=[filter_interaction_action],
-        )
+        table = vm.Table(id="text_table", figure=dash_data_table_with_id, actions=[filter_interaction_action])
         table.pre_build()
 
         assert table._callable_object_id == "underlying_table_id"
@@ -171,10 +140,7 @@ class TestPreBuildTable:
 
 class TestBuildTable:
     def test_table_build_mandatory_only(self, standard_dash_table, expected_table):
-        table = vm.Table(
-            id="text_table",
-            figure=standard_dash_table,
-        )
+        table = vm.Table(id="text_table", figure=standard_dash_table)
 
         table.pre_build()
 
@@ -183,11 +149,7 @@ class TestBuildTable:
         assert result == expected
 
     def test_table_build_with_id(self, dash_data_table_with_id, filter_interaction_action, expected_table_with_id):
-        table = vm.Table(
-            id="text_table",
-            figure=dash_data_table_with_id,
-            actions=[filter_interaction_action],
-        )
+        table = vm.Table(id="text_table", figure=dash_data_table_with_id, actions=[filter_interaction_action])
 
         table.pre_build()
 

--- a/vizro-core/tests/unit/vizro/models/_controls/test_filter.py
+++ b/vizro-core/tests/unit/vizro/models/_controls/test_filter.py
@@ -17,11 +17,7 @@ class TestFilterFunctions:
             ([1, 2, 3, 4, 5], [1, 5], [True, True, True, True, True]),  # Test for inclusive all
             ([1, 2, 3, 4, 5], [4, 2], [False, False, False, False, False]),  # Test for inverted values
             ([], [2, 4], pd.Series([], dtype=bool)),  # Test for empty series
-            (
-                [1.1, 2.2, 3.3, 4.4, 5.5],
-                [2.1, 4.5],
-                [False, True, True, True, False],
-            ),  # Test with float data
+            ([1.1, 2.2, 3.3, 4.4, 5.5], [2.1, 4.5], [False, True, True, True, False]),  # Test with float data
         ],
     )
     def test_filter_between(self, data, value, expected):
@@ -35,11 +31,7 @@ class TestFilterFunctions:
         [
             ([1, 2, 3, 4, 5], [2, 4], [False, True, False, True, False]),  # Test for integers
             (["apple", "banana", "orange"], ["banana", "grape"], [False, True, False]),  # Test for strings
-            (
-                [1.1, 2.2, 3.3, 4.4, 5.5],
-                [2.2, 4.4],  # Test for float values
-                [False, True, False, True, False],
-            ),
+            ([1.1, 2.2, 3.3, 4.4, 5.5], [2.2, 4.4], [False, True, False, True, False]),  # Test for float values
             ([1, 2, 3, 4, 5], [], [False, False, False, False, False]),  # Test for empty value list
         ],
     )

--- a/vizro-core/tests/unit/vizro/models/_controls/test_parameter.py
+++ b/vizro-core/tests/unit/vizro/models/_controls/test_parameter.py
@@ -26,35 +26,20 @@ class TestParameterInstantiation:
             match="Invalid target scatter_chart. Targets must be supplied in the from of "
             "<target_component>.<target_argument>",
         ):
-            Parameter(
-                targets=["scatter_chart"],
-                selector=vm.Dropdown(options=["lifeExp", "pop"]),
-            )
+            Parameter(targets=["scatter_chart"], selector=vm.Dropdown(options=["lifeExp", "pop"]))
 
     def test_check_target_present_failed(self):
         with pytest.raises(ValueError, match="Target scatter_chart_invalid not found in model_manager."):
-            Parameter(
-                targets=["scatter_chart_invalid.x"],
-                selector=vm.Dropdown(options=["lifeExp", "pop"]),
-            )
+            Parameter(targets=["scatter_chart_invalid.x"], selector=vm.Dropdown(options=["lifeExp", "pop"]))
 
     def test_duplicate_parameter_target_failed(self):
         with pytest.raises(ValueError, match="Duplicate parameter targets {'scatter_chart.x'} found."):
-            Parameter(
-                targets=["scatter_chart.x", "scatter_chart.x"],
-                selector=vm.Dropdown(options=["lifeExp", "pop"]),
-            )
+            Parameter(targets=["scatter_chart.x", "scatter_chart.x"], selector=vm.Dropdown(options=["lifeExp", "pop"]))
 
     def test_duplicate_parameter_target_failed_two_params(self):
         with pytest.raises(ValueError, match="Duplicate parameter targets {'scatter_chart.x'} found."):
-            Parameter(
-                targets=["scatter_chart.x"],
-                selector=vm.Dropdown(options=["lifeExp", "pop"]),
-            )
-            Parameter(
-                targets=["scatter_chart.x"],
-                selector=vm.Dropdown(options=["lifeExp", "pop"]),
-            )
+            Parameter(targets=["scatter_chart.x"], selector=vm.Dropdown(options=["lifeExp", "pop"]))
+            Parameter(targets=["scatter_chart.x"], selector=vm.Dropdown(options=["lifeExp", "pop"]))
 
 
 @pytest.mark.usefixtures("managers_one_page_two_graphs")

--- a/vizro-core/tests/unit/vizro/models/_navigation/test_accordion.py
+++ b/vizro-core/tests/unit/vizro/models/_navigation/test_accordion.py
@@ -80,16 +80,12 @@ class TestAccordionBuild:
             dbc.Accordion(
                 children=[
                     dbc.AccordionItem(
-                        children=[
-                            dbc.Button(children=["Page 1"], active=True, href="/", key="/"),
-                        ],
+                        children=[dbc.Button(children=["Page 1"], active=True, href="/", key="/")],
                         title="GROUP 1",
                         item_id="Group 1",
                     ),
                     dbc.AccordionItem(
-                        children=[
-                            dbc.Button(children=["Page 2"], active=False, href="/page-2", key="/page-2"),
-                        ],
+                        children=[dbc.Button(children=["Page 2"], active=False, href="/page-2", key="/page-2")],
                         title="GROUP 2",
                         item_id="Group 2",
                     ),
@@ -109,7 +105,7 @@ class TestAccordionBuild:
                         ],
                         title=ACCORDION_DEFAULT_TITLE,
                         item_id="SELECT PAGE",
-                    ),
+                    )
                 ],
                 active_item="SELECT PAGE",
                 **common_args,

--- a/vizro-core/tests/unit/vizro/models/test_dashboard.py
+++ b/vizro-core/tests/unit/vizro/models/test_dashboard.py
@@ -96,10 +96,7 @@ class TestDashboardPreBuild:
             order=1,
             layout=mocker.ANY,  # partial call is tricky to mock out so we ignore it.
         )
-        mock_register_page.assert_any_call(
-            module="not_found_404",
-            layout=mock_make_page_404_layout(),
-        )
+        mock_register_page.assert_any_call(module="not_found_404", layout=mock_make_page_404_layout())
         assert mock_register_page.call_count == 3
 
     def test_page_registry_with_title(self, vizro_app, page_1, mocker):

--- a/vizro-core/tests/unit/vizro/models/test_layout.py
+++ b/vizro-core/tests/unit/vizro/models/test_layout.py
@@ -56,12 +56,28 @@ class TestLayoutInstantiation:
 class TestMalformedGrid:
     """Tests validators to detect malformed grid."""
 
-    @pytest.mark.parametrize("grid", [0, [0], [-1], [[0], 1], [0, 1, 0], [0, 1, 3]])
+    @pytest.mark.parametrize(
+        "grid",
+        [
+            0,
+            [0],
+            [-1],
+            [[0], 1],
+            [0, 1, 0],
+            [0, 1, 3],
+        ],
+    )
     def test_invalid_input_type(self, grid):
         with pytest.raises(ValidationError, match="value is not a valid list"):
             vm.Layout(grid=grid)
 
-    @pytest.mark.parametrize("grid", [[["Table Graph"], ["Table ."]], [["A"], ["B"], ["C"]]])
+    @pytest.mark.parametrize(
+        "grid",
+        [
+            [["Table Graph"], ["Table ."]],
+            [["A"], ["B"], ["C"]],
+        ],
+    )
     def test_invalid_input_value(self, grid):
         with pytest.raises(ValidationError, match="value is not a valid integer"):
             vm.Layout(grid=grid)
@@ -83,12 +99,25 @@ class TestMalformedGrid:
         with pytest.raises(ValidationError, match="Grid areas must be rectangular and not overlap!"):
             vm.Layout(grid=grid)
 
-    @pytest.mark.parametrize("grid", [[[1, 2], [3, 4]], [[0, 2], [3, 4]], [[6, 4], [2, 5]]])
+    @pytest.mark.parametrize(
+        "grid",
+        [
+            [[1, 2], [3, 4]],
+            [[0, 2], [3, 4]],
+            [[6, 4], [2, 5]],
+        ],
+    )
     def test_invalid_int_sequence(self, grid):
         with pytest.raises(ValidationError, match="Grid must contain consecutive integers starting from 0."):
             vm.Layout(grid=grid)
 
-    @pytest.mark.parametrize("grid", [[[0, 1, 2], [3, 4]], [[0, 1], [2, 3, 4]]])
+    @pytest.mark.parametrize(
+        "grid",
+        [
+            [[0, 1, 2], [3, 4]],
+            [[0, 1], [2, 3, 4]],
+        ],
+    )
     def test_invalid_list_length(self, grid):
         with pytest.raises(ValidationError, match="All rows must be of same length."):
             vm.Layout(grid=grid)
@@ -122,7 +151,14 @@ class TestWorkingGrid:
 
 
 class TestSharedLayoutHelpers:
-    @pytest.mark.parametrize("grid", [[[0, -1], [1, 2]], [[0, -1, 1, 2]], [[-1, -1, -1], [0, 1, 2]]])
+    @pytest.mark.parametrize(
+        "grid",
+        [
+            [[0, -1], [1, 2]],
+            [[0, -1, 1, 2]],
+            [[-1, -1, -1], [0, 1, 2]],
+        ],
+    )
     def test_get_unique_grid_component_ids(self, grid):
         result = _get_unique_grid_component_ids(grid)
         expected = np.array([0, 1, 2])

--- a/vizro-core/tests/unit/vizro/models/test_layout.py
+++ b/vizro-core/tests/unit/vizro/models/test_layout.py
@@ -56,28 +56,12 @@ class TestLayoutInstantiation:
 class TestMalformedGrid:
     """Tests validators to detect malformed grid."""
 
-    @pytest.mark.parametrize(
-        "grid",
-        [
-            0,
-            [0],
-            [-1],
-            [[0], 1],
-            [0, 1, 0],
-            [0, 1, 3],
-        ],
-    )
+    @pytest.mark.parametrize("grid", [0, [0], [-1], [[0], 1], [0, 1, 0], [0, 1, 3]])
     def test_invalid_input_type(self, grid):
         with pytest.raises(ValidationError, match="value is not a valid list"):
             vm.Layout(grid=grid)
 
-    @pytest.mark.parametrize(
-        "grid",
-        [
-            [["Table Graph"], ["Table ."]],
-            [["A"], ["B"], ["C"]],
-        ],
-    )
+    @pytest.mark.parametrize("grid", [[["Table Graph"], ["Table ."]], [["A"], ["B"], ["C"]]])
     def test_invalid_input_value(self, grid):
         with pytest.raises(ValidationError, match="value is not a valid integer"):
             vm.Layout(grid=grid)
@@ -99,25 +83,12 @@ class TestMalformedGrid:
         with pytest.raises(ValidationError, match="Grid areas must be rectangular and not overlap!"):
             vm.Layout(grid=grid)
 
-    @pytest.mark.parametrize(
-        "grid",
-        [
-            [[1, 2], [3, 4]],
-            [[0, 2], [3, 4]],
-            [[6, 4], [2, 5]],
-        ],
-    )
+    @pytest.mark.parametrize("grid", [[[1, 2], [3, 4]], [[0, 2], [3, 4]], [[6, 4], [2, 5]]])
     def test_invalid_int_sequence(self, grid):
         with pytest.raises(ValidationError, match="Grid must contain consecutive integers starting from 0."):
             vm.Layout(grid=grid)
 
-    @pytest.mark.parametrize(
-        "grid",
-        [
-            [[0, 1, 2], [3, 4]],
-            [[0, 1], [2, 3, 4]],
-        ],
-    )
+    @pytest.mark.parametrize("grid", [[[0, 1, 2], [3, 4]], [[0, 1], [2, 3, 4]]])
     def test_invalid_list_length(self, grid):
         with pytest.raises(ValidationError, match="All rows must be of same length."):
             vm.Layout(grid=grid)

--- a/vizro-core/tests/unit/vizro/models/test_types.py
+++ b/vizro-core/tests/unit/vizro/models/test_types.py
@@ -49,9 +49,7 @@ def captured_callable(request):
 
 
 @pytest.mark.parametrize(
-    "captured_callable",
-    [positional_or_keyword_function, keyword_only_function, var_keyword_function],
-    indirect=True,
+    "captured_callable", [positional_or_keyword_function, keyword_only_function, var_keyword_function], indirect=True
 )
 class TestCallKeywordArguments:
     def test_call_provide_required_argument(self, captured_callable):
@@ -61,19 +59,13 @@ class TestCallKeywordArguments:
         assert captured_callable(a=5, b=2, c=6) == 5 + 2 + 6
 
 
-@pytest.mark.parametrize(
-    "captured_callable",
-    [positional_or_keyword_function],
-    indirect=True,
-)
+@pytest.mark.parametrize("captured_callable", [positional_or_keyword_function], indirect=True)
 def test_call_positional_arguments(captured_callable):
     assert captured_callable(3) == 1 + 2 + 3
 
 
 @pytest.mark.parametrize(
-    "captured_callable",
-    [positional_or_keyword_function, keyword_only_function, var_keyword_function],
-    indirect=True,
+    "captured_callable", [positional_or_keyword_function, keyword_only_function, var_keyword_function], indirect=True
 )
 class TestDunderMethods:
     def test_getitem_known_args(self, captured_callable):
@@ -92,9 +84,7 @@ class TestDunderMethods:
 
 
 @pytest.mark.parametrize(
-    "captured_callable",
-    [positional_or_keyword_function, keyword_only_function, var_keyword_function],
-    indirect=True,
+    "captured_callable", [positional_or_keyword_function, keyword_only_function, var_keyword_function], indirect=True
 )
 def test_call_positional_and_keyword_supplied(captured_callable):
     with pytest.raises(ValueError, match="does not support calling with both positional and keyword arguments"):
@@ -170,11 +160,7 @@ def decorated_graph_function(data_frame):
 
 @capture("graph")
 def decorated_graph_function_px(data_frame):
-    return plotly_express.scatter(
-        data_frame=data_frame,
-        x="gdpPercap",
-        y="lifeExp",
-    )
+    return plotly_express.scatter(data_frame=data_frame, x="gdpPercap", y="lifeExp")
 
 
 @capture("graph")
@@ -213,17 +199,11 @@ class TestCapture:
         assert len(fig.data) == 0
 
     def test_decorated_graph_function_missing_data_frame(self):
-        with pytest.raises(
-            ValueError,
-            match="decorated_graph_function must supply a value to data_frame argument",
-        ):
+        with pytest.raises(ValueError, match="decorated_graph_function must supply a value to data_frame argument"):
             decorated_graph_function()
 
     def test_invalid_decorated_graph_function(self):
-        with pytest.raises(
-            ValueError,
-            match="invalid_decorated_graph_function must have data_frame argument",
-        ):
+        with pytest.raises(ValueError, match="invalid_decorated_graph_function must have data_frame argument"):
             invalid_decorated_graph_function()
 
 


### PR DESCRIPTION
## Description
See following discussion thread: https://github.com/mckinsey/vizro/pull/283#discussion_r1467341688

Idea was to tidy some of our code and remove redundant wrapping into multiple lines

If you see some spots where you would prefer multi-lines instead of a single line, you just have to add the trailing comma back. I've quickly scanned through the files and added some of the trailing commas (mostly for our example configurations).

**Note: Will be merged after https://github.com/mckinsey/vizro/pull/293**

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
