### PR TITLE
[Docs]fix vizro ai doc links

### DIFF
--- a/vizro-ai/changelog.d/20240522_095814_anna_xiong_vizro_ai_faq_links.md
+++ b/vizro-ai/changelog.d/20240522_095814_anna_xiong_vizro_ai_faq_links.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-ai/docs/pages/explanation/disclaimer.md
+++ b/vizro-ai/docs/pages/explanation/disclaimer.md
@@ -1,6 +1,6 @@
 # Disclaimer
 
-Users must select one of the [supported large language models (LLMs)](./faq.md#which-llms-are-supported-by-vizro-ai) to use the `vizro_ai` package,
+Users must select one of the [supported large language models (LLMs)](../user-guides/customize-vizro-ai.md#supported-models) to use the `vizro_ai` package,
 and are responsible for obtaining their own suitable API key for the relevant model.
 
 <!-- vale off -->

--- a/vizro-ai/docs/pages/explanation/faq.md
+++ b/vizro-ai/docs/pages/explanation/faq.md
@@ -19,4 +19,4 @@ With thanks to Sam Bourton and Stephen Xu for sponsorship, inspiration and guida
 
 
 ## Which large language models are supported by vizro-ai?
-Please refer to [supported models](../user-guides/customize-vizro-ai.md#supported-models) in `vizro-ai` docs.
+Refer to [supported models](../user-guides/customize-vizro-ai.md#supported-models) in `vizro-ai` docs.

--- a/vizro-ai/docs/pages/explanation/faq.md
+++ b/vizro-ai/docs/pages/explanation/faq.md
@@ -16,3 +16,13 @@
 [Petar Pejovic](https://github.com/petar-qb).
 
 With thanks to Sam Bourton and Stephen Xu for sponsorship, inspiration and guidance, plus everyone else who helped to test, guide, support and encourage development.
+
+
+## Which llms are supported by vizro-ai?
+- `gpt-3.5-turbo` (default model)
+- `gpt-4-turbo` (recommended for best model performance)
+- `gpt-3.5-turbo-0125`
+- `gpt-3.5-turbo-1106`
+- `gpt-4-0613`
+- `gpt-4-1106-preview`
+- `gpt-3.5-turbo-0613` (to be deprecated on June 13, 2024)

--- a/vizro-ai/docs/pages/explanation/faq.md
+++ b/vizro-ai/docs/pages/explanation/faq.md
@@ -18,11 +18,5 @@
 With thanks to Sam Bourton and Stephen Xu for sponsorship, inspiration and guidance, plus everyone else who helped to test, guide, support and encourage development.
 
 
-## Which llms are supported by vizro-ai?
-- `gpt-3.5-turbo` (default model)
-- `gpt-4-turbo` (recommended for best model performance)
-- `gpt-3.5-turbo-0125`
-- `gpt-3.5-turbo-1106`
-- `gpt-4-0613`
-- `gpt-4-1106-preview`
-- `gpt-3.5-turbo-0613` (to be deprecated on June 13, 2024)
+## Which large language models are supported by vizro-ai?
+Please refer to [supported models](../user-guides/customize-vizro-ai.md#supported-models) in `vizro-ai` docs.

--- a/vizro-ai/docs/pages/user-guides/run-vizro-ai.md
+++ b/vizro-ai/docs/pages/user-guides/run-vizro-ai.md
@@ -6,7 +6,7 @@ This guide offers insights into different ways of running Vizro-AI code, includi
 To run Vizro-AI code in a Jupyter Notebook, create a new cell and execute the code below to render the described visualization. You should see the chart as output.
 
 ??? note "Note: API key"
-    Make sure you have followed the [LLM setup guide](../user-guides/install.md#large-language-model) and
+    Make sure you have followed the [LLM setup guide](../user-guides/install.md#set-up-access-to-a-large-language-model) and
     your api key is set up in a `.env` file in the same folder as your Notebook file (`.ipynb`).
 
 !!! example "Bar chart"


### PR DESCRIPTION
## Description
fix links missing in docs:

```
INFO    -  Doc file 'pages/explanation/disclaimer.md' contains a link './faq.md#which-llms-are-supported-by-vizro-ai', but the doc 'pages/explanation/faq.md' does not contain an anchor '#which-llms-are-supported-by-vizro-ai'.
INFO    -  Doc file 'pages/user-guides/run-vizro-ai.md' contains a link '../user-guides/install.md#large-language-model', but the doc 'pages/user-guides/install.md' does not contain an anchor '#large-language-model'.
```

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
