### PR TITLE
[Bug] Fix inconsistent return types in selector values

### DIFF
--- a/vizro-core/changelog.d/20240703_091955_huong_li_nguyen_fix_selector_return_type.md
+++ b/vizro-core/changelog.d/20240703_091955_huong_li_nguyen_fix_selector_return_type.md
@@ -37,7 +37,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Fixed
 
-- Ensure that selectors always return a list of values. ([#562](https://github.com/mckinsey/vizro/pull/562))
+- Ensure that categorical selectors always return a list of values. ([#562](https://github.com/mckinsey/vizro/pull/562))
 
 <!--
 ### Security

--- a/vizro-core/changelog.d/20240703_091955_huong_li_nguyen_fix_selector_return_type.md
+++ b/vizro-core/changelog.d/20240703_091955_huong_li_nguyen_fix_selector_return_type.md
@@ -1,0 +1,47 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+
+### Fixed
+
+- Ensure that selectors always return a list of values. ([#561](https://github.com/mckinsey/vizro/pull/561))
+
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/changelog.d/20240703_091955_huong_li_nguyen_fix_selector_return_type.md
+++ b/vizro-core/changelog.d/20240703_091955_huong_li_nguyen_fix_selector_return_type.md
@@ -37,7 +37,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Fixed
 
-- Ensure that selectors always return a list of values. ([#561](https://github.com/mckinsey/vizro/pull/561))
+- Ensure that selectors always return a list of values. ([#562](https://github.com/mckinsey/vizro/pull/562))
 
 <!--
 ### Security

--- a/vizro-core/examples/_dev/app.py
+++ b/vizro-core/examples/_dev/app.py
@@ -1,64 +1,49 @@
 """Dev app to try things out."""
 
-from typing import Optional
-
-import dash_bootstrap_components as dbc
 import pandas as pd
 import vizro.models as vm
 import vizro.plotly.express as px
-from dash import html
 from vizro import Vizro
-from vizro.figures import kpi_card
 from vizro.models.types import capture
 
-tips = px.data.tips
+df_stocks = px.data.stocks(datetimes=True)
+df_stocks_long = pd.melt(
+    df_stocks,
+    id_vars="date",
+    value_vars=["GOOG", "AAPL", "AMZN", "FB", "NFLX", "MSFT"],
+    var_name="stocks",
+    value_name="value",
+)
 
 
-@capture("figure")  # (1)!
-def custom_kpi_card(  # noqa: PLR0913
-    data_frame: pd.DataFrame,
-    value_column: str,
-    *,
-    value_format: str = "{value}",
-    agg_func: str = "sum",
-    title: Optional[str] = None,
-    icon: Optional[str] = None,
-) -> dbc.Card:  # (2)!
-    """Creates a custom KPI card."""
-    title = title or f"{agg_func} {value_column}".title()
-    value = data_frame[value_column].agg(agg_func)
+@capture("graph")
+def vizro_plot(data_frame, stocks_selected, **kwargs):
+    """Custom chart function."""
+    return px.line(data_frame[data_frame["stocks"].isin(stocks_selected)], **kwargs)
 
-    header = dbc.CardHeader(
-        [
-            html.H2(title),
-            html.P(icon, className="material-symbols-outlined") if icon else None,  # (3)!
-        ]
-    )
-    body = dbc.CardBody([value_format.format(value=value)])
-    return dbc.Card([header, body], className="card-kpi")
 
+df_stocks_long["value"] = df_stocks_long["value"].round(3)
 
 page = vm.Page(
-    title="Create your own KPI card",
-    layout=vm.Layout(grid=[[0, 1, -1, -1]] + [[-1, -1, -1, -1]] * 3),  # (4)!
+    title="My first page",
     components=[
-        vm.Figure(
-            figure=kpi_card(  # (5)!
-                data_frame=tips,
-                value_column="tip",
-                value_format="${value:.2f}",
-                icon="shopping_cart",
-                title="Default KPI card",
-            )
+        vm.Graph(
+            id="my_graph",
+            figure=vizro_plot(
+                data_frame=df_stocks_long,
+                stocks_selected=list(df_stocks_long["stocks"].unique()),
+                x="date",
+                y="value",
+                color="stocks",
+            ),
         ),
-        vm.Figure(
-            figure=custom_kpi_card(  # (6)!
-                data_frame=tips,
-                value_column="tip",
-                value_format="${value:.2f}",
-                icon="payment",
-                title="Custom KPI card",
-            )
+    ],
+    controls=[
+        vm.Parameter(
+            targets=["my_graph.stocks_selected"],
+            selector=vm.Dropdown(
+                options=[{"label": s, "value": s} for s in df_stocks_long["stocks"].unique()],
+            ),
         ),
     ],
 )

--- a/vizro-core/src/vizro/actions/_actions_utils.py
+++ b/vizro-core/src/vizro/actions/_actions_utils.py
@@ -146,8 +146,8 @@ def _get_parametrized_config(target: ModelID, ctd_parameters: List[CallbackTrigg
 
             # Even if options are provided as List[Dict], the Dash component only returns a List of values.
             # So we need to ensure that we always return a List only as well to provide consistent types.
-            if all(isinstance(i, dict) for i in selector.options):
-                selector_value = [value["value"] for value in selector.options]
+            if all(isinstance(option, dict) for option in selector.options):
+                selector_value = [option["value"] for option in selector.options]
             else:
                 selector_value = selector.options
 

--- a/vizro-core/src/vizro/actions/_actions_utils.py
+++ b/vizro-core/src/vizro/actions/_actions_utils.py
@@ -138,12 +138,19 @@ def _get_parametrized_config(target: ModelID, ctd_parameters: List[CallbackTrigg
     config["data_frame"] = {}
 
     for ctd in ctd_parameters:
-        selector_value = ctd[
-            "value"
-        ]  # TODO: needs to be refactored so that it is independent of implementation details
+        # TODO: needs to be refactored so that it is independent of implementation details
+        selector_value = ctd["value"]
+
         if hasattr(selector_value, "__iter__") and ALL_OPTION in selector_value:  # type: ignore[operator]
             selector: SelectorType = model_manager[ctd["id"]]
-            selector_value = selector.options
+
+            # Even if options are provided as List[Dict], the Dash component only returns a List of values.
+            # So we need to ensure that we always return a List only as well to provide consistent types.
+            if all(isinstance(i, dict) for i in selector.options):
+                selector_value = [value["value"] for value in selector.options]
+            else:
+                selector_value = selector.options
+
         selector_value = _validate_selector_value_none(selector_value)
         selector_actions = _get_component_actions(model_manager[ctd["id"]])
 

--- a/vizro-core/src/vizro/models/_action/_action.py
+++ b/vizro-core/src/vizro/models/_action/_action.py
@@ -105,7 +105,7 @@ class Action(VizroBaseModel):
     ) -> Any:
         logger.debug("===== Running action with id %s, function %s =====", self.id, self.function._function.__name__)
         if logger.isEnabledFor(logging.DEBUG):
-            logger.debug("Action inputs:\n%s", pformat(inputs, depth=2, width=200))
+            logger.debug("Action inputs:\n%s", pformat(inputs, depth=3, width=200))
             logger.debug("Action outputs:\n%s", pformat(outputs, width=200))
 
         if isinstance(inputs, Mapping):

--- a/vizro-core/tests/unit/vizro/actions/conftest.py
+++ b/vizro-core/tests/unit/vizro/actions/conftest.py
@@ -11,6 +11,11 @@ def gapminder_2007(gapminder):
 
 
 @pytest.fixture
+def iris():
+    return px.data.iris()
+
+
+@pytest.fixture
 def gapminder_dynamic_first_n_last_n_function(gapminder):
     return lambda first_n=None, last_n=None: (
         pd.concat([gapminder[:first_n], gapminder[-last_n:]])
@@ -42,6 +47,16 @@ def scatter_params():
 @pytest.fixture
 def scatter_chart(gapminder_2007, scatter_params):
     return px.scatter(gapminder_2007, **scatter_params).update_layout(margin_t=24)
+
+
+@pytest.fixture
+def scatter_matrix_params():
+    return {"dimensions": ["sepal_width", "sepal_length", "petal_width", "petal_length"]}
+
+
+@pytest.fixture
+def scatter_matrix_chart(iris, scatter_matrix_params):
+    return px.scatter_matrix(iris, **scatter_matrix_params).update_layout(margin_t=24)
 
 
 @pytest.fixture
@@ -107,6 +122,19 @@ def managers_one_page_two_graphs_one_table_one_aggrid_one_button(
             vm.Table(id="vizro_table", figure=dash_data_table_with_id),
             vm.AgGrid(id="ag_grid", figure=ag_grid_with_id),
             vm.Button(id="button"),
+        ],
+    )
+    Vizro._pre_build()
+
+
+@pytest.fixture
+def managers_one_page_one_graph_with_dict_param_input(scatter_matrix_chart):
+    """Instantiates a model_manager and data_manager with a page and a graph that requires a list input."""
+    vm.Page(
+        id="test_page",
+        title="My first dashboard",
+        components=[
+            vm.Graph(id="scatter_matrix_chart", figure=scatter_matrix_chart),
         ],
     )
     Vizro._pre_build()


### PR DESCRIPTION
## Description
Previously if you've specified the options of a selector as a `List[Dict]` inside a `Parameter`, the value was returned as a List[Dict] when "ALL" was selected (introduced by us), but would return a List of values only when selecting other values from the multi selector (dash default). This could lead to issues when using custom charts, as it's not immediately transparent for the user what the return type is, see https://github.com/mckinsey/vizro/issues/557. 

- Fixes inconsistent return types in selectors by always returning a List (similar to Dash)

FYI: @lingyielia @petar-qb @antonymilne 

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and/or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not directly or indirectly referenced individuals, products or companies in any commits.
  - I have not added data or restricted code in any commits, directly or indirectly.
