### PR TITLE
Create a documentation style guide to apply across docs

### DIFF
--- a/vizro-core/changelog.d/20240221_121749_jo_stichbury_create_style_guide.md
+++ b/vizro-core/changelog.d/20240221_121749_jo_stichbury_create_style_guide.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/docs/pages/development/documentation-style-guide.md
+++ b/vizro-core/docs/pages/development/documentation-style-guide.md
@@ -109,7 +109,7 @@ Keep your sentences short and easy to read. Your tone of voice should be simple,
 
 Simple is clear, concise and direct:
 
-> We build new skills within your team.
+> We build new skills in your team.
 
 Simple is not vague, verbose or full of jargon:
 

--- a/vizro-core/docs/pages/development/documentation-style-guide.md
+++ b/vizro-core/docs/pages/development/documentation-style-guide.md
@@ -38,7 +38,7 @@ Keep the amount of text, and the number and variety of callouts used, to a minim
 
 !!!example "example"
 
-     For example code
+     For example code.
 
 
 Boxes can be made collapsible, and if you choose this option, prefer to add them to the page so they are initially collapsed, to avoid crowding.

--- a/vizro-core/docs/pages/development/documentation-style-guide.md
+++ b/vizro-core/docs/pages/development/documentation-style-guide.md
@@ -14,11 +14,11 @@ We refer to other products using their preferred capitalization. For example, Da
 
 Vizro components are named using lower case:
 
-> "Here is a guide to using containers..."
+> Here is a guide to using containers...
 
 Use code font when referring to the component as a class or object:
 
-> "To add a `Container` to your page..."
+> To add a `Container` to your page...
 
 ## Bullets
 * Capitalize the first word, and end the bullet with a period.
@@ -41,7 +41,11 @@ Keep the amount of text, and the number and variety of callouts used, to a minim
      For example code.
 
 
-Boxes can be made collapsible, and if you choose this option, prefer to add them to the page so they are initially collapsed, to avoid crowding.
+Callout boxes can be made collapsible: if you use them, add them to the page so they are initially collapsed.
+
+???+ note "Limit the use of collapsible callouts to secondary information only"
+
+    Don't use expanded-on-load collapsibles. If the callout contains important information and needs to be shown as expanded on page load, it should simply be non-collapsible.
 
 ## Capitalization
 * Only capitalize proper nouns e.g. names of technology products, other tools and services.
@@ -57,15 +61,15 @@ Boxes can be made collapsible, and if you choose this option, prefer to add them
 ## Instructions
 
 Prefer to use imperatives to make instructions. For example:
-> "Complete the configuration steps"
+> Complete the configuration steps
 
 You don't need to use the word "please" -- readers want less to read and don't think it's rude if you omit it.
 
 You can also use second person:
-> "You should complete the configuration steps". Don't use the passive "The configuration steps should be completed" (see next bullet).
+> You should complete the configuration steps.
 
-
-Avoid using the passive tense where possible.
+Don't use the passive tense:
+> The configuration steps should be completed.
 
 !!!note "What is passive tense?"
 
@@ -91,6 +95,14 @@ This is less helpful:
 Don't write this:
 
 > To learn how to contribute to Vizro, see [here](https://vizro.readthedocs.io/en/stable/pages/development/contributing/).
+
+### Internal cross-referencing
+We use internal cross-references as follows:
+
+* For each documentation page, if it helps the reader, we link to narrative documentation (non-API documentation) about each Vizro concept where it is first introduced.
+* On any single page, we limit the repetition of links: do not re-link to the same page again unless there is good reason to do so (for example, linking to a specific sub-section to illustrate a point).
+* Add links to relevant API documentation where it is useful for the reader, and consider how they will navigate from where they land in the API documentation back to the narrative content. Consider adding a link in the relevant docstring back to your page.
+
 
 ## Oxford commas
 Use these in lists to avoid confusion. This is confusing:
@@ -136,7 +148,7 @@ Functional is not try-hard, cliched or hyperbolic:
 
 ## Things to avoid
 
-* **Gerunds in headings**. What are these? They are the "-ing" forms of verbs. If you find yourself writing "Getting started" in a heading, then consider "Get started" or "How to get started" instead.
+* **Gerunds in headings**. What are these? They are the "-ing" forms of verbs. If you find yourself writing "Getting started" in a heading, then consider "Get started" or "How to get started" instead. In fact, in general, it's better to avoid gerund-forms of verbs where you can.
 * **Plagiarism**. Link to their text and credit them.
 * **Colloquialisms**. Avoid them "like the plague" because they may not translate to other regions/languages.
 * **Technical terminology**. This applies particularly to acronyms that do not pass the "Google test". If it is not possible to find their meaning from a simple Google search, don't use them, or explain them with a link or some text.

--- a/vizro-core/docs/pages/development/documentation-style-guide.md
+++ b/vizro-core/docs/pages/development/documentation-style-guide.md
@@ -1,0 +1,143 @@
+# Vizro documentation style guide
+
+This is the style guide we apply to the [Vizro documentation](https://vizro.readthedocs.io/en/stable/).
+
+We ask anyone kind enough to contribute documentation changes to follow this style for consistency and simplicity.
+
+What follows is a set of lightweight guidelines rather than rules. There are always edge cases and exceptions, and if it's not obvious what the style should be, consult the [Microsoft style guide](https://docs.microsoft.com/en-gb/style-guide/welcome/) for an example of good practice. We also use the [INCITS Inclusive Terminology Guidelines](https://standards.incits.org/apps/group_public/download.php/131246/eb-2021-00288-001-INCITS-Inclusive-Terminology-Guidelines.pdf).
+
+## Vizro lexicon
+
+The names of our products are **Vizro** and **Vizro-AI**.
+
+We refer to other products using their preferred capitalization. For example, Dash and Plotly are always capitalized, except where given as Python package names `dash` and `plotly`.
+
+Vizro components are named using lower case:
+
+> "Here is a guide to using containers..."
+
+Use code font when referring to the component as a class or object:
+
+> "To add a `Container` to your page..."
+
+## Bullets
+* Capitalize the first word, and end the bullet with a period.
+* Don't use numbered bullets except for a sequence of instructions, or where you have to refer back to one of them in the text (or a diagram).
+
+## Call out boxes
+
+Keep the amount of text, and the number and variety of callouts used, to a minimum. There is a [broad set available](https://squidfunk.github.io/mkdocs-material/reference/admonitions/#supported-types) for use in the Vizro docs, but we prefer to limit usage mostly to the following:
+
+!!!note "note"
+
+     For notable information
+
+!!!warning "warning"
+
+     To indicate a potential gotcha.
+
+!!!example "example"
+
+     For example code
+
+
+Boxes can be made collapsible, and rendered initially collapsed or expanded.
+
+## Capitalization
+* Only capitalize proper nouns e.g. names of technology products, other tools and services.
+* Don't capitalize cloud, internet, machine learning, or advanced analytics. Take a look at the [Microsoft style guide](https://docs.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/term-collections/accessibility-terms) if you're unsure.
+* Follow sentence case, which capitalizes only the first word of a title/subtitle. We prefer this "An introduction to data visualization" to this "An Introduction to Data Visualization".
+
+
+## Code formatting
+* Mark code blocks with the appropriate language to enable syntax highlighting.
+* We use a `bash` lexer for all codeblocks that represent the terminal, and we don't include the prompt.
+* Use the code format for Python package names such as `pandas` or `pylint`.
+
+## Instructions
+
+Prefer to use imperatives to make instructions. For example:
+> "Complete the configuration steps"
+
+You don't need to use the word "please" -- readers want less to read and don't think it's rude if you omit it.
+
+You can also use second person:
+> "You should complete the configuration steps". Don't use the passive "The configuration steps should be completed" (see next bullet).
+
+
+Avoid using the passive tense where possible.
+
+!!!note "What is passive tense?"
+
+    If you can add "by zombies" to the end of any sentence, it is passive.
+
+    * For example: "The configuration steps should be completed." can also be read as: "The configuration should be completed BY ZOMBIES".
+    * Instead, you'd write this: "You should complete the configuration steps" or better still, "Complete the configuration steps".
+
+
+## Language
+* Use US English.
+
+
+## Links
+* Make hyperlink descriptions as descriptive as you can. This is a good description:
+
+> Learn how to [contribute to Vizro](https://vizro.readthedocs.io/en/stable/pages/development/contributing/).
+
+This is less helpful:
+
+> [Learn how to](https://vizro.readthedocs.io/en/stable/pages/development/contributing/) contribute to Vizro.
+
+Don't write this:
+
+> To learn how to contribute to Vizro, see [here](https://vizro.readthedocs.io/en/stable/pages/development/contributing/).
+
+## Oxford commas
+Use these in lists to avoid confusion. This is confusing:
+
+> The ice cream comes in a range of flavors including banana and strawberry, mango and raspberry and blueberry.
+
+This is clearer:
+
+> The ice cream comes in a range of flavors including banana and strawberry, mango and raspberry, and blueberry.
+
+## Style
+
+Keep your sentences short and easy to read. Your tone of voice should be simple, friendly and functional.
+
+### Simple
+
+Simple is clear, concise and direct:
+
+> We build new skills within your team.
+
+Simple is not vague, verbose or full of jargon:
+
+> We leverage your existing organizational resources to synthesize novel competencies.
+
+### Friendly
+Friendly is approachable and open, and it makes discussions flow:
+
+> Vizro: Let’s make cool visualizations happen. Together.
+
+Friendly is not secretive, negative, vague or non-inclusive:
+
+> Vizro is utilized to build tier one visualizations for your organization.
+
+### Functional
+
+Functional is compelling, positive, inspiring:
+
+> 200+ successful projects and counting.
+
+Functional is not try-hard, cliched or hyperbolic:
+
+> We’re ultra-sucessful business-builders.
+
+## Things to avoid
+
+* **Gerunds in headings**. What are these? They are the "-ing" forms of verbs. If you find yourself writing "Getting started" in a heading, then consider "Get started" or "How to get started" instead.
+* **Plagiarism**. Link to their text and credit them.
+* **Colloquialisms**. Avoid them "like the plague" because they may not translate to other regions/languages.
+* **Technical terminology**. This applies particularly to acronyms that do not pass the "Google test". If it is not possible to find their meaning from a simple Google search, don't use them, or explain them with a link or some text.
+* **Business speak**. You can explain simply without using words like "leverage", "utilize" or "facilitate" and still sound clever.

--- a/vizro-core/docs/pages/development/documentation-style-guide.md
+++ b/vizro-core/docs/pages/development/documentation-style-guide.md
@@ -30,7 +30,7 @@ Keep the amount of text, and the number and variety of callouts used, to a minim
 
 !!!note "note"
 
-     For notable information
+     For notable information.
 
 !!!warning "warning"
 

--- a/vizro-core/docs/pages/development/documentation-style-guide.md
+++ b/vizro-core/docs/pages/development/documentation-style-guide.md
@@ -46,7 +46,7 @@ Boxes can be made collapsible, and if you choose this option, prefer to add them
 ## Capitalization
 * Only capitalize proper nouns e.g. names of technology products, other tools and services.
 * Don't capitalize cloud, internet, machine learning, or advanced analytics. Take a look at the [Microsoft style guide](https://docs.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/term-collections/accessibility-terms) if you're unsure.
-* Follow sentence case, which capitalizes only the first word of a title/subtitle. We prefer this "An introduction to data visualization" to this "An Introduction to Data Visualization".
+* Follow sentence case, which capitalizes only the first word of a title/subtitle. We prefer "An introduction to data visualization" to "An Introduction to Data Visualization".
 
 
 ## Code formatting

--- a/vizro-core/docs/pages/development/documentation-style-guide.md
+++ b/vizro-core/docs/pages/development/documentation-style-guide.md
@@ -10,7 +10,7 @@ What follows is a set of lightweight guidelines rather than rules. There are alw
 
 The names of our products are **Vizro** and **Vizro-AI**.
 
-We refer to other products using their preferred capitalization. For example, Dash and Plotly are always capitalized, except where given as Python package names `dash` and `plotly`.
+We refer to other products using their preferred capitalization. For example, Dash and Pydantic are always capitalized, except where given as Python package names `dash` and `pydantic`.
 
 Vizro components are named using lower case:
 

--- a/vizro-core/docs/pages/development/documentation-style-guide.md
+++ b/vizro-core/docs/pages/development/documentation-style-guide.md
@@ -52,7 +52,7 @@ Boxes can be made collapsible, and if you choose this option, prefer to add them
 ## Code formatting
 * Mark code blocks with the appropriate language to enable syntax highlighting.
 * We use a `bash` lexer for all codeblocks that represent the terminal, and we don't include the prompt.
-* Use the code format for Python package names such as `pandas` or `pylint`.
+* Use the code format for Python package names such as `pandas` or `pydantic`.
 
 ## Instructions
 

--- a/vizro-core/docs/pages/development/documentation-style-guide.md
+++ b/vizro-core/docs/pages/development/documentation-style-guide.md
@@ -41,7 +41,7 @@ Keep the amount of text, and the number and variety of callouts used, to a minim
      For example code
 
 
-Boxes can be made collapsible, and rendered initially collapsed or expanded.
+Boxes can be made collapsible, and if you choose this option, prefer to add them to the page so they are initially collapsed, to avoid crowding.
 
 ## Capitalization
 * Only capitalize proper nouns e.g. names of technology products, other tools and services.

--- a/vizro-core/mkdocs.yml
+++ b/vizro-core/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
       - Why Vizro: pages/explanation/why-vizro.md
   - Contribute:
       - Contributing: pages/development/contributing.md
+      - Documentation style: pages/development/documentation-style-guide.md
       - Authors: pages/development/authors.md
 
 repo_url: https://github.com/mckinsey/vizro


### PR DESCRIPTION
## Description
This is part of the work to apply a light edit and consistency check to docs. I've created a page with a lightweight guide for us to agree upon before I start editing.

[You can read it here!](https://vizro--325.org.readthedocs.build/en/325/pages/development/documentation-style-guide/)

## Related issues
I've created a separate issue to install Vale (which is a text linter) to check text changes in CI and catch when the guidelines are not observed. This isn't urgent but a nice-to-have.

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
