### PR TITLE
[Bug] Fix CSS on `page-main` in mobile layouts

### DIFF
--- a/vizro-core/changelog.d/20240226_100408_huong_li_nguyen_fix_css_grid.md
+++ b/vizro-core/changelog.d/20240226_100408_huong_li_nguyen_fix_css_grid.md
@@ -1,0 +1,47 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+
+### Fixed
+
+- Fix CSS bug on `page-main` overflowing `page-container` in mobile layouts. ([#331](https://github.com/mckinsey/vizro/pull/331))
+
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/src/vizro/static/css/card.css
+++ b/vizro-core/src/vizro/static/css/card.css
@@ -33,8 +33,8 @@
 }
 
 .card_text {
-  padding: var(--spacing-04);
   height: 100%;
+  padding: var(--spacing-04);
   width: 100%;
 }
 

--- a/vizro-core/src/vizro/static/css/card.css
+++ b/vizro-core/src/vizro/static/css/card.css
@@ -24,13 +24,13 @@
 
 .card-link {
   color: transparent;
+  display: contents;
   height: 100%;
   left: 0;
   padding: var(--spacing-04);
   position: absolute;
   top: 0;
   width: 100%;
-  display: contents;
 }
 
 .card_text h1,

--- a/vizro-core/src/vizro/static/css/card.css
+++ b/vizro-core/src/vizro/static/css/card.css
@@ -32,8 +32,8 @@
 }
 
 .card_text {
-  padding: var(--spacing-04);
   height: 100%;
+  padding: var(--spacing-04);
   width: 100%;
 }
 

--- a/vizro-core/src/vizro/static/css/card.css
+++ b/vizro-core/src/vizro/static/css/card.css
@@ -23,18 +23,17 @@
 
 .card-link {
   color: transparent;
-  display: contents;
+  display: flex;
   height: 100%;
   left: 0;
-  padding: var(--spacing-04);
-  position: absolute;
+  position: relative;
   top: 0;
   width: 100%;
 }
 
 .card_text {
-  height: 100%;
   padding: var(--spacing-04);
+  height: 100%;
   width: 100%;
 }
 

--- a/vizro-core/src/vizro/static/css/card.css
+++ b/vizro-core/src/vizro/static/css/card.css
@@ -30,6 +30,7 @@
   position: absolute;
   top: 0;
   width: 100%;
+  display: contents;
 }
 
 .card_text h1,

--- a/vizro-core/src/vizro/static/css/card.css
+++ b/vizro-core/src/vizro/static/css/card.css
@@ -6,7 +6,6 @@
   flex-direction: column;
   height: 100%;
   overflow: auto;
-  padding: var(--spacing-04);
   position: relative;
 }
 
@@ -34,6 +33,7 @@
 }
 
 .card_text {
+  padding: var(--spacing-04);
   height: 100%;
   width: 100%;
 }

--- a/vizro-core/src/vizro/static/css/card.css
+++ b/vizro-core/src/vizro/static/css/card.css
@@ -33,6 +33,11 @@
   width: 100%;
 }
 
+.card-text {
+  height: 100%;
+  width: 100%;
+}
+
 .card_text h1,
 h2,
 h3,

--- a/vizro-core/src/vizro/static/css/card.css
+++ b/vizro-core/src/vizro/static/css/card.css
@@ -33,7 +33,7 @@
   width: 100%;
 }
 
-.card-text {
+.card_text {
   height: 100%;
   width: 100%;
 }

--- a/vizro-core/src/vizro/static/css/card.css
+++ b/vizro-core/src/vizro/static/css/card.css
@@ -6,13 +6,11 @@
   flex-direction: column;
   height: 100%;
   overflow: auto;
-  position: relative;
 }
 
 .nav_card_container {
   height: 98%;
   margin-top: 4px;
-  position: relative;
 }
 
 .nav_card_container:hover {

--- a/vizro-core/src/vizro/static/css/layout.css
+++ b/vizro-core/src/vizro/static/css/layout.css
@@ -188,6 +188,7 @@ div.dashboard_container .custom-tooltip {
   flex: 1 1 0;
   flex-direction: row;
   height: calc(100vh - 64px);
+  overflow: auto;
 }
 
 #dashboard-title {


### PR DESCRIPTION
## Description
Noticed two bugs which are fixed by this PR:
- `page-main` not overflowing correctly in mobile mode
- `card-link` not extending properly in mobile mode

@l0uden - we should probably have some screenshot tests for the mobile layouts as well. So far I've been manually checking every week as I know there are currently other priorities, but would be good to add this to the next sprint 🙏 

## Screenshot
**Before:**
**`page-main` not overflowing correctly in mobile mode**
<img src="https://github.com/mckinsey/vizro/assets/90609403/f00509b1-633d-442c-8915-e8105c6b8412" height="600">


**`card-link` not extending properly in mobile mode**
![Screenshot 2024-02-26 at 10 08 27](https://github.com/mckinsey/vizro/assets/90609403/c71ea25e-16b9-4d0c-960b-e1f02ae23085)


## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
