### PR TITLE
[Bug] Turn on `autocolorscale` for assignment of correct continuous color palettes

### DIFF
--- a/vizro-core/changelog.d/20240405_135655_huong_li_nguyen_change_theme_default.md
+++ b/vizro-core/changelog.d/20240405_135655_huong_li_nguyen_change_theme_default.md
@@ -1,0 +1,47 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+
+### Fixed
+
+- Turn on `autocolorscale` for color palettes to be assigned correctly in Plotly charts. ([#407](https://github.com/mckinsey/vizro/pull/407))
+
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/examples/_dev/app.py
+++ b/vizro-core/examples/_dev/app.py
@@ -1,31 +1,57 @@
 """Example to show dashboard configuration."""
 
+from typing import Optional
+
+import pandas as pd
 import vizro.models as vm
 import vizro.plotly.express as px
 from vizro import Vizro
-from vizro.tables import dash_ag_grid
+from vizro.models.types import capture
 
-df = px.data.gapminder()
+gapminder_pos = px.data.gapminder()
+gapminder_neg = px.data.gapminder()
+gapminder_mixed = px.data.gapminder()
+gapminder_neg["lifeExp"] = gapminder_neg["lifeExp"] * (-1)
+gapminder_mixed["lifeExp"][:40] = gapminder_mixed["lifeExp"][:40] * (-1)
+
+
+@capture("graph")
+def variable_map(data_frame: pd.DataFrame = None, color: Optional[str] = None):
+    """Custom choropleth figure that needs post update calls."""
+    fig = px.choropleth(
+        data_frame,
+        locations="iso_alpha",
+        color=color,
+        hover_name="country",
+        animation_frame="year",
+        labels={
+            "year": "year",
+            "lifeExp": "Life expectancy",
+            "pop": "Population",
+            "gdpPercap": "GDP per capita",
+        },
+        title="Global development over time",
+    )
+    fig.update_layout(showlegend=False)
+    fig.update_yaxes(automargin=True)
+    fig.update_xaxes(automargin=True)
+    fig.update_coloraxes(colorbar={"thickness": 10, "title": {"side": "right"}})
+    return fig
+
 
 page = vm.Page(
-    title="Enhanced AG Grid",
+    title="Autocolorscale",
     components=[
-        vm.AgGrid(
-            title="Dash AG Grid",
-            figure=dash_ag_grid(
-                data_frame=df,
-                columnDefs=[
-                    {"field": "country", "floatingFilter": True, "suppressHeaderMenuButton": True},
-                    {"field": "continent", "floatingFilter": True, "suppressHeaderMenuButton": True},
-                    {"field": "year"},
-                    {"field": "lifeExp", "cellDataType": "numeric"},
-                    {"field": "pop", "cellDataType": "numeric"},
-                    {"field": "gdpPercap", "cellDataType": "euro"},
-                ],
-            ),
+        vm.Graph(
+            figure=variable_map(data_frame=gapminder_pos, color="lifeExp", title="Positive Life Expectancy"),
+        ),
+        vm.Graph(
+            figure=variable_map(data_frame=gapminder_neg, color="lifeExp", title="Negative Life Expectancy"),
+        ),
+        vm.Graph(
+            figure=variable_map(data_frame=gapminder_mixed, color="lifeExp", title="Mixed Life Expectancy"),
         ),
     ],
-    controls=[vm.Filter(column="continent")],
 )
 dashboard = vm.Dashboard(pages=[page])
 

--- a/vizro-core/examples/_dev/app.py
+++ b/vizro-core/examples/_dev/app.py
@@ -16,7 +16,7 @@ gapminder_mixed["lifeExp"][:200] = gapminder_mixed["lifeExp"][:200] * (-1)
 
 
 @capture("graph")
-def variable_map(data_frame: pd.DataFrame = None, color: Optional[str] = None, title: Optional[str]=None):
+def variable_map(data_frame: pd.DataFrame = None, color: Optional[str] = None, title: Optional[str] = None):
     """Custom choropleth figure that needs post update calls."""
     fig = px.choropleth(
         data_frame,

--- a/vizro-core/examples/_dev/app.py
+++ b/vizro-core/examples/_dev/app.py
@@ -12,18 +12,17 @@ gapminder_pos = px.data.gapminder()
 gapminder_neg = px.data.gapminder()
 gapminder_mixed = px.data.gapminder()
 gapminder_neg["lifeExp"] = gapminder_neg["lifeExp"] * (-1)
-gapminder_mixed["lifeExp"][:40] = gapminder_mixed["lifeExp"][:40] * (-1)
+gapminder_mixed["lifeExp"][:200] = gapminder_mixed["lifeExp"][:200] * (-1)
 
 
 @capture("graph")
-def variable_map(data_frame: pd.DataFrame = None, color: Optional[str] = None):
+def variable_map(data_frame: pd.DataFrame = None, color: Optional[str] = None, title: Optional[str]=None):
     """Custom choropleth figure that needs post update calls."""
     fig = px.choropleth(
         data_frame,
         locations="iso_alpha",
         color=color,
         hover_name="country",
-        animation_frame="year",
         labels={
             "year": "year",
             "lifeExp": "Life expectancy",
@@ -32,15 +31,14 @@ def variable_map(data_frame: pd.DataFrame = None, color: Optional[str] = None):
         },
         title="Global development over time",
     )
-    fig.update_layout(showlegend=False)
-    fig.update_yaxes(automargin=True)
-    fig.update_xaxes(automargin=True)
+    fig.update_layout(showlegend=False, title=title)
     fig.update_coloraxes(colorbar={"thickness": 10, "title": {"side": "right"}})
     return fig
 
 
 page = vm.Page(
     title="Autocolorscale",
+    layout=vm.Layout(grid=[[0, 1, 2]]),
     components=[
         vm.Graph(
             figure=variable_map(data_frame=gapminder_pos, color="lifeExp", title="Positive Life Expectancy"),

--- a/vizro-core/src/vizro/_themes/_templates/common_values.py
+++ b/vizro-core/src/vizro/_themes/_templates/common_values.py
@@ -48,6 +48,7 @@ def create_template_common():
         margin_b=64,
         margin_pad=0,
         margin_autoexpand=True,
+        coloraxis_autocolorscale=True,  # Set to True so colorscale is dynamically applied based on data
         coloraxis_colorbar_outlinewidth=0,
         coloraxis_colorbar_thickness=20,
         coloraxis_colorbar_showticklabels=True,

--- a/vizro-core/src/vizro/_themes/_templates/template_dark.py
+++ b/vizro-core/src/vizro/_themes/_templates/template_dark.py
@@ -42,8 +42,11 @@ def create_template_dark() -> Template:
     template_dark["layout"]["coloraxis"]["colorbar"]["tickcolor"] = COLORS["WHITE_30"]
     template_dark["layout"]["coloraxis"]["colorbar"]["tickfont"]["color"] = COLORS["WHITE_55"]
     template_dark["layout"]["coloraxis"]["colorbar"]["title"]["font"]["color"] = COLORS["WHITE_55"]
+    # Applied when data for color is positive and negative
     template_dark["layout"]["colorscale"]["diverging"] = COLORS["DIVERGING_RED_CYAN"][::-1]
-    template_dark["layout"]["colorscale"]["sequential"] = COLORS["DIVERGING_RED_CYAN"]  # default for continuous
+    # Applied when data for color is positive
+    template_dark["layout"]["colorscale"]["sequential"] = COLORS["SEQUENTIAL_CYAN"]
+    # Applied when data for color is positive
     template_dark["layout"]["colorscale"]["sequentialminus"] = COLORS["SEQUENTIAL_RED"][::-1]
     template_dark["layout"]["colorway"] = COLORS["DISCRETE_10"]
 

--- a/vizro-core/src/vizro/_themes/_templates/template_light.py
+++ b/vizro-core/src/vizro/_themes/_templates/template_light.py
@@ -44,7 +44,7 @@ def create_template_light() -> Template:
     template_light["layout"]["coloraxis"]["colorbar"]["tickfont"]["color"] = COLORS["BLACK_55"]
     template_light["layout"]["coloraxis"]["colorbar"]["title"]["font"]["color"] = COLORS["BLACK_55"]
     template_light["layout"]["colorscale"]["diverging"] = COLORS["DIVERGING_RED_CYAN"][::-1]
-    template_light["layout"]["colorscale"]["sequential"] = COLORS["DIVERGING_RED_CYAN"]  # default for continuous
+    template_light["layout"]["colorscale"]["sequential"] = COLORS["SEQUENTIAL_CYAN"]
     template_light["layout"]["colorscale"]["sequentialminus"] = COLORS["SEQUENTIAL_RED"][::-1]
     template_light["layout"]["colorway"] = COLORS["DISCRETE_10"]
 

--- a/vizro-core/src/vizro/static/css/accordion.css
+++ b/vizro-core/src/vizro/static/css/accordion.css
@@ -114,3 +114,9 @@
 .accordion-body .accordion-item-link:last-child {
   margin-bottom: var(--spacing-03);
 }
+
+.nav-link:focus-visible {
+  border: none;
+  box-shadow: none;
+  outline: none;
+}


### PR DESCRIPTION
## Description
- Previously continous color palettes were not correctly assigned to Plotly charts, which is now fixed by turning autocolorscale to True
- See the example dev to understand:
    - Our diverging color palette is assigned if the data has positive and negative values
    - Our sequential color palette is assigned if the data has positive values only
    - Our sequentialminus color palette is assigned if the data has negative values only
- Squeezed in another fix for a CSS bug that has been triggering me everytime I saw a screenshot 😄  It's removing these blue lines when you focus on it

![Screenshot 2024-04-05 at 13 27 47](https://github.com/mckinsey/vizro/assets/90609403/ea97576a-dd9f-4c49-bd57-e0cca5a6ec0e)

## Screenshot

**Run dev example:**

![Screenshot 2024-04-05 at 13 56 30](https://github.com/mckinsey/vizro/assets/90609403/647c0aa2-dcbb-4c8c-ab0c-be21d40e90a6)


## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
