### PR TITLE
[Tidy] Replace `html.Label` with `dbc.Label`

### DIFF
--- a/vizro-core/changelog.d/20240409_110318_huong_li_nguyen_replace_label.md
+++ b/vizro-core/changelog.d/20240409_110318_huong_li_nguyen_replace_label.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/src/vizro/models/_components/form/_text_area.py
+++ b/vizro-core/src/vizro/models/_components/form/_text_area.py
@@ -41,7 +41,7 @@ class TextArea(VizroBaseModel):
     def build(self):
         return html.Div(
             [
-                html.Label(self.title, htmlFor=self.id) if self.title else None,
+                dbc.Label(self.title, html_for=self.id) if self.title else None,
                 dbc.Textarea(
                     id=self.id,
                     placeholder=self.placeholder,

--- a/vizro-core/src/vizro/models/_components/form/_user_input.py
+++ b/vizro-core/src/vizro/models/_components/form/_user_input.py
@@ -41,7 +41,7 @@ class UserInput(VizroBaseModel):
     def build(self):
         return html.Div(
             [
-                html.Label(self.title, htmlFor=self.id) if self.title else None,
+                dbc.Label(self.title, html_for=self.id) if self.title else None,
                 dbc.Input(
                     id=self.id,
                     placeholder=self.placeholder,

--- a/vizro-core/src/vizro/models/_components/form/checklist.py
+++ b/vizro-core/src/vizro/models/_components/form/checklist.py
@@ -7,6 +7,8 @@ try:
 except ImportError:  # pragma: no cov
     from pydantic import Field, PrivateAttr, root_validator, validator
 
+import dash_bootstrap_components as dbc
+
 from vizro.models import Action, VizroBaseModel
 from vizro.models._action._actions_chain import _action_validator_factory
 from vizro.models._components.form._form_utils import get_options_and_default, validate_options_dict, validate_value
@@ -50,7 +52,7 @@ class Checklist(VizroBaseModel):
 
         return html.Div(
             [
-                html.Label(self.title, htmlFor=self.id) if self.title else None,
+                dbc.Label(self.title, html_for=self.id) if self.title else None,
                 dcc.Checklist(
                     id=self.id,
                     options=full_options,

--- a/vizro-core/src/vizro/models/_components/form/date_picker.py
+++ b/vizro-core/src/vizro/models/_components/form/date_picker.py
@@ -12,6 +12,8 @@ except ImportError:  # pragma: no cov
 import datetime
 from datetime import date
 
+import dash_bootstrap_components as dbc
+
 from vizro.models import Action, VizroBaseModel
 from vizro.models._action._actions_chain import _action_validator_factory
 from vizro.models._components.form._form_utils import validate_date_picker_range, validate_max, validate_range_value
@@ -102,7 +104,7 @@ class DatePicker(VizroBaseModel):
 
         return html.Div(
             [
-                html.Label(self.title, htmlFor=self.id) if self.title else None,
+                dbc.Label(self.title, html_for=self.id) if self.title else None,
                 date_picker,
                 dcc.Store(id=f"{self.id}_input_store", storage_type="session", data=init_value),
             ],

--- a/vizro-core/src/vizro/models/_components/form/dropdown.py
+++ b/vizro-core/src/vizro/models/_components/form/dropdown.py
@@ -7,6 +7,8 @@ try:
 except ImportError:  # pragma: no cov
     from pydantic import Field, PrivateAttr, root_validator, validator
 
+import dash_bootstrap_components as dbc
+
 from vizro.models import Action, VizroBaseModel
 from vizro.models._action._actions_chain import _action_validator_factory
 from vizro.models._components.form._form_utils import get_options_and_default, validate_options_dict, validate_value
@@ -62,7 +64,7 @@ class Dropdown(VizroBaseModel):
         full_options, default_value = get_options_and_default(options=self.options, multi=self.multi)
         return html.Div(
             [
-                html.Label(self.title, htmlFor=self.id) if self.title else None,
+                dbc.Label(self.title, html_for=self.id) if self.title else None,
                 dcc.Dropdown(
                     id=self.id,
                     options=full_options,

--- a/vizro-core/src/vizro/models/_components/form/radio_items.py
+++ b/vizro-core/src/vizro/models/_components/form/radio_items.py
@@ -7,6 +7,8 @@ try:
 except ImportError:  # pragma: no cov
     from pydantic import Field, PrivateAttr, root_validator, validator
 
+import dash_bootstrap_components as dbc
+
 from vizro.models import Action, VizroBaseModel
 from vizro.models._action._actions_chain import _action_validator_factory
 from vizro.models._components.form._form_utils import get_options_and_default, validate_options_dict, validate_value
@@ -51,7 +53,7 @@ class RadioItems(VizroBaseModel):
 
         return html.Div(
             [
-                html.Label(self.title, htmlFor=self.id) if self.title else None,
+                dbc.Label(self.title, html_for=self.id) if self.title else None,
                 dcc.RadioItems(
                     id=self.id,
                     options=full_options,

--- a/vizro-core/src/vizro/models/_components/form/range_slider.py
+++ b/vizro-core/src/vizro/models/_components/form/range_slider.py
@@ -7,6 +7,8 @@ try:
 except ImportError:  # pragma: no cov
     from pydantic import Field, PrivateAttr, validator
 
+import dash_bootstrap_components as dbc
+
 from vizro.models import Action, VizroBaseModel
 from vizro.models._action._actions_chain import _action_validator_factory
 from vizro.models._components.form._form_utils import (
@@ -87,7 +89,7 @@ class RangeSlider(VizroBaseModel):
                 dcc.Store(f"{self.id}_callback_data", data={"id": self.id, "min": self.min, "max": self.max}),
                 html.Div(
                     [
-                        html.Label(self.title, htmlFor=self.id) if self.title else None,
+                        dbc.Label(self.title, html_for=self.id) if self.title else None,
                         html.Div(
                             [
                                 dcc.Input(

--- a/vizro-core/src/vizro/models/_components/form/slider.py
+++ b/vizro-core/src/vizro/models/_components/form/slider.py
@@ -7,6 +7,8 @@ try:
 except ImportError:  # pragma: no cov
     from pydantic import Field, PrivateAttr, validator
 
+import dash_bootstrap_components as dbc
+
 from vizro.models import Action, VizroBaseModel
 from vizro.models._action._actions_chain import _action_validator_factory
 from vizro.models._components.form._form_utils import (
@@ -83,7 +85,7 @@ class Slider(VizroBaseModel):
                 dcc.Store(f"{self.id}_callback_data", data={"id": self.id, "min": self.min, "max": self.max}),
                 html.Div(
                     [
-                        html.Label(self.title, htmlFor=self.id) if self.title else None,
+                        dbc.Label(self.title, html_for=self.id) if self.title else None,
                         html.Div(
                             [
                                 dcc.Input(

--- a/vizro-core/src/vizro/static/css/bootstrap_overwrites.css
+++ b/vizro-core/src/vizro/static/css/bootstrap_overwrites.css
@@ -1,0 +1,3 @@
+.form-label {
+  margin-bottom: 0;
+}

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_checklist.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_checklist.py
@@ -1,5 +1,6 @@
 """Unit tests for vizro.models.Checklist."""
 
+import dash_bootstrap_components as dbc
 import pytest
 from asserts import assert_component_equal
 from dash import dcc, html
@@ -131,7 +132,7 @@ class TestChecklistBuild:
         checklist = Checklist(id="checklist_id", options=["A", "B", "C"], title="Title").build()
         expected_checklist = html.Div(
             [
-                html.Label("Title", htmlFor="checklist_id"),
+                dbc.Label("Title", html_for="checklist_id"),
                 dcc.Checklist(
                     id="checklist_id",
                     options=["ALL", "A", "B", "C"],

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_date_picker.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_date_picker.py
@@ -2,6 +2,7 @@
 
 from datetime import date, datetime
 
+import dash_bootstrap_components as dbc
 import dash_mantine_components as dmc
 import pytest
 from asserts import assert_component_equal
@@ -120,7 +121,7 @@ class TestBuildMethod:
         additional_kwargs = {"allowSingleDateInRange": True} if range else {}
         expected_datepicker = html.Div(
             [
-                html.Label("Test title", htmlFor="datepicker_id"),
+                dbc.Label("Test title", html_for="datepicker_id"),
                 date_picker_class(
                     id="datepicker_id",
                     minDate="2023-01-01",

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_dropdown.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_dropdown.py
@@ -1,5 +1,6 @@
 """Unit tests for vizro.models.Dropdown."""
 
+import dash_bootstrap_components as dbc
 import pytest
 from asserts import assert_component_equal
 from dash import dcc, html
@@ -150,7 +151,7 @@ class TestDropdownBuild:
         dropdown = Dropdown(options=["A", "B", "C"], title="Title", id="dropdown_id").build()
         expected_dropdown = html.Div(
             [
-                html.Label("Title", htmlFor="dropdown_id"),
+                dbc.Label("Title", html_for="dropdown_id"),
                 dcc.Dropdown(
                     id="dropdown_id",
                     options=["ALL", "A", "B", "C"],
@@ -171,7 +172,7 @@ class TestDropdownBuild:
         dropdown = Dropdown(id="dropdown_id", options=["A", "B", "C"], multi=False, title="Title").build()
         expected_dropdown = html.Div(
             [
-                html.Label("Title", htmlFor="dropdown_id"),
+                dbc.Label("Title", html_for="dropdown_id"),
                 dcc.Dropdown(
                     id="dropdown_id",
                     options=["A", "B", "C"],

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_radio_items.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_radio_items.py
@@ -1,5 +1,6 @@
 """Unit tests for vizro.models.RadioItems."""
 
+import dash_bootstrap_components as dbc
 import pytest
 from asserts import assert_component_equal
 from dash import dcc, html
@@ -131,7 +132,7 @@ class TestRadioItemsBuild:
         radio_items = RadioItems(id="radio_items_id", options=["A", "B", "C"], title="Title").build()
         expected_radio_items = html.Div(
             [
-                html.Label("Title", htmlFor="radio_items_id"),
+                dbc.Label("Title", html_for="radio_items_id"),
                 dcc.RadioItems(
                     id="radio_items_id",
                     options=["A", "B", "C"],

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_range_slider.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_range_slider.py
@@ -1,5 +1,6 @@
 """Unit tests for hyphen.models.slider."""
 
+import dash_bootstrap_components as dbc
 import pytest
 from asserts import assert_component_equal
 from dash import dcc, html
@@ -78,7 +79,7 @@ def expected_range_slider_with_optional():
             dcc.Store("range_slider_callback_data", data={"id": "range_slider", "min": 0.0, "max": 10.0}),
             html.Div(
                 [
-                    html.Label("Title", htmlFor="range_slider"),
+                    dbc.Label("Title", html_for="range_slider"),
                     html.Div(
                         [
                             dcc.Input(

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_slider.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_slider.py
@@ -1,5 +1,6 @@
 """Unit tests for hyphen.models.slider."""
 
+import dash_bootstrap_components as dbc
 import pytest
 from asserts import assert_component_equal
 from dash import dcc, html
@@ -19,7 +20,7 @@ def expected_slider():
             dcc.Store("slider_id_callback_data", data={"id": "slider_id", "min": 0.0, "max": 10.0}),
             html.Div(
                 [
-                    html.Label("Test title", htmlFor="slider_id"),
+                    dbc.Label("Test title", html_for="slider_id"),
                     html.Div(
                         [
                             dcc.Input(

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_text_area.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_text_area.py
@@ -35,7 +35,7 @@ class TestUserInputBuild:
         text_area = TextArea(title="Title", placeholder="Placeholder", id="text-area-id").build()
         expected_text_area = html.Div(
             [
-                html.Label("Title", htmlFor="text-area-id"),
+                dbc.Label("Title", html_for="text-area-id"),
                 dbc.Textarea(
                     id="text-area-id",
                     placeholder="Placeholder",

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_user_input.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_user_input.py
@@ -35,7 +35,7 @@ class TestUserInputBuild:
         user_input = UserInput(title="Title", placeholder="Placeholder", id="user-input-id").build()
         expected_user_input = html.Div(
             [
-                html.Label("Title", htmlFor="user-input-id"),
+                dbc.Label("Title", html_for="user-input-id"),
                 dbc.Input(
                     id="user-input-id",
                     placeholder="Placeholder",


### PR DESCRIPTION
## Description
**Context:** This will be one of many PRs where I gradually replace our existing components with dbc equivalents (as long as functionality is the same). Simultaneously, I will always encode the relevant SASS code for our official Bootstrap theme, so everything that is temporarily added to overwrite Bootstrap can then be removed as soon as we replace the underlying source Bootstrap CSS file.


- Replace `html.Label` with `dbc.Label`
- Add temporary CSS overwrite

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
