### PR TITLE
[Docs] Two small docs changes for improved usability

### DIFF
--- a/vizro-core/docs/index.md
+++ b/vizro-core/docs/index.md
@@ -38,7 +38,8 @@ Vizro is a toolkit for creating modular data visualization applications.
     ---
 
     [:octicons-arrow-right-24: How is Vizro different to Streamlit?](pages/explanation/faq/#how-does-vizro-differ-from-dash-or-streamlit) <br/>
-    [:octicons-arrow-right-24: Other FAQs](/pages/explanation/faq/)
+    [:octicons-arrow-right-24: Other FAQs](/pages/explanation/faq/) <br/>
+    [:octicons-arrow-right-24: Where can I ask a question?](pages/explanation/contributing/#got-a-vizro-question) <br/>
 
 
 

--- a/vizro-core/docs/pages/examples/examples.md
+++ b/vizro-core/docs/pages/examples/examples.md
@@ -23,3 +23,7 @@ The [`examples/features` folder](https://github.com/mckinsey/vizro/tree/main/viz
 !!! info "Ways to configure a dashboard"
 
     In most cases, the pydantic model should be your preferred method of dashboard configuration, but you can also [define a dashboard with YAML, JSON, or as a Python dictionary](../user-guides/dashboard.md).
+
+## Examples from Vizro users
+
+We maintain a separate, curated page of [videos, blog posts, and examples of Vizro usage from our community](./your-examples.md).

--- a/vizro-core/docs/pages/examples/examples.md
+++ b/vizro-core/docs/pages/examples/examples.md
@@ -29,4 +29,3 @@ The [`examples/features` folder](https://github.com/mckinsey/vizro/tree/main/viz
 ## Examples from Vizro users
 
 We maintain a separate, curated page of [videos, blog posts, and examples of Vizro usage from our community](your-examples.md).
-

--- a/vizro-core/docs/pages/examples/examples.md
+++ b/vizro-core/docs/pages/examples/examples.md
@@ -1,4 +1,6 @@
-# Vizro examples
+# Example dashboard code
+
+This page explains the dashboard code examples found in the `examples` folder of the [Vizro GitHub repository](https://github.com/mckinsey/vizro/tree/main/vizro-core/examples).
 
 ## Vizro live demo
 For an example of Vizro in action, take a look at the live demo running at [vizro.mckinsey.com](https://vizro.mckinsey.com), which uses the [Plotly gapminder data](https://plotly.com/python-api-reference/generated/plotly.express.data.html#plotly.express.data.gapminder).
@@ -27,3 +29,4 @@ The [`examples/features` folder](https://github.com/mckinsey/vizro/tree/main/viz
 ## Examples from Vizro users
 
 We maintain a separate, curated page of [videos, blog posts, and examples of Vizro usage from our community](your-examples.md).
+

--- a/vizro-core/docs/pages/explanation/contributing.md
+++ b/vizro-core/docs/pages/explanation/contributing.md
@@ -14,6 +14,8 @@ Splendid! To raise a feature request, head to our [issues page](https://github.c
 
 Nice! We are happy to receive general questions around Vizro. Take a look at our [issues page](https://github.com/mckinsey/vizro/issues) and raise a ticket in the category `general question`. We would be grateful if you could check for any similar descriptions in the existing issues before opening a new ticket.
 
+If you are already active on the Plotly Community Forum, you can alternatively ask your question over there in the [Dash Python category](https://community.plotly.com/c/python/25).
+
 ## How to interact with the repository
 
 The easiest way to get up and running is to [open the repository in GitHub Codespaces](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=626855142). This will create a temporary development environment with all the necessary configurations, making it especially convenient for tasks like reviewing pull requests.

--- a/vizro-core/docs/pages/explanation/contributing.md
+++ b/vizro-core/docs/pages/explanation/contributing.md
@@ -1,18 +1,18 @@
-## Contributing guidelines
+# Contributing guidelines
 
 Contributions of all experience levels are welcome! There are many ways to contribute, and we appreciate any help. Use our [issues page](https://github.com/mckinsey/vizro/issues) to discuss any contributions. Before opening a pull request, ensure you've first opened an issue to discuss the contribution.
 
-### Found a bug?
+## Found a bug?
 
-Great! We would appreciate if you could head to our [issues page](https://github.com/mckinsey/vizro/issues) and raise a ticket in the category `bug report`. It would help us if you could first check if there are any existing issues with a similar description before submitting a new ticket. We will try to reproduce the bug you've reported and follow up with the next steps.
+Head over to our [issues page](https://github.com/mckinsey/vizro/issues) and raise a ticket in the category `bug report`. It would help us if you could first check if there are any existing issues with a similar description before submitting a new ticket. We will try to reproduce the bug you've reported and follow up with the next steps.
 
-### Request a feature
+## Want to request a feature?
 
-Splendid! To raise a feature request, head to our [issues page](https://github.com/mckinsey/vizro/issues) and raise a ticket in the category `feature request`. We would appreciate if you searched the existing issues for a similar description before raising a new ticket. The team will then try to understand the request in more detail, explore the feasibility and prioritize it in relation to the current roadmap. We will get back to you as soon as possible with an estimate of whether and when this feature could be released.
+To raise a feature request, head to our [issues page](https://github.com/mckinsey/vizro/issues) and raise a ticket in the category `feature request`. We would appreciate if you searched the existing issues for a similar description before raising a new ticket. The team will then try to understand the request in more detail, explore the feasibility and prioritize it in relation to the current roadmap. We will get back to you as soon as possible with an estimate of whether and when this feature could be released.
 
-### General question
+## Got a Vizro question?
 
-Nice! We are happy to receive general questions around Vizro. Take a look at our [issues page](https://github.com/mckinsey/vizro/issues) and raise a ticket in the category `general question`. We would be grateful if you could check for any similar descriptions in the existing issues before opening a new ticket.
+We are happy to receive general questions around Vizro. Take a look at our [issues page](https://github.com/mckinsey/vizro/issues) and raise a ticket in the category `general question`. We would be grateful if you could check for any similar descriptions in the existing issues before opening a new ticket.
 
 If you are already active on the Plotly Community Forum, you can alternatively ask your question over there in the [Dash Python category](https://community.plotly.com/c/python/25).
 
@@ -36,17 +36,7 @@ We use [Hatch](https://hatch.pypa.io/) as a project management tool. To get star
 
 ---
 
-## Examples
-
-Several example dashboards are given in [examples](https://github.com/mckinsey/vizro/tree/main/vizro-core/examples). To run, for instance, the `features/yaml_version` example, execute:
-
-```console
-hatch run example features/yaml_version
-```
-
-If no example dashboard is specified (`hatch run example`) then the [example dashboard in `_dev`](https://github.com/mckinsey/vizro/tree/main/vizro-core/examples/_dev/app.py) is used.
-
-## Documentation
+## Contribute to documentation
 
 If you're modifying documentation, the following will do a hot-reloading build of the rendered docs:
 
@@ -181,7 +171,7 @@ To build the source distribution and wheel, run `hatch build`.
 
 The Vizro team pledges to foster and maintain a friendly community. We enforce a [Code of Conduct](https://github.com/mckinsey/vizro/tree/main/CODE_OF_CONDUCT.md) to ensure every Vizro contributor is welcomed and treated with respect.
 
-## Frequently asked questions
+## Frequently asked contribution questions
 
 <!-- vale off -->
 ### How do I add a dependency?

--- a/vizro-core/docs/pages/explanation/faq.md
+++ b/vizro-core/docs/pages/explanation/faq.md
@@ -35,7 +35,7 @@ We do not consider frontend changes (such as changing the appearance of a compon
 
 ## Where I can find example dashboards?
 
-Check out our [examples section](../examples/examples.md) which describes the contents of the `examples` folder of the [Vizro GitHub repository](https://github.com/mckinsey/vizro/tree/main/vizro-core/examples). 
+Check out our [examples section](../examples/examples.md) which describes the contents of the `examples` folder of the [Vizro GitHub repository](https://github.com/mckinsey/vizro/tree/main/vizro-core/examples).
 
 <!-- vale off -->
 ## Why should I use Vizro?

--- a/vizro-core/docs/pages/explanation/faq.md
+++ b/vizro-core/docs/pages/explanation/faq.md
@@ -11,10 +11,13 @@ Here are some answers to frequently asked questions:
 
 * [Which browsers does Vizro support?](#which-browsers-does-vizro-support)
 * [What is the Vizro versioning policy?](#what-is-the-vizro-versioning-policy)
+* [Where can I find example dashboards?](#where-i-can-find-example-dashboards)
 * [Why should I use Vizro?](#why-should-i-use-vizro)
 * [How does Vizro differ from Dash or Streamlit?](#how-does-vizro-differ-from-dash-or-streamlit)
 * [How does Vizro compare with Python packages and business intelligence (BI) tools?](#how-does-vizro-compare-with-python-packages-and-business-intelligence-bi-tools)
 * [When would an alternative to Vizro be more suitable?](#when-would-an-alternative-to-vizro-be-more-suitable)
+* [I want to contribute to Vizro, how can I find out more?](contributing.md)
+* [I still have a question. Where can I ask it?](contributing.md/#got-a-vizro-question)
 
 <!-- vale on -->
 
@@ -29,6 +32,10 @@ We do not consider frontend changes (such as changing the appearance of a compon
 !!! note
 
     While being in version `0.x.x`, we may introduce breaking changes in minor versions.
+
+## Where I can find example dashboards?
+
+Check out our [examples section](../examples/examples.md) which describes the contents of the `examples` folder of the [Vizro GitHub repository](https://github.com/mckinsey/vizro/tree/main/vizro-core/examples). 
 
 <!-- vale off -->
 ## Why should I use Vizro?

--- a/vizro-core/docs/pages/tutorials/first-dashboard.md
+++ b/vizro-core/docs/pages/tutorials/first-dashboard.md
@@ -2,7 +2,7 @@
 
 This is a short tutorial for you to create your first dashboard, showing you the basic setup so you can explore Vizro further.
 
-Once you've completed this tutorial, the following ["Explore Vizro" tutorial](./explore-components.md) creates a more complex dashboard so you can explore Vizro's features.
+Once you've completed this tutorial, the following ["Explore Vizro" tutorial](explore-components.md) creates a more complex dashboard so you can explore Vizro's features.
 
 
 ## Get started
@@ -87,4 +87,4 @@ Paste the following example into a Notebook cell, run it, and view the generated
 <!-- vale off -->
 ### 4. Explore further
 <!-- vale on -->
-You are now ready to explore Vizro further, by working through the ["Explore Vizro" tutorial](./explore-components.md) or by consulting the [how-to guides](../user-guides/dashboard.md).
+You are now ready to explore Vizro further, by working through the ["Explore Vizro" tutorial](explore-components.md) or by consulting the [how-to guides](../user-guides/dashboard.md).

--- a/vizro-core/mkdocs.yml
+++ b/vizro-core/mkdocs.yml
@@ -49,7 +49,7 @@ nav:
       - Documentation style: pages/explanation/documentation-style-guide.md
       - Authors: pages/explanation/authors.md
   - Examples:
-      - Examples: pages/examples/examples.md
+      - Example dashboard code: pages/examples/examples.md
       - Examples from Vizro users: pages/examples/your-examples.md
   - Vizro-AI:
       - Vizro-AI: https://vizro.readthedocs.io/projects/vizro-ai/en/latest/


### PR DESCRIPTION
## Description
Following discussion with @antonymilne 

* Add a link to the user examples from the main examples page, in case people don't spot the user examples page (which requires them to understand how the left hand nav works). By adding a section with a title, it brings it into the RHS table of contents, so more obvious.
* Add a mention of Plotly community forums. Have I got the right category @antonymilne ?
    * TBH that whole contribution guide needs a solid revision and I have this on my list, just not yet, so if it makes sense to do so, I can park this change for now and add it in later. Alternatively, we could put something about these forums behind a "Got a question?" link on the front page of the docs, and point straight through to the Plotly forums there, so it's really obvious. LMK if you'd like to try that and see how many queries get raised. 

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
