### PR TITLE
[QA] Using assert_component_equal in actions, dashboard and controls tests

### DIFF
--- a/vizro-core/changelog.d/20240328_163211_petar_pejovic_actions_assert_component_equal_tests.md
+++ b/vizro-core/changelog.d/20240328_163211_petar_pejovic_actions_assert_component_equal_tests.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/tests/unit/vizro/actions/_action_loop/test_get_action_loop_components.py
+++ b/vizro-core/tests/unit/vizro/actions/_action_loop/test_get_action_loop_components.py
@@ -1,11 +1,9 @@
 """Unit tests for vizro.actions._action_loop._get_action_loop_components file."""
 
-import json
-
-import plotly
 import pytest
 import vizro.models as vm
 import vizro.plotly.express as px
+from asserts import assert_component_equal
 from dash import dcc, html
 from vizro import Vizro
 from vizro.actions import export_data, filter_interaction
@@ -125,11 +123,7 @@ class TestGetActionLoopComponents:
     @pytest.mark.usefixtures("managers_one_page_no_actions")
     def test_no_components(self):
         result = _get_action_loop_components()
-        result = json.loads(json.dumps(result, cls=plotly.utils.PlotlyJSONEncoder))
-
-        expected = json.loads(json.dumps(html.Div(id="action_loop_components_div"), cls=plotly.utils.PlotlyJSONEncoder))
-
-        assert result == expected
+        assert_component_equal(result, html.Div(id="action_loop_components_div"))
 
     @pytest.mark.usefixtures("managers_one_page_two_components_two_controls")
     @pytest.mark.parametrize(
@@ -155,21 +149,14 @@ class TestGetActionLoopComponents:
         action_trigger_actions_id_component,
         trigger_to_actions_chain_mapper_component,
     ):
-        result = json.loads(json.dumps(_get_action_loop_components(), cls=plotly.utils.PlotlyJSONEncoder))
-
-        all_action_loop_components_expected = (
-            fundamental_components
+        result = _get_action_loop_components()
+        expected = html.Div(
+            id="action_loop_components_div",
+            children=fundamental_components
             + gateway_components
             + action_trigger_components
             + [action_trigger_actions_id_component]
-            + [trigger_to_actions_chain_mapper_component]
+            + [trigger_to_actions_chain_mapper_component],
         )
 
-        expected = json.loads(
-            json.dumps(
-                html.Div(children=all_action_loop_components_expected, id="action_loop_components_div"),
-                cls=plotly.utils.PlotlyJSONEncoder,
-            )
-        )
-
-        assert result == expected
+        assert_component_equal(result, expected)

--- a/vizro-core/tests/unit/vizro/actions/_callback_mapping/test_get_action_callback_mapping.py
+++ b/vizro-core/tests/unit/vizro/actions/_callback_mapping/test_get_action_callback_mapping.py
@@ -1,12 +1,10 @@
 """Unit tests for vizro.actions._callback_mapping._get_action_callback_mapping file."""
 
-import json
-
 import dash
-import plotly
 import pytest
 import vizro.models as vm
 import vizro.plotly.express as px
+from asserts import assert_component_equal
 from vizro import Vizro
 from vizro.actions import export_data, filter_interaction
 from vizro.actions._callback_mapping._get_action_callback_mapping import _get_action_callback_mapping
@@ -299,10 +297,7 @@ class TestCallbackMapping:
     )
     def test_export_data_no_targets_set_mapping_components(self, export_data_components_expected):
         result_components = _get_action_callback_mapping(action_id="export_data_action", argument="components")
-
-        result = json.dumps(result_components, cls=plotly.utils.PlotlyJSONEncoder)
-        expected = json.dumps(export_data_components_expected, cls=plotly.utils.PlotlyJSONEncoder)
-        assert result == expected
+        assert_component_equal(result_components, export_data_components_expected)
 
     @pytest.mark.parametrize(
         "config_for_testing_all_components_with_actions, export_data_components_expected",
@@ -318,9 +313,7 @@ class TestCallbackMapping:
         self, config_for_testing_all_components_with_actions, export_data_components_expected
     ):
         result_components = _get_action_callback_mapping(action_id="export_data_action", argument="components")
-        result = json.dumps(result_components, cls=plotly.utils.PlotlyJSONEncoder)
-        expected = json.dumps(export_data_components_expected, cls=plotly.utils.PlotlyJSONEncoder)
-        assert result == expected
+        assert_component_equal(result_components, export_data_components_expected)
 
     def test_known_action_unknown_argument(self):
         result = _get_action_callback_mapping(action_id="export_data_action", argument="unknown-argument")

--- a/vizro-core/tests/unit/vizro/models/_action/test_action.py
+++ b/vizro-core/tests/unit/vizro/models/_action/test_action.py
@@ -1,10 +1,8 @@
 """Unit tests for vizro.models.Action."""
 
-import json
 import sys
 
 import pandas as pd
-import plotly
 import pytest
 from dash import Output, State, html
 
@@ -15,6 +13,7 @@ except ImportError:  # pragma: no cov
 
 import vizro.models as vm
 import vizro.plotly.express as px
+from asserts import assert_component_equal
 from vizro import Vizro
 from vizro.actions import export_data
 from vizro.managers import model_manager
@@ -152,17 +151,13 @@ class TestActionBuild:
     """Tests action build method."""
 
     def test_custom_action_build(self, identity_action_function, custom_action_build_expected):
-        action = Action(id="action_test", function=identity_action_function())
-        result = json.loads(json.dumps(action.build(), cls=plotly.utils.PlotlyJSONEncoder))
-        expected = json.loads(json.dumps(custom_action_build_expected, cls=plotly.utils.PlotlyJSONEncoder))
-        assert result == expected
+        action = Action(id="action_test", function=identity_action_function()).build()
+        assert_component_equal(action, custom_action_build_expected)
 
     @pytest.mark.usefixtures("managers_one_page_without_graphs_one_button")
     def test_predefined_export_data_action_build(self, predefined_action_build_expected):
-        predefined_filter_action = model_manager["test_page"].controls[0].selector.actions[0].actions[0]
-        result = json.loads(json.dumps(predefined_filter_action.build(), cls=plotly.utils.PlotlyJSONEncoder))
-        expected = json.loads(json.dumps(predefined_action_build_expected, cls=plotly.utils.PlotlyJSONEncoder))
-        assert result == expected
+        predefined_filter_action = model_manager["test_page"].controls[0].selector.actions[0].actions[0].build()
+        assert_component_equal(predefined_filter_action, predefined_action_build_expected)
 
 
 class TestActionPrivateMethods:

--- a/vizro-core/tests/unit/vizro/models/_controls/test_filter.py
+++ b/vizro-core/tests/unit/vizro/models/_controls/test_filter.py
@@ -5,6 +5,7 @@ from typing import Literal
 import pandas as pd
 import pytest
 import vizro.models as vm
+from asserts import assert_component_equal
 from vizro.managers import model_manager
 from vizro.models._action._actions_chain import ActionsChain
 from vizro.models._controls.filter import Filter, _filter_between, _filter_isin
@@ -427,6 +428,7 @@ class TestFilterBuild:
         filter = vm.Filter(column=test_column, selector=test_selector)
         model_manager["test_page"].controls = [filter]
         filter.pre_build()
-        result = str(filter.build())
-        expected = str(test_selector.build())
-        assert result == expected
+        result = filter.build()
+        expected = test_selector.build()
+
+        assert_component_equal(result, expected)

--- a/vizro-core/tests/unit/vizro/models/_controls/test_parameter.py
+++ b/vizro-core/tests/unit/vizro/models/_controls/test_parameter.py
@@ -1,5 +1,6 @@
 import pytest
 import vizro.models as vm
+from asserts import assert_component_equal
 from vizro.managers import model_manager
 from vizro.models._action._actions_chain import ActionsChain
 from vizro.models._controls.parameter import Parameter
@@ -118,6 +119,7 @@ class TestParameterBuild:
         page = model_manager["test_page"]
         page.controls = [parameter]
         parameter.pre_build()
-        result = str(parameter.build())
-        expected = str(test_input.build())
-        assert result == expected
+        result = parameter.build()
+        expected = test_input.build()
+
+        assert_component_equal(result, expected)

--- a/vizro-core/tests/unit/vizro/models/test_dashboard.py
+++ b/vizro-core/tests/unit/vizro/models/test_dashboard.py
@@ -1,9 +1,7 @@
-import json
 from pathlib import Path
 
 import dash
 import dash_bootstrap_components as dbc
-import plotly
 import pytest
 from asserts import assert_component_equal
 from dash import html
@@ -228,7 +226,7 @@ class TestDashboardBuild:
         dashboard = vm.Dashboard(pages=[page_1, page_2])
         dashboard.pre_build()
 
-        dashboard_container = html.Div(
+        expected_dashboard_container = html.Div(
             id="dashboard-container",
             children=[
                 html.Div(vizro.__version__, id="vizro_version", hidden=True),
@@ -237,9 +235,7 @@ class TestDashboardBuild:
             ],
             className="vizro_dark",
         )
-        result = json.loads(json.dumps(dashboard.build(), cls=plotly.utils.PlotlyJSONEncoder))
-        expected = json.loads(json.dumps(dashboard_container, cls=plotly.utils.PlotlyJSONEncoder))
-        assert result == expected
+        assert_component_equal(dashboard.build(), expected_dashboard_container)
 
 
 @pytest.mark.parametrize(

--- a/vizro-core/tests/unit/vizro/models/test_page.py
+++ b/vizro-core/tests/unit/vizro/models/test_page.py
@@ -96,4 +96,5 @@ class TestPagePreBuildMethod:
         assert page.actions[0].id == f"{ON_PAGE_LOAD_ACTION_PREFIX}_Page 1"
 
 
+# TODO: Add unit tests for page build method
 # TODO: Add unit tests for private methods in page build


### PR DESCRIPTION
## Description
`assert_component_equal` is implemented in the following test files:
 - test_get_action_loop_components.py
 - test_get_action_callback_mapping.py
 - test_action.py
 - test_dashboard.py
 - test_filter.py
 - test_parameter.py

Here is the ticket for reference -> https://github.com/McK-Internal/vizro-internal/issues/546

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
