### PR TITLE
[Tidy] Add validation to card href

### DIFF
--- a/vizro-core/changelog.d/20240315_110144_nadija_ratkusic_graca_add_validation_to_card.md
+++ b/vizro-core/changelog.d/20240315_110144_nadija_ratkusic_graca_add_validation_to_card.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/src/vizro/models/_components/card.py
+++ b/vizro-core/src/vizro/models/_components/card.py
@@ -4,9 +4,9 @@ import dash_bootstrap_components as dbc
 from dash import dcc, get_relative_path
 
 try:
-    from pydantic.v1 import Field
+    from pydantic.v1 import Field, validator
 except ImportError:  # pragma: no cov
-    from pydantic import Field
+    from pydantic import Field, validator
 
 from vizro.models import VizroBaseModel
 from vizro.models._models_utils import _log_call
@@ -31,6 +31,13 @@ class Card(VizroBaseModel):
         "",
         description="URL (relative or absolute) to navigate to. If not provided the Card serves as a text card only.",
     )
+
+    @validator("href")
+    def set_href(cls, href) -> str:
+        if href:
+            return href.strip().lower().replace(" ", "-")
+
+        return href
 
     @_log_call
     def build(self):


### PR DESCRIPTION
## Description

- Add validation similar to page.path to the card href property.

Issue solved:
If user sets `page.path` with uppercase, space etc the validator will format it correctly. However, if user sets the same path as `card.href` it will lead to 404 page as card.href does not have validation. Now, any path that can be set in `page.path` can also be set as `card.href`.

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
