### PR TITLE
[CI] Fix docs build

### DIFF
--- a/vizro-ai/.readthedocs.yaml
+++ b/vizro-ai/.readthedocs.yaml
@@ -11,6 +11,8 @@ build:
     python: "3.11"
   commands:
     - pip install hatch
-    - cd vizro-ai/ && hatch run docs:build && hatch run docs:link-check
+    - cd vizro-ai/ && hatch run docs:pip freeze
+    - cd vizro-ai/ && hatch run docs:build
+    - cd vizro-ai/ && hatch run docs:link-check
     - mkdir --parents $READTHEDOCS_OUTPUT
     - mv vizro-ai/site/ $READTHEDOCS_OUTPUT/html

--- a/vizro-ai/changelog.d/20240619_105033_antony.milne_fix_docs.md
+++ b/vizro-ai/changelog.d/20240619_105033_antony.milne_fix_docs.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-ai/hatch.toml
+++ b/vizro-ai/hatch.toml
@@ -49,6 +49,7 @@ dependencies = [
   "mkdocs-material",
   "mkdocs-git-revision-date-localized-plugin",
   "mkdocstrings[python]",
+  "mkdocstrings-python<1.10.4",
   "linkchecker"
 ]
 detached = true

--- a/vizro-ai/hatch.toml
+++ b/vizro-ai/hatch.toml
@@ -58,7 +58,7 @@ build = "mkdocs build --strict"
 # Disable warnings on the linkcheck so that HTTP redirects are accepted. We could ignore only that warning and specify
 # more advanced settings using a linkcheckerrc config file. openai.com doesn't seem to work well with linkchecking,
 # throwing 403 errors, but these are not real errors.
-link-check = "linkchecker site --check-extern --no-warnings --ignore=404.html --ignore-url=127.0.0.1 --ignore-url=https://platform.openai.com/docs/models --ignore-url=openai.com --ignore-url=https://openai.com/"
+link-check = "linkchecker site --check-extern --no-warnings --ignore=404.html --ignore-url=127.0.0.1 --ignore-url=https://vizro.readthedocs.io/ --ignore-url=https://platform.openai.com/docs/models --ignore-url=openai.com --ignore-url=https://openai.com/"
 serve = "mkdocs serve --strict"
 
 [envs.lint]

--- a/vizro-core/.readthedocs.yaml
+++ b/vizro-core/.readthedocs.yaml
@@ -11,7 +11,6 @@ build:
     python: "3.11"
   commands:
     - pip install hatch
-    - hatch run docs:pip freeze
-    - cd vizro-core/ && hatch run docs:build && hatch run docs:link-check
+    - cd vizro-core/ && hatch run docs:pip freeze && hatch run docs:build && hatch run docs:link-check
     - mkdir --parents $READTHEDOCS_OUTPUT
     - mv vizro-core/site/ $READTHEDOCS_OUTPUT/html

--- a/vizro-core/.readthedocs.yaml
+++ b/vizro-core/.readthedocs.yaml
@@ -11,6 +11,8 @@ build:
     python: "3.11"
   commands:
     - pip install hatch
-    - cd vizro-core/ && hatch run docs:pip freeze && hatch run docs:build && hatch run docs:link-check
+    - cd vizro-core/ && hatch run docs:pip freeze
+    - cd vizro-core/ && hatch run docs:build
+    - cd vizro-core/ && hatch run docs:link-check
     - mkdir --parents $READTHEDOCS_OUTPUT
     - mv vizro-core/site/ $READTHEDOCS_OUTPUT/html

--- a/vizro-core/.readthedocs.yaml
+++ b/vizro-core/.readthedocs.yaml
@@ -11,6 +11,7 @@ build:
     python: "3.11"
   commands:
     - pip install hatch
+    - hatch run docs:pip freeze
     - cd vizro-core/ && hatch run docs:build && hatch run docs:link-check
     - mkdir --parents $READTHEDOCS_OUTPUT
     - mv vizro-core/site/ $READTHEDOCS_OUTPUT/html

--- a/vizro-core/changelog.d/20240619_102218_antony.milne_fix_docs.md
+++ b/vizro-core/changelog.d/20240619_102218_antony.milne_fix_docs.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -68,6 +68,7 @@ dependencies = [
   "mkdocs-material",
   "mkdocs-git-revision-date-localized-plugin",
   "mkdocstrings[python]",
+  "mkdocstrings-python < 1.10.4",
   "linkchecker"
 ]
 detached = true

--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -68,7 +68,7 @@ dependencies = [
   "mkdocs-material",
   "mkdocs-git-revision-date-localized-plugin",
   "mkdocstrings[python]",
-  "mkdocstrings-python < 1.10.4",
+  "mkdocstrings-python<1.10.4",
   "linkchecker"
 ]
 detached = true

--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -77,7 +77,7 @@ detached = true
 build = "mkdocs build --strict"
 # Disable warnings on the linkcheck so that HTTP redirects are accepted. We could ignore only that warning and specify
 # more advanced settings using a linkcheckerrc config file.
-link-check = "linkchecker site --check-extern --no-warnings --ignore=404.html --ignore-url=127.0.0.1"
+link-check = "linkchecker site --check-extern --no-warnings --ignore=404.html --ignore-url=127.0.0.1 --ignore-url=https://vizro.readthedocs.io/"
 serve = "mkdocs serve --strict"
 
 [envs.lint]


### PR DESCRIPTION
## Description

Pin `mkdocstrings-python<1.10.4` since 1.1.0.4 (and probably future versions) seems to break our docs build. See e.g. https://readthedocs.org/projects/vizro/builds/24734796/
```
WARNING -  mkdocs_autorefs: pages/API-reference/captured-callables.md: Could not find cross-reference target '[vizro.models.AgGrid]'
```

Probably this is to do with the first point here on their release notes: https://github.com/mkdocstrings/python/releases/tag/1.10.4.

I'll make a ticket to investigate further and unpin.

Also:
* Add `pip freeze` stage to docs builds to make debugging easier
* Cherrypick the `--ignore-url` change from [ea5cf95](https://github.com/mckinsey/vizro/pull/524/commits/ea5cf959d3ae17584fe1e95e1bc7a37c3e0fbfee) to merge it sooner because it's already blocking us

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
