### PR TITLE
[CI] Fix mypy linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,7 @@ repos:
       - id: mypy
         files: ^vizro-core/src/
         additional_dependencies:
-          - pydantic>=1.10.13, <2 # deliberately pinned to <2 until we bump our pydantic requirement to strictly >=2
+          - pydantic==1.10.14 #, <2 # deliberately pinned to <2 until we bump our pydantic requirement to strictly >=2
 
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.18.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -119,5 +119,5 @@ ci:
     - check-branch-name
     - codespell
     - bandit
-    - mypy
     - gitleaks
+    - vale

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,11 @@ repos:
       - id: mypy
         files: ^vizro-core/src/
         additional_dependencies:
-          - pydantic==1.10.14 #, <2 # deliberately pinned to <2 until we bump our pydantic requirement to strictly >=2
+          # Deliberately pinned to <2 until we bump our pydantic requirement to strictly >=2.
+          # pydantic>=1.10.15 includes this fix which flags some genuine type problems. These will take a while to fix
+          # or ignore so for now we just pin to 1.10.14 which doesn't flag the problems.
+          # https://github.com/pydantic/pydantic/pull/8765
+          - pydantic==1.10.14
 
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.18.2
@@ -119,5 +123,6 @@ ci:
     - check-branch-name
     - codespell
     - bandit
+    - mypy
     - gitleaks
     - vale

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,7 @@ repos:
         additional_dependencies: ["bandit[toml]"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.9.0
     hooks:
       - id: mypy
         files: ^vizro-core/src/

--- a/vizro-core/changelog.d/20240405_103212_antony.milne_fix_mypy.md
+++ b/vizro-core/changelog.d/20240405_103212_antony.milne_fix_mypy.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->


### PR DESCRIPTION
## Description

#397 bumped our pre-commit mypy from 1.8.0 to 1.9.0, which seemed to flag new errors that were still there even after reversion to 0.18.0 in #403.

The reason for these new errors was **not** actually the change to mypy version but that there was a new pydantic release at about the same time. Pinning the pydantic version used by mypy fixes this.

There is no caching in our CI. There is caching on pre-commit.ci but it works well and will always be running the correct version specified in our .pre-commit-config.yaml. So both our CI and pre-commit.ci are still perfect sources of truth and working correctly. Behaviour locally should be the identical to these, but just in case it's not then `pre-commit clean` should fix it by clearing your local cache.

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
