### PR TITLE
[CI] Fix changelog fragment check again

### DIFF
--- a/.github/workflows/checks-vizro-ai.yml
+++ b/.github/workflows/checks-vizro-ai.yml
@@ -50,8 +50,8 @@ jobs:
         # --no-renames is required so that an empty changelog file added in a release PR always counts as added rather
         # than a renamed version of an already-existing empty changelog file.
         run: |
-          echo "changelog_fragment_added=$(git diff --name-only --no-renames --diff-filter=A HEAD^1 HEAD -- 'changelog.d/*.md' | cat)" >> $GITHUB_OUTPUT
-          echo "files_outside_docs_changed=$(git diff --name-only HEAD^1 HEAD -- ':!docs' | cat)" >> $GITHUB_OUTPUT
+          echo "changelog_fragment_added=$(git diff --name-only --no-renames --diff-filter=A HEAD^1 HEAD -- 'changelog.d/*.md' | xargs)" >> $GITHUB_OUTPUT
+          echo "files_outside_docs_changed=$(git diff --name-only HEAD^1 HEAD -- ':!docs' | xargs)" >> $GITHUB_OUTPUT
 
       - name: Fail if changelog fragment needed and wasn't added
         if: ${{ steps.changed-files.outcome != 'skipped' && steps.changed-files.outputs.files_outside_docs_changed && !steps.changed-files.outputs.changelog_fragment_added}}

--- a/.github/workflows/checks-vizro-core.yml
+++ b/.github/workflows/checks-vizro-core.yml
@@ -53,8 +53,8 @@ jobs:
         # --no-renames is required so that an empty changelog file added in a release PR always counts as added rather
         # than a renamed version of an already-existing empty changelog file.
         run: |
-          echo "changelog_fragment_added=$(git diff --name-only --no-renames --diff-filter=A HEAD^1 HEAD -- 'changelog.d/*.md' | cat)" >> $GITHUB_OUTPUT
-          echo "files_outside_docs_changed=$(git diff --name-only HEAD^1 HEAD -- ':!docs' | cat)" >> $GITHUB_OUTPUT
+          echo "changelog_fragment_added=$(git diff --name-only --no-renames --diff-filter=A HEAD^1 HEAD -- 'changelog.d/*.md' | xargs)" >> $GITHUB_OUTPUT
+          echo "files_outside_docs_changed=$(git diff --name-only HEAD^1 HEAD -- ':!docs' | xargs)" >> $GITHUB_OUTPUT
 
       - name: Fail if changelog fragment needed and wasn't added
         if: ${{ steps.changed-files.outcome != 'skipped' && steps.changed-files.outputs.files_outside_docs_changed && !steps.changed-files.outputs.changelog_fragment_added}}


### PR DESCRIPTION
## Description

#503 swapped `xargs` for `cat` to be more readable, but that causes problems when sending the output to `GITHUB_OUTPUT` so I've changed that bit back.

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
