### PR TITLE
Remove unused dependency from vizro_ai

### DIFF
--- a/vizro-ai/changelog.d/20240621_204959_lingyi_zhang_remove_langchain_community.md
+++ b/vizro-ai/changelog.d/20240621_204959_lingyi_zhang_remove_langchain_community.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-ai/hatch.toml
+++ b/vizro-ai/hatch.toml
@@ -16,7 +16,8 @@ dependencies = [
   "toml",
   "nbformat>=4.2.0",
   "pyhamcrest",
-  "jupyter"
+  "jupyter",
+  "langchain_community"
 ]
 
 [envs.default.env-vars]

--- a/vizro-ai/pyproject.toml
+++ b/vizro-ai/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
   "ipython>=8.10.0",  # not directly required, pinned by Snyk to avoid a vulnerability: https://app.snyk.io/vuln/SNYK-PYTHON-IPYTHON-3318382
   "urllib3>=2.0.7",  # not directly required, pinned by Snyk to avoid a vulnerability: https://security.snyk.io/vuln/SNYK-PYTHON-URLLIB3-6002459
   "aiohttp>=3.9.2",  # not directly required, pinned by Snyk to avoid a vulnerability: https://security.snyk.io/vuln/SNYK-PYTHON-AIOHTTP-6209407
-  "langchain-community>=0.0.27",  # not directly required, pinned by Snyk to avoid a vulnerability: https://security.snyk.io/vuln/SNYK-PYTHON-LANGCHAINCOMMUNITY-6421036
   "langchain-core>=0.1.31"  # not directly required, pinned by Snyk to avoid a vulnerability: https://security.snyk.io/vuln/SNYK-PYTHON-LANGCHAINCORE-6370598
 ]
 description = "Vizro-AI is a tool for generating data visualizations"

--- a/vizro-ai/snyk/requirements.txt
+++ b/vizro-ai/snyk/requirements.txt
@@ -8,5 +8,4 @@ vizro>=0.1.4
 ipython>=8.10.0
 urllib3>=2.0.7
 aiohttp>=3.9.2
-langchain-community>=0.0.27
 langchain-core>=0.1.31

--- a/vizro-ai/tests/unit/vizro-ai/components/test_chart_selection.py
+++ b/vizro-ai/tests/unit/vizro-ai/components/test_chart_selection.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import pytest
-from langchain.llms.fake import FakeListLLM
+from langchain_community.llms.fake import FakeListLLM
 from vizro_ai.components import GetChartSelection
 
 

--- a/vizro-ai/tests/unit/vizro-ai/components/test_code_validation.py
+++ b/vizro-ai/tests/unit/vizro-ai/components/test_code_validation.py
@@ -1,5 +1,5 @@
 import pytest
-from langchain.llms.fake import FakeListLLM
+from langchain_community.llms.fake import FakeListLLM
 from vizro_ai.components import GetDebugger
 
 

--- a/vizro-ai/tests/unit/vizro-ai/components/test_custom_chart_wrap.py
+++ b/vizro-ai/tests/unit/vizro-ai/components/test_custom_chart_wrap.py
@@ -1,5 +1,5 @@
 import pytest
-from langchain.llms.fake import FakeListLLM
+from langchain_community.llms.fake import FakeListLLM
 from vizro_ai.components import GetCustomChart
 
 

--- a/vizro-ai/tests/unit/vizro-ai/components/test_dataframe_craft.py
+++ b/vizro-ai/tests/unit/vizro-ai/components/test_dataframe_craft.py
@@ -2,7 +2,7 @@ import re
 
 import pandas as pd
 import pytest
-from langchain.llms.fake import FakeListLLM
+from langchain_community.llms.fake import FakeListLLM
 from vizro_ai.components import GetDataFrameCraft
 
 

--- a/vizro-ai/tests/unit/vizro-ai/components/test_explanation.py
+++ b/vizro-ai/tests/unit/vizro-ai/components/test_explanation.py
@@ -1,5 +1,5 @@
 import pytest
-from langchain.llms.fake import FakeListLLM
+from langchain_community.llms.fake import FakeListLLM
 from vizro_ai.components import GetCodeExplanation
 
 

--- a/vizro-ai/tests/unit/vizro-ai/components/test_visual_code.py
+++ b/vizro-ai/tests/unit/vizro-ai/components/test_visual_code.py
@@ -1,5 +1,5 @@
 import pytest
-from langchain.llms.fake import FakeListLLM
+from langchain_community.llms.fake import FakeListLLM
 from vizro_ai.components import GetVisualCode
 
 


### PR DESCRIPTION
## Description
`langchain` is not dependent on `langchain-community` anymore since v0.2, and `langchain-community` is not a dependency of vizro_ai.

https://github.com/langchain-ai/langchain/discussions/19083

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
