### PR TITLE
[Tidy] Improve `reference_format` of `kpi_card_reference`

### DIFF
--- a/vizro-core/changelog.d/20240626_165216_huong_li_nguyen_add_sign_kpi_card.md
+++ b/vizro-core/changelog.d/20240626_165216_huong_li_nguyen_add_sign_kpi_card.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/changelog.d/20240626_165216_huong_li_nguyen_add_sign_kpi_card.md
+++ b/vizro-core/changelog.d/20240626_165216_huong_li_nguyen_add_sign_kpi_card.md
@@ -22,12 +22,11 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 - A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
 
 -->
-<!--
+
 ### Changed
 
-- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+- Include sign in default `reference_format` of `kpi_card_reference`. ([#549](https://github.com/mckinsey/vizro/pull/549))
 
--->
 <!--
 ### Deprecated
 

--- a/vizro-core/examples/_dev/app.py
+++ b/vizro-core/examples/_dev/app.py
@@ -46,7 +46,7 @@ example_reference_cards = [
         reference_column="Actual",
         title="Delta Zero",
         value_format="{value:.2f}$",
-        reference_format="{delta:.2f}$ vs. last year ({reference:.2f}$)",
+        reference_format="{delta:+.2f}$ vs. last year ({reference:.2f}$)",
     ),
     kpi_card_reference(
         data_frame=df_kpi,

--- a/vizro-core/src/vizro/figures/kpi_cards.py
+++ b/vizro-core/src/vizro/figures/kpi_cards.py
@@ -72,7 +72,7 @@ def kpi_card_reference(  # noqa: PLR0913
     reference_column: str,
     *,
     value_format: str = "{value}",
-    reference_format: str = "{delta_relative:.1%} vs. reference ({reference})",
+    reference_format: str = "{delta_relative:+.1%} vs. reference ({reference})",
     agg_func: str = "sum",
     title: Optional[str] = None,
     icon: Optional[str] = None,

--- a/vizro-core/tests/unit/vizro/figures/test_kpi_cards.py
+++ b/vizro-core/tests/unit/vizro/figures/test_kpi_cards.py
@@ -79,7 +79,7 @@ class TestKPICardReference:
                 dbc.CardFooter(
                     [
                         html.Span("arrow_circle_up", className="material-symbols-outlined"),
-                        html.Span("100.0% vs. reference (6)"),
+                        html.Span("+100.0% vs. reference (6)"),
                     ],
                     className="color-pos",
                 ),
@@ -97,7 +97,7 @@ class TestKPICardReference:
                 dbc.CardFooter(
                     [
                         html.Span("arrow_circle_right", className="material-symbols-outlined"),
-                        html.Span("0.0% vs. reference (6)"),
+                        html.Span("+0.0% vs. reference (6)"),
                     ],
                     className="",
                 ),
@@ -115,7 +115,7 @@ class TestKPICardReference:
                 dbc.CardFooter(
                     [
                         html.Span("arrow_circle_up", className="material-symbols-outlined"),
-                        html.Span("nan% vs. reference (0)"),
+                        html.Span("+nan% vs. reference (0)"),
                     ],
                     className="color-pos",
                 ),


### PR DESCRIPTION
## Description
- Improve `reference_format` of `kpi_card_reference` by showing + sign in case positive delta

## Screenshot
![Screenshot 2024-06-26 at 16 50 31](https://github.com/mckinsey/vizro/assets/90609403/5d1b8dbd-5354-455a-9888-5ac76281d30d)

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
