### PR TITLE
[Feat] Add new dcc.Loading features in dash 2.17

### DIFF
--- a/vizro-core/changelog.d/20240523_085359_amward_update_dcc_loading.md
+++ b/vizro-core/changelog.d/20240523_085359_amward_update_dcc_loading.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+
+### Changed
+
+- Made components visible with added opacity while loading.  Updated the minimum Dash version requirement to 2.17.0 to incorporate these new dcc.Loading features.  ([#487](https://github.com/mckinsey/vizro/pull/487))
+
+-->
+
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/changelog.d/20240523_085359_amward_update_dcc_loading.md
+++ b/vizro-core/changelog.d/20240523_085359_amward_update_dcc_loading.md
@@ -22,19 +22,18 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 - A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
 
 -->
-
+<!--
 ### Changed
 
-- Made components visible with added opacity while loading. Updated the minimum Dash version requirement to 2.17.0 to incorporate these new dcc.Loading features. ([#487](https://github.com/mckinsey/vizro/pull/487))
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
 
 -->
-
+<!--
 ### Deprecated
 
 - A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
 
 -->
-
 <!--
 ### Fixed
 

--- a/vizro-core/changelog.d/20240523_085359_amward_update_dcc_loading.md
+++ b/vizro-core/changelog.d/20240523_085359_amward_update_dcc_loading.md
@@ -25,7 +25,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Changed
 
-- Made components visible with added opacity while loading.  Updated the minimum Dash version requirement to 2.17.0 to incorporate these new dcc.Loading features.  ([#487](https://github.com/mckinsey/vizro/pull/487))
+- Made components visible with added opacity while loading. Updated the minimum Dash version requirement to 2.17.0 to incorporate these new dcc.Loading features. ([#487](https://github.com/mckinsey/vizro/pull/487))
 
 -->
 
@@ -34,6 +34,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 - A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
 
 -->
+
 <!--
 ### Fixed
 

--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -88,7 +88,7 @@ scripts = {lint = "SKIP=gitleaks pre-commit run {args:--all-files}"}
 [envs.lower-bounds]
 extra-dependencies = [
   "pydantic==1.10.13",
-  "dash==2.14.1"
+  "dash==2.17.0"
 ]
 
 [publish.index]

--- a/vizro-core/pyproject.toml
+++ b/vizro-core/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 dependencies = [
   # Temporarily set an upper limit on dash: https://github.com/plotly/dash/issues/2778
-  "dash>=2.17.0",  # 2.14.1 needed for compatibility with werkzeug
+  "dash>=2.17.0",  # 2.17.0 needed for new features on loading spinner
   "dash_bootstrap_components",
   "dash-ag-grid>=31.0.0",
   "pandas",

--- a/vizro-core/pyproject.toml
+++ b/vizro-core/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 dependencies = [
   # Temporarily set an upper limit on dash: https://github.com/plotly/dash/issues/2778
-  "dash>=2.14.1, !=2.16.0",  # 2.14.1 needed for compatibility with werkzeug
+  "dash>=2.17.0",  # 2.14.1 needed for compatibility with werkzeug
   "dash_bootstrap_components",
   "dash-ag-grid>=31.0.0",
   "pandas",

--- a/vizro-core/snyk/requirements.txt
+++ b/vizro-core/snyk/requirements.txt
@@ -1,4 +1,4 @@
-dash>=2.14.1, !=2.16.0
+dash>=2.17.0
 dash_bootstrap_components
 dash-ag-grid>=31.0.0
 pandas

--- a/vizro-core/src/vizro/models/_components/ag_grid.py
+++ b/vizro-core/src/vizro/models/_components/ag_grid.py
@@ -118,5 +118,5 @@ class AgGrid(VizroBaseModel):
             color="grey",
             parent_className="loading-container",
             delay_show=500,
-            overlay_style={"visibility": "visible", "filter": "blur(2px)"}
+            overlay_style={"visibility": "visible", "filter": "blur(2px)"},
         )

--- a/vizro-core/src/vizro/models/_components/ag_grid.py
+++ b/vizro-core/src/vizro/models/_components/ag_grid.py
@@ -117,7 +117,5 @@ class AgGrid(VizroBaseModel):
             ],
             color="grey",
             parent_className="loading-container",
-            delay_show=500,
-            delay_hide=500,
             overlay_style={"visibility": "visible", "opacity": 0.3},
         )

--- a/vizro-core/src/vizro/models/_components/ag_grid.py
+++ b/vizro-core/src/vizro/models/_components/ag_grid.py
@@ -117,4 +117,6 @@ class AgGrid(VizroBaseModel):
             ],
             color="grey",
             parent_className="loading-container",
+            delay_show=500,
+            overlay_style={"visibility": "visible", "filter": "blur(2px)"}
         )

--- a/vizro-core/src/vizro/models/_components/ag_grid.py
+++ b/vizro-core/src/vizro/models/_components/ag_grid.py
@@ -118,5 +118,6 @@ class AgGrid(VizroBaseModel):
             color="grey",
             parent_className="loading-container",
             delay_show=500,
+            delay_hide=500,
             overlay_style={"visibility": "visible", "filter": "blur(2px)"},
         )

--- a/vizro-core/src/vizro/models/_components/ag_grid.py
+++ b/vizro-core/src/vizro/models/_components/ag_grid.py
@@ -119,5 +119,5 @@ class AgGrid(VizroBaseModel):
             parent_className="loading-container",
             delay_show=500,
             delay_hide=500,
-            overlay_style={"visibility": "visible", "filter": "blur(2px)"},
+            overlay_style={"visibility": "visible", "opacity": 0.3},
         )

--- a/vizro-core/src/vizro/models/_components/graph.py
+++ b/vizro-core/src/vizro/models/_components/graph.py
@@ -136,8 +136,6 @@ class Graph(VizroBaseModel):
             ),
             color="grey",
             parent_className="loading-container",
-            delay_show=500,
-            delay_hide=500,
             overlay_style={"visibility": "visible", "opacity": 0.3},
         )
 

--- a/vizro-core/src/vizro/models/_components/graph.py
+++ b/vizro-core/src/vizro/models/_components/graph.py
@@ -136,6 +136,8 @@ class Graph(VizroBaseModel):
             ),
             color="grey",
             parent_className="loading-container",
+            delay_show=500,
+            overlay_style={"visibility": "visible", "filter": "blur(2px)"}
         )
 
     @staticmethod

--- a/vizro-core/src/vizro/models/_components/graph.py
+++ b/vizro-core/src/vizro/models/_components/graph.py
@@ -137,7 +137,6 @@ class Graph(VizroBaseModel):
             color="grey",
             parent_className="loading-container",
             delay_show=500,
-            overlay_style={"visibility": "visible", "filter": "blur(2px)"},
         )
 
     @staticmethod

--- a/vizro-core/src/vizro/models/_components/graph.py
+++ b/vizro-core/src/vizro/models/_components/graph.py
@@ -137,7 +137,7 @@ class Graph(VizroBaseModel):
             color="grey",
             parent_className="loading-container",
             delay_show=500,
-            overlay_style={"visibility": "visible", "filter": "blur(2px)"}
+            overlay_style={"visibility": "visible", "filter": "blur(2px)"},
         )
 
     @staticmethod

--- a/vizro-core/src/vizro/models/_components/graph.py
+++ b/vizro-core/src/vizro/models/_components/graph.py
@@ -137,6 +137,7 @@ class Graph(VizroBaseModel):
             color="grey",
             parent_className="loading-container",
             delay_show=500,
+            delay_hide=500,
         )
 
     @staticmethod

--- a/vizro-core/src/vizro/models/_components/graph.py
+++ b/vizro-core/src/vizro/models/_components/graph.py
@@ -138,6 +138,7 @@ class Graph(VizroBaseModel):
             parent_className="loading-container",
             delay_show=500,
             delay_hide=500,
+            overlay_style={"visibility": "visible", "opacity": 0.3},
         )
 
     @staticmethod

--- a/vizro-core/src/vizro/models/_components/table.py
+++ b/vizro-core/src/vizro/models/_components/table.py
@@ -118,5 +118,5 @@ class Table(VizroBaseModel):
             color="grey",
             parent_className="loading-container",
             delay_show=500,
-            overlay_style={"visibility": "visible", "filter": "blur(2px)"}
+            overlay_style={"visibility": "visible", "filter": "blur(2px)"},
         )

--- a/vizro-core/src/vizro/models/_components/table.py
+++ b/vizro-core/src/vizro/models/_components/table.py
@@ -118,5 +118,6 @@ class Table(VizroBaseModel):
             color="grey",
             parent_className="loading-container",
             delay_show=500,
+            delay_hide=500,
             overlay_style={"visibility": "visible", "filter": "blur(2px)"},
         )

--- a/vizro-core/src/vizro/models/_components/table.py
+++ b/vizro-core/src/vizro/models/_components/table.py
@@ -117,7 +117,5 @@ class Table(VizroBaseModel):
             ),
             color="grey",
             parent_className="loading-container",
-            delay_show=500,
-            delay_hide=500,
             overlay_style={"visibility": "visible", "opacity": 0.3},
         )

--- a/vizro-core/src/vizro/models/_components/table.py
+++ b/vizro-core/src/vizro/models/_components/table.py
@@ -117,4 +117,6 @@ class Table(VizroBaseModel):
             ),
             color="grey",
             parent_className="loading-container",
+            delay_show=500,
+            overlay_style={"visibility": "visible", "filter": "blur(2px)"}
         )

--- a/vizro-core/src/vizro/models/_components/table.py
+++ b/vizro-core/src/vizro/models/_components/table.py
@@ -119,5 +119,5 @@ class Table(VizroBaseModel):
             parent_className="loading-container",
             delay_show=500,
             delay_hide=500,
-            overlay_style={"visibility": "visible", "filter": "blur(2px)"},
+            overlay_style={"visibility": "visible", "opacity": 0.3},
         )

--- a/vizro-core/tests/unit/vizro/models/_components/test_ag_grid.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_ag_grid.py
@@ -149,6 +149,7 @@ class TestBuildAgGrid:
             ],
             color="grey",
             parent_className="loading-container",
+            overlay_style={"visibility": "visible", "opacity": 0.3},
         )
 
         assert_component_equal(ag_grid, expected_ag_grid)

--- a/vizro-core/tests/unit/vizro/models/_components/test_ag_grid.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_ag_grid.py
@@ -127,6 +127,7 @@ class TestBuildAgGrid:
             ],
             color="grey",
             parent_className="loading-container",
+            overlay_style={"visibility": "visible", "opacity": 0.3},
         )
 
         assert_component_equal(ag_grid, expected_ag_grid)

--- a/vizro-core/tests/unit/vizro/models/_components/test_graph.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_graph.py
@@ -154,5 +154,6 @@ class TestBuild:
             ),
             color="grey",
             parent_className="loading-container",
+            overlay_style={"visibility": "visible", "opacity": 0.3},
         )
         assert_component_equal(graph, expected_graph)

--- a/vizro-core/tests/unit/vizro/models/_components/test_table.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_table.py
@@ -146,6 +146,7 @@ class TestBuildTable:
             ),
             color="grey",
             parent_className="loading-container",
+            overlay_style={"visibility": "visible", "opacity": 0.3},
         )
 
         assert_component_equal(table, expected_table)

--- a/vizro-core/tests/unit/vizro/models/_components/test_table.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_table.py
@@ -127,6 +127,7 @@ class TestBuildTable:
             ),
             color="grey",
             parent_className="loading-container",
+            overlay_style={"visibility": "visible", "opacity": 0.3},
         )
 
         assert_component_equal(table, expected_table)

--- a/vizro-core/tests/unit/vizro/tables/test_dash_ag_grid.py
+++ b/vizro-core/tests/unit/vizro/tables/test_dash_ag_grid.py
@@ -81,6 +81,7 @@ class TestCustomDashAgGrid:
             ],
             color="grey",
             parent_className="loading-container",
+            overlay_style={"visibility": "visible", "opacity": 0.3},
         )
 
         assert_component_equal(custom_grid, expected_grid)
@@ -118,6 +119,7 @@ class TestCustomDashAgGrid:
             ],
             color="grey",
             parent_className="loading-container",
+            overlay_style={"visibility": "visible", "opacity": 0.3},
         )
 
         assert_component_equal(custom_grid, expected_grid)

--- a/vizro-core/tests/unit/vizro/tables/test_dash_table.py
+++ b/vizro-core/tests/unit/vizro/tables/test_dash_table.py
@@ -89,6 +89,7 @@ class TestCustomDashDataTable:
             ),
             color="grey",
             parent_className="loading-container",
+            overlay_style={"visibility": "visible", "opacity": 0.3},
         )
 
         assert_component_equal(custom_table, expected_table)
@@ -132,6 +133,7 @@ class TestCustomDashDataTable:
             ),
             color="grey",
             parent_className="loading-container",
+            overlay_style={"visibility": "visible", "opacity": 0.3},
         )
 
         assert_component_equal(custom_table, expected_table)


### PR DESCRIPTION
## Description

Closes #486 

This PR is a quick demo of a couple new features in dcc.Loading available in dash 2.17. This is just to make it easier to see how it it might work in Vizro apps.

It adds 
- `delay_show=500` to reduce the flickering on short loading times
- `overlay_style={"visibility": "visible", "filter": "blur(2px)"}` as an example of styling the  background.

I'm interested to hear what you think!


## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
