### PR TITLE
[Bug] Fix default icon provision for `vm.NavLink`

### DIFF
--- a/vizro-core/changelog.d/20240708_105029_huong_li_nguyen_fix_default_nav_items.md
+++ b/vizro-core/changelog.d/20240708_105029_huong_li_nguyen_fix_default_nav_items.md
@@ -1,0 +1,47 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+
+### Fixed
+
+- Remove default icon provision for `vm.NavLink` when the icon count exceeds 9 and a user icon is provided.([#571](https://github.com/mckinsey/vizro/pull/571))
+
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/examples/_dev/app.py
+++ b/vizro-core/examples/_dev/app.py
@@ -1,54 +1,38 @@
 """Dev app to try things out."""
 
-import pandas as pd
 import vizro.models as vm
-import vizro.plotly.express as px
 from vizro import Vizro
-from vizro.models.types import capture
 
-df_stocks = px.data.stocks(datetimes=True)
-df_stocks_long = pd.melt(
-    df_stocks,
-    id_vars="date",
-    value_vars=["GOOG", "AAPL", "AMZN", "FB", "NFLX", "MSFT"],
-    var_name="stocks",
-    value_name="value",
+page_1 = vm.Page(title="Page 1", components=[vm.Card(text="Placeholder")])
+page_2 = vm.Page(title="Page 2", components=[vm.Card(text="Placeholder")])
+page_3 = vm.Page(title="Page 3", components=[vm.Card(text="Placeholder")])
+page_4 = vm.Page(title="Page 4", components=[vm.Card(text="Placeholder")])
+page_5 = vm.Page(title="Page 5", components=[vm.Card(text="Placeholder")])
+page_6 = vm.Page(title="Page 6", components=[vm.Card(text="Placeholder")])
+page_7 = vm.Page(title="Page 7", components=[vm.Card(text="Placeholder")])
+page_8 = vm.Page(title="Page 8", components=[vm.Card(text="Placeholder")])
+page_9 = vm.Page(title="Page 9", components=[vm.Card(text="Placeholder")])
+page_10 = vm.Page(title="Page 10", components=[vm.Card(text="Placeholder")])
+
+dashboard = vm.Dashboard(
+    pages=[page_1, page_2, page_3, page_4, page_5, page_6, page_7, page_8, page_9, page_10],
+    navigation=vm.Navigation(
+        nav_selector=vm.NavBar(
+            items=[
+                vm.NavLink(label="Page 1", pages=["Page 1"], icon="Home"),
+                vm.NavLink(label="Page 1", pages=["Page 2"], icon="Home"),
+                vm.NavLink(label="Page 1", pages=["Page 3"], icon="Home"),
+                vm.NavLink(label="Page 1", pages=["Page 4"], icon="Home"),
+                vm.NavLink(label="Page 1", pages=["Page 5"], icon="Home"),
+                vm.NavLink(label="Page 1", pages=["Page 6"], icon="Home"),
+                vm.NavLink(label="Page 1", pages=["Page 7"], icon="Home"),
+                vm.NavLink(label="Page 1", pages=["Page 8"], icon="Home"),
+                vm.NavLink(label="Page 1", pages=["Page 9"], icon="Home"),
+                vm.NavLink(label="Page 1", pages=["Page 10"], icon="Home"),
+            ]
+        )
+    ),
 )
-
-
-@capture("graph")
-def vizro_plot(data_frame, stocks_selected, **kwargs):
-    """Custom chart function."""
-    return px.line(data_frame[data_frame["stocks"].isin(stocks_selected)], **kwargs)
-
-
-df_stocks_long["value"] = df_stocks_long["value"].round(3)
-
-page = vm.Page(
-    title="My first page",
-    components=[
-        vm.Graph(
-            id="my_graph",
-            figure=vizro_plot(
-                data_frame=df_stocks_long,
-                stocks_selected=list(df_stocks_long["stocks"].unique()),
-                x="date",
-                y="value",
-                color="stocks",
-            ),
-        ),
-    ],
-    controls=[
-        vm.Parameter(
-            targets=["my_graph.stocks_selected"],
-            selector=vm.Dropdown(
-                options=[{"label": s, "value": s} for s in df_stocks_long["stocks"].unique()],
-            ),
-        ),
-    ],
-)
-
-dashboard = vm.Dashboard(pages=[page])
 
 if __name__ == "__main__":
     Vizro().build(dashboard).run()

--- a/vizro-core/src/vizro/models/_navigation/nav_bar.py
+++ b/vizro-core/src/vizro/models/_navigation/nav_bar.py
@@ -17,8 +17,6 @@ from vizro.models._models_utils import _log_call
 from vizro.models._navigation._navigation_utils import _NavBuildType, _validate_pages
 from vizro.models._navigation.nav_link import NavLink
 
-MAX_NUMBER_DEFAULT_ICONS = 9
-
 
 class NavBar(VizroBaseModel):
     """Navigation bar to be used as a nav_selector for `Navigation`.
@@ -50,9 +48,9 @@ class NavBar(VizroBaseModel):
         ]
 
         for position, item in enumerate(self.items, 1):
-            # The default icons  (if none are specified) are named filter_1, filter_2, etc. up to filter_9.
+            # The default icons are named filter_1, filter_2, etc. up to filter_9.
             # If there are more than 9 items, then the 10th and all subsequent items are named filter_9+.
-            icon_default = "filter_9+" if position > MAX_NUMBER_DEFAULT_ICONS else f"filter_{position}"
+            icon_default = f"filter_{position}" if position <= 9 else "filter_9+"  # noqa: PLR2004
             item.icon = item.icon or icon_default
 
         # Since models instantiated in pre_build do not themselves have pre_build called on them, we call it manually

--- a/vizro-core/src/vizro/models/_navigation/nav_bar.py
+++ b/vizro-core/src/vizro/models/_navigation/nav_bar.py
@@ -17,6 +17,8 @@ from vizro.models._models_utils import _log_call
 from vizro.models._navigation._navigation_utils import _NavBuildType, _validate_pages
 from vizro.models._navigation.nav_link import NavLink
 
+MAX_NUMBER_DEFAULT_ICONS = 9
+
 
 class NavBar(VizroBaseModel):
     """Navigation bar to be used as a nav_selector for `Navigation`.
@@ -48,9 +50,10 @@ class NavBar(VizroBaseModel):
         ]
 
         for position, item in enumerate(self.items, 1):
-            # The filter icons are named filter_1, filter_2, etc. up to filter_9. If there are more than 9 items, then
-            # the 10th and all subsequent items are named filter_9+.
-            item.icon = item.icon or f"filter_{position}" if position <= 9 else "filter_9+"  # noqa: PLR2004
+            # The default icons  (if none are specified) are named filter_1, filter_2, etc. up to filter_9.
+            # If there are more than 9 items, then the 10th and all subsequent items are named filter_9+.
+            icon_default = "filter_9+" if position > MAX_NUMBER_DEFAULT_ICONS else f"filter_{position}"
+            item.icon = item.icon or icon_default
 
         # Since models instantiated in pre_build do not themselves have pre_build called on them, we call it manually
         # here.


### PR DESCRIPTION
## Description
- Remove default icon provision for `vm.NavLink` when the icon count exceeds 9 and a user icon is provided

## Screenshot
Before:
![Screenshot 2024-07-08 at 10 47 50](https://github.com/mckinsey/vizro/assets/90609403/0cf4a9aa-7a59-43c3-985c-269b4426bbdf)

After:
![Screenshot 2024-07-08 at 10 47 33](https://github.com/mckinsey/vizro/assets/90609403/0d9d97d1-384a-4468-869e-c51dcb94ccb2)


## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
