### PR TITLE
[Tidy] Update langchain upper bound

### DIFF
--- a/vizro-ai/changelog.d/20240501_111259_anna_xiong_langchian_verison_upperbound.md
+++ b/vizro-ai/changelog.d/20240501_111259_anna_xiong_langchian_verison_upperbound.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-ai/pyproject.toml
+++ b/vizro-ai/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "pandas",
   "tabulate",
   "openai>=1.0.0",
-  "langchain>=0.1.0",
+  "langchain>=0.1.0, <0.3.0",  # TODO update all LLMChain class and remove upper bound
   "langchain-openai",
   "python-dotenv>=1.0.0",  # TODO decide env var management to see if we need this
   "vizro>=0.1.4",  # TODO set upper bound later
@@ -58,5 +58,8 @@ filterwarnings = [
   # Ignore until pandas is made compatible with Python 3.12:
   "ignore:.*utcfromtimestamp:DeprecationWarning",
   # Ignore until pandas 3 is released:
-  "ignore:(?s).*Pyarrow will become a required dependency of pandas:DeprecationWarning"
+  "ignore:(?s).*Pyarrow will become a required dependency of pandas:DeprecationWarning",
+  # TODO update all LLMChain class and remove this warning
+  # Ignore LLMchian deprecation warning:
+  "ignore:.*The class `LLMChain` was deprecated in LangChain 0.1.17"
 ]

--- a/vizro-ai/snyk/requirements.txt
+++ b/vizro-ai/snyk/requirements.txt
@@ -1,7 +1,7 @@
 pandas
 tabulate
 openai>=1.0.0
-langchain>=0.1.0
+langchain>=0.1.0, <0.3.0
 langchain-openai
 python-dotenv>=1.0.0
 vizro>=0.1.4

--- a/vizro-ai/src/vizro_ai/__init__.py
+++ b/vizro-ai/src/vizro_ai/__init__.py
@@ -9,6 +9,6 @@ from ._vizro_ai import VizroAI
 
 __all__ = ["VizroAI"]
 
-__version__ = "0.1.3.dev0"
+__version__ = "0.2.0.dev0"
 
 logging.basicConfig(level=os.getenv("VIZRO_AI_LOG_LEVEL", "INFO"))


### PR DESCRIPTION
## Description
- The class `LLMChain` is deprecated in LangChain 0.1.17 and will be removed in 0.3.0.  
- Now langchain is at 0.1.17 version so it's safe to pin upper bound and ignore warnings, given there would still be some time for 0.3.0 to be released.
- Here is a ticket created in backlog to resolve it and update LLMChain class:
update all vizro-ai base components for upper langchain version [#776](https://github.com/McK-Internal/vizro-internal/issues/776)


error msg in ci:
https://github.com/mckinsey/vizro/actions/runs/8910243758/job/24469126587
****
## Screenshot
<img width="883" alt="image" src="https://github.com/mckinsey/vizro/assets/115583997/af57b919-bf25-45ed-a34e-7f52e7bb1aa6">

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
