### PR TITLE
Ignored unexpected query parameters rather than raising an exception

### DIFF
--- a/vizro-core/src/vizro/models/_dashboard.py
+++ b/vizro-core/src/vizro/models/_dashboard.py
@@ -246,7 +246,7 @@ class Dashboard(VizroBaseModel):
         page_main = html.Div(id="page-main", children=[collapsable_left_side, collapsable_icon, right_side])
         return html.Div(children=[page_header, page_main], className="page-container")
 
-    def _make_page_layout(self, page: Page):
+    def _make_page_layout(self, page: Page, **kwargs):
         page_divs = self._get_page_divs(page=page)
         page_layout = self._arrange_page_divs(page_divs=page_divs)
         page_layout.id = page.id


### PR DESCRIPTION
## Description

**Before**
Going to http://localhost:8050/?species=virginica would raise error:
```
TypeError: Dashboard._make_page_layout() got an unexpected keyword argument 'species'
```

**Now**
The query parameter is just ignored.

This is the solution recommended in https://github.com/AnnMarieW/dash-multi-page-app-demos/?tab=readme-ov-file#5-preventing-query-string-errors. it doesn't prevent us from using query parameters in the future (very likely to do so) and is consistent with behaviour if `layout` is no longer a function at some point in the future (not so likely).

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
