### PR TITLE
[Tidy] Use BaseChatModel for type hint

### DIFF
--- a/vizro-ai/changelog.d/20240627_003947_lingyi_zhang_use_basechatmodel.md
+++ b/vizro-ai/changelog.d/20240627_003947_lingyi_zhang_use_basechatmodel.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-ai/src/vizro_ai/chains/_llm_chain.py
+++ b/vizro-ai/src/vizro_ai/chains/_llm_chain.py
@@ -8,8 +8,7 @@ from langchain.chains import LLMChain
 from langchain.prompts import PromptTemplate
 from langchain.schema import ChatGeneration, Generation
 from langchain.schema.messages import AIMessage
-
-from vizro_ai.chains._llm_models import LLM_MODELS
+from langchain_core.language_models.chat_models import BaseChatModel
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +37,7 @@ class FunctionCallChain(VizroBaseChain, ABC):
 
     def __init__(  # noqa: PLR0913
         self,
-        llm: LLM_MODELS,
+        llm: BaseChatModel,
         raw_prompt: str,
         partial_vars_map: Optional[Dict[Any, Any]] = None,
         llm_kwargs: Optional[Dict[str, Any]] = None,

--- a/vizro-ai/src/vizro_ai/chains/_llm_models.py
+++ b/vizro-ai/src/vizro_ai/chains/_llm_models.py
@@ -1,12 +1,10 @@
 from typing import Dict, Optional, Union
 
+from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_openai import ChatOpenAI
 
-# TODO add new wrappers in if new model support is added
-LLM_MODELS = Union[ChatOpenAI]
-
 # TODO constant of model inventory, can be converted to yaml and link to docs
-PREDEFINED_MODELS: Dict[str, Dict[str, Union[int, LLM_MODELS]]] = {
+PREDEFINED_MODELS: Dict[str, Dict[str, Union[int, BaseChatModel]]] = {
     "gpt-3.5-turbo-0613": {
         "max_tokens": 4096,
         "wrapper": ChatOpenAI,
@@ -41,7 +39,7 @@ DEFAULT_MODEL = "gpt-3.5-turbo"
 DEFAULT_TEMPERATURE = 0
 
 
-def _get_llm_model(model: Optional[Union[ChatOpenAI, str]] = None) -> LLM_MODELS:
+def _get_llm_model(model: Optional[Union[ChatOpenAI, str]] = None) -> BaseChatModel:
     """Fetches and initializes an instance of the LLM.
 
     Args:

--- a/vizro-ai/src/vizro_ai/components/_base.py
+++ b/vizro-ai/src/vizro_ai/components/_base.py
@@ -1,8 +1,9 @@
 from abc import ABC, abstractmethod
 from typing import Dict, Tuple, Union
 
+from langchain_core.language_models.chat_models import BaseChatModel
+
 from vizro_ai.chains import FunctionCallChain
-from vizro_ai.chains._llm_models import LLM_MODELS
 
 
 class VizroAiComponentBase(ABC):
@@ -22,7 +23,7 @@ class VizroAiComponentBase(ABC):
 
     prompt: str = "default prompt place holder"
 
-    def __init__(self, llm: LLM_MODELS):
+    def __init__(self, llm: BaseChatModel):
         """Initialize Vizro-AI base component.
 
         Args:

--- a/vizro-ai/src/vizro_ai/components/chart_selection.py
+++ b/vizro-ai/src/vizro_ai/components/chart_selection.py
@@ -9,8 +9,9 @@ try:
 except ImportError:  # pragma: no cov
     from pydantic import BaseModel, Field
 
+from langchain_core.language_models.chat_models import BaseChatModel
+
 from vizro_ai.chains._chain_utils import _log_time
-from vizro_ai.chains._llm_models import LLM_MODELS
 from vizro_ai.components import VizroAiComponentBase
 from vizro_ai.schema_manager import SchemaManager
 
@@ -48,7 +49,7 @@ class GetChartSelection(VizroAiComponentBase):
 
     prompt: str = chart_type_prompt
 
-    def __init__(self, llm: LLM_MODELS):
+    def __init__(self, llm: BaseChatModel):
         """Initialization of Chart Selection components.
 
         Args:

--- a/vizro-ai/src/vizro_ai/components/code_validation.py
+++ b/vizro-ai/src/vizro_ai/components/code_validation.py
@@ -8,8 +8,9 @@ try:
 except ImportError:  # pragma: no cov
     from pydantic import BaseModel, Field
 
+from langchain_core.language_models.chat_models import BaseChatModel
+
 from vizro_ai.chains._chain_utils import _log_time
-from vizro_ai.chains._llm_models import LLM_MODELS
 from vizro_ai.components import VizroAiComponentBase
 from vizro_ai.schema_manager import SchemaManager
 
@@ -44,7 +45,7 @@ class GetDebugger(VizroAiComponentBase):
 
     prompt: str = debugging_prompt
 
-    def __init__(self, llm: LLM_MODELS):
+    def __init__(self, llm: BaseChatModel):
         """Initialization of Chart Selection components.
 
         Args:

--- a/vizro-ai/src/vizro_ai/components/custom_chart_wrap.py
+++ b/vizro-ai/src/vizro_ai/components/custom_chart_wrap.py
@@ -8,8 +8,9 @@ try:
 except ImportError:  # pragma: no cov
     from pydantic import BaseModel, Field
 
+from langchain_core.language_models.chat_models import BaseChatModel
+
 from vizro_ai.chains._chain_utils import _log_time
-from vizro_ai.chains._llm_models import LLM_MODELS
 from vizro_ai.components import VizroAiComponentBase
 from vizro_ai.schema_manager import SchemaManager
 
@@ -48,7 +49,7 @@ class GetCustomChart(VizroAiComponentBase):
 
     prompt: str = custom_chart_prompt
 
-    def __init__(self, llm: LLM_MODELS):
+    def __init__(self, llm: BaseChatModel):
         """Initialization of custom chart components.
 
         Args:

--- a/vizro-ai/src/vizro_ai/components/dataframe_craft.py
+++ b/vizro-ai/src/vizro_ai/components/dataframe_craft.py
@@ -11,8 +11,9 @@ try:
 except ImportError:  # pragma: no cov
     from pydantic import BaseModel, Field
 
+from langchain_core.language_models.chat_models import BaseChatModel
+
 from vizro_ai.chains._chain_utils import _log_time
-from vizro_ai.chains._llm_models import LLM_MODELS
 from vizro_ai.components import VizroAiComponentBase
 from vizro_ai.schema_manager import SchemaManager
 
@@ -51,7 +52,7 @@ class GetDataFrameCraft(VizroAiComponentBase):
 
     prompt: str = dataframe_prompt
 
-    def __init__(self, llm: LLM_MODELS):
+    def __init__(self, llm: BaseChatModel):
         """Initialization of dataframe crafting components.
 
         Args:

--- a/vizro-ai/src/vizro_ai/components/explanation.py
+++ b/vizro-ai/src/vizro_ai/components/explanation.py
@@ -7,8 +7,9 @@ try:
 except ImportError:  # pragma: no cov
     from pydantic import BaseModel, Field
 
+from langchain_core.language_models.chat_models import BaseChatModel
+
 from vizro_ai.chains._chain_utils import _log_time
-from vizro_ai.chains._llm_models import LLM_MODELS
 from vizro_ai.components import VizroAiComponentBase
 from vizro_ai.schema_manager import SchemaManager
 
@@ -44,7 +45,7 @@ class GetCodeExplanation(VizroAiComponentBase):
 
     prompt: str = code_explanation_prompt
 
-    def __init__(self, llm: LLM_MODELS):
+    def __init__(self, llm: BaseChatModel):
         """Initialization of Code Explanation components.
 
         Args:

--- a/vizro-ai/src/vizro_ai/components/visual_code.py
+++ b/vizro-ai/src/vizro_ai/components/visual_code.py
@@ -7,8 +7,9 @@ try:
 except ImportError:  # pragma: no cov
     from pydantic import BaseModel, Field
 
+from langchain_core.language_models.chat_models import BaseChatModel
+
 from vizro_ai.chains._chain_utils import _log_time
-from vizro_ai.chains._llm_models import LLM_MODELS
 from vizro_ai.components import VizroAiComponentBase
 from vizro_ai.schema_manager import SchemaManager
 
@@ -43,7 +44,7 @@ class GetVisualCode(VizroAiComponentBase):
 
     prompt: str = visual_code_prompt
 
-    def __init__(self, llm: LLM_MODELS):
+    def __init__(self, llm: BaseChatModel):
         """Initialization of Chart Selection components.
 
         Args:

--- a/vizro-ai/src/vizro_ai/task_pipeline/_pipeline.py
+++ b/vizro-ai/src/vizro_ai/task_pipeline/_pipeline.py
@@ -2,13 +2,13 @@
 
 from typing import Any, Dict, List, Optional
 
-from vizro_ai.chains._llm_models import LLM_MODELS
+from langchain_core.language_models.chat_models import BaseChatModel
 
 
 class Pipeline:
     """A pipeline to manage the flow of tasks in a sequence."""
 
-    def __init__(self, llm: LLM_MODELS):
+    def __init__(self, llm: BaseChatModel):
         """Initialize the Pipeline.
 
         Args:

--- a/vizro-ai/src/vizro_ai/task_pipeline/_pipeline_manager.py
+++ b/vizro-ai/src/vizro_ai/task_pipeline/_pipeline_manager.py
@@ -1,6 +1,6 @@
 """Pipeline Manager."""
 
-from vizro_ai.chains._llm_models import LLM_MODELS
+from langchain_core.language_models.chat_models import BaseChatModel
 from vizro_ai.components import GetChartSelection, GetCustomChart, GetDataFrameCraft, GetVisualCode
 from vizro_ai.task_pipeline._pipeline import Pipeline
 
@@ -8,7 +8,7 @@ from vizro_ai.task_pipeline._pipeline import Pipeline
 class PipelineManager:
     """Task pipeline manager."""
 
-    def __init__(self, llm: LLM_MODELS = None):
+    def __init__(self, llm: BaseChatModel = None):
         """Initialize the Pipeline Manager.
 
         Args:


### PR DESCRIPTION
## Description


Motivation:
when adding optional model families, in current setting, LLM_MODELS value varies based on import result
```
try:
    from langchain_anthropic import ChatAnthropic
except ImportError:
    ChatAnthropic=None

if ChatAnthropic in not None:
    LLM_MODELS = Union[ChatOpenAI, ChatAnthropic]
```

Use the parent class of all langchain supported chat models
Then we don't need this lines of code:
```
# TODO add new wrappers in if new model support is added
LLM_MODELS = Union[ChatOpenAI]

if ChatAnthropic in not None:
    LLM_MODELS = Union[ChatOpenAI, ChatAnthropic]
```

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
