### PR TITLE
[CI] Fix changelog fragment check

### DIFF
--- a/.github/workflows/checks-vizro-ai.yml
+++ b/.github/workflows/checks-vizro-ai.yml
@@ -26,7 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+          # Use fetch-depth of 2 to enable the changelog fragment check, which only runs in a pull request, not on push.
+          # See https://stackoverflow.com/questions/74265821/get-modified-files-in-github-actions
+          fetch-depth: 2
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5
@@ -45,9 +47,11 @@ jobs:
       - name: Find changed files to see if changelog fragment needed
         id: changed-files
         if: ${{ github.event_name == 'pull_request' }}
+        # --no-renames is required so that an empty changelog file added in a release PR always counts as added rather
+        # than a renamed version of an already-existing empty changelog file.
         run: |
-          echo "changelog_fragment_added=$(git diff --name-only --diff-filter=A -r HEAD^1 HEAD -- 'changelog.d/*.md' | xargs)" >> $GITHUB_OUTPUT
-          echo "files_outside_docs_changed=$(git diff --name-only -r HEAD^1 HEAD -- ':!docs/*' | xargs)" >> $GITHUB_OUTPUT
+          echo "changelog_fragment_added=$(git diff --name-only --no-renames --diff-filter=A HEAD^1 HEAD -- 'changelog.d/*.md' | cat)" >> $GITHUB_OUTPUT
+          echo "files_outside_docs_changed=$(git diff --name-only HEAD^1 HEAD -- ':!docs' | cat)" >> $GITHUB_OUTPUT
 
       - name: Fail if changelog fragment needed and wasn't added
         if: ${{ steps.changed-files.outcome != 'skipped' && steps.changed-files.outputs.files_outside_docs_changed && !steps.changed-files.outputs.changelog_fragment_added}}

--- a/.github/workflows/checks-vizro-core.yml
+++ b/.github/workflows/checks-vizro-core.yml
@@ -26,7 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+          # Use fetch-depth of 2 to enable the changelog fragment check, which only runs in a pull request, not on push.
+          # See https://stackoverflow.com/questions/74265821/get-modified-files-in-github-actions
+          fetch-depth: 2
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5
@@ -48,9 +50,11 @@ jobs:
       - name: Find changed files to see if changelog fragment needed
         id: changed-files
         if: ${{ github.event_name == 'pull_request' }}
+        # --no-renames is required so that an empty changelog file added in a release PR always counts as added rather
+        # than a renamed version of an already-existing empty changelog file.
         run: |
-          echo "changelog_fragment_added=$(git diff --name-only --diff-filter=A -r HEAD^1 HEAD -- 'changelog.d/*.md' | xargs)" >> $GITHUB_OUTPUT
-          echo "files_outside_docs_changed=$(git diff --name-only -r HEAD^1 HEAD -- ':!docs/*' | xargs)" >> $GITHUB_OUTPUT
+          echo "changelog_fragment_added=$(git diff --name-only --no-renames --diff-filter=A HEAD^1 HEAD -- 'changelog.d/*.md' | cat)" >> $GITHUB_OUTPUT
+          echo "files_outside_docs_changed=$(git diff --name-only HEAD^1 HEAD -- ':!docs' | cat)" >> $GITHUB_OUTPUT
 
       - name: Fail if changelog fragment needed and wasn't added
         if: ${{ steps.changed-files.outcome != 'skipped' && steps.changed-files.outputs.files_outside_docs_changed && !steps.changed-files.outputs.changelog_fragment_added}}

--- a/.github/workflows/lint-vizro-all.yml
+++ b/.github/workflows/lint-vizro-all.yml
@@ -22,8 +22,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5

--- a/.github/workflows/test-integration-vizro-ai.yml
+++ b/.github/workflows/test-integration-vizro-ai.yml
@@ -67,8 +67,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Description

https://github.com/mckinsey/vizro/pull/480 altered the "new changelog fragment added" check slightly, and this made the check fail in #502. This PR fixes it.

In short, the crucial change that broke the check was that I had added `'` in the command:
```
# before PR #480
git diff --name-only --diff-filter=A -r HEAD^1 HEAD -- changelog.d/*.md | xargs
# after PR #480
git diff --name-only --diff-filter=A -r HEAD^1 HEAD -- 'changelog.d/*.md' | xargs
```

Actually adding `'` _was the correct thing to do_, and the fact that it worked correctly before was a bit of an accident and very difficult to understand why. The overall correct command is this, which has `'` and `--no-renames`:

```
git diff --name-only --no-renames --diff-filter=A -r HEAD^1 HEAD -- 'changelog.d/*.md' | xargs
```

Tidying up a bit, I've now changed the command to this:
```
git diff --name-only --no-renames --diff-filter=A HEAD^1 HEAD -- 'changelog.d/*.md' | cat
```
since the `-r` is not required and using `cat` is more readable than `xargs`.

## More information - just for future reference or if you're really interested

Putting this here since it took a long time to fully understand the behaviour of what git was doing. Note that [GHA does the checkout as a detached head to simulate the merge process](https://stackoverflow.com/questions/74265821/get-modified-files-in-github-actions).

Initial setup to simulate the release PR:
```
➜ git checkout main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.

➜ hatch run changelog:add
Creating changelog.d/20240530_122258_antony.milne.md
Added changelog.d/20240530_122258_antony.milne.md

➜ git commit -m "Add empty changelog file"
[main 57c231e7] Add empty changelog file
 1 file changed, 48 insertions(+)
 create mode 100644 vizro-core/changelog.d/20240530_122258_antony.milne.md

➜ git checkout -b branch
Switched to a new branch 'branch'

➜ hatch run changelog:add
Creating changelog.d/20240530_122340_antony.milne_branch.md
Added changelog.d/20240530_122340_antony.milne_branch.md

➜ rm changelog.d/20240530_122258_antony.milne.md
```

Now look at the `git diff` of working tree compared to `main`. These all make sense because [git interprets the file deletion and creation process as a rename](https://stackoverflow.com/questions/15031576/how-can-i-prevent-git-from-thinking-i-did-a-rename). 

```
➜ git diff --summary main | cat
 rename vizro-core/changelog.d/{20240530_122258_antony.milne.md => 20240530_122340_antony.milne_branch.md} (100%)

➜ git diff --summary main -- changelog.d | cat
 rename vizro-core/changelog.d/{20240530_122258_antony.milne.md => 20240530_122340_antony.milne_branch.md} (100%)

➜ git diff --summary main -- 'changelog.d/*.md' | cat
 rename vizro-core/changelog.d/{20240530_122258_antony.milne.md => 20240530_122340_antony.milne_branch.md} (100%)
```

But this one without the quote marks is not what we want. The `*` gets interpreted by the shell rather than pathspec in `git diff` so it doesn't do the same as the above. This doesn't do what it looks like it should because what acts like path filtering above is in fact running a different command and not filtering the result - it's kind of creating something from nothing. It thinks the rename process is a file creation, which is why the command before #480 worked, but that was fortunate rather than intentional (and not consistent with using pathspec correctly in `'` in the subsequent `files_outside_docs_changed` check). 

```
➜ git diff --summary main -- changelog.d/*.md | cat
 create mode 100644 vizro-core/changelog.d/20240530_122340_antony.milne_branch.md
```

When we add `--no-rename` so that git interpets the file creation as a creation and not renaming, the above commands act like this:

```
➜ git diff --summary --no-renames main | cat
 delete mode 100644 vizro-core/changelog.d/20240530_122258_antony.milne.md
 create mode 100644 vizro-core/changelog.d/20240530_122340_antony.milne_branch.md

➜ git diff --summary --no-renames main -- changelog.d | cat
 delete mode 100644 vizro-core/changelog.d/20240530_122258_antony.milne.md
 create mode 100644 vizro-core/changelog.d/20240530_122340_antony.milne_branch.md

➜ git diff --summary --no-renames main -- 'changelog.d/*.md' | cat
 delete mode 100644 vizro-core/changelog.d/20240530_122258_antony.milne.md
 create mode 100644 vizro-core/changelog.d/20240530_122340_antony.milne_branch.md
```

This is good because it means that the release PR will still be interpreted as having a changelog added and pathspec is working as intended (`*` gets interpreted by `git diff` and not prematurely).

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
