### PR TITLE
[Feat] Update `optionHeight` of `vm.Dropdown` dynamically

### DIFF
--- a/vizro-core/changelog.d/20240708_185435_huong_li_nguyen_enable_dynamic_option_height.md
+++ b/vizro-core/changelog.d/20240708_185435_huong_li_nguyen_enable_dynamic_option_height.md
@@ -25,7 +25,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Changed
 
-- Update `optionHeight` of `vm.Dropdown` dynamically based on character length. ([#573](https://github.com/mckinsey/vizro/pull/573))
+- Update `optionHeight` of `vm.Dropdown` dynamically based on character length. ([#574](https://github.com/mckinsey/vizro/pull/574))
 
 <!--
 ### Deprecated

--- a/vizro-core/changelog.d/20240708_185435_huong_li_nguyen_enable_dynamic_option_height.md
+++ b/vizro-core/changelog.d/20240708_185435_huong_li_nguyen_enable_dynamic_option_height.md
@@ -22,23 +22,23 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 - A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
 
 -->
-<!--
+
 ### Changed
 
-- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+- Update `optionHeight` of `vm.Dropdown` dynamically based on character length. ([#573](https://github.com/mckinsey/vizro/pull/573))
 
--->
 <!--
 ### Deprecated
 
 - A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
 
 -->
-
+<!--
 ### Fixed
 
-- Remove default icon provision for `vm.NavLink` when the icon count exceeds 9 and a user icon is provided.([#572](https://github.com/mckinsey/vizro/pull/572))
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
 
+-->
 <!--
 ### Security
 

--- a/vizro-core/examples/_dev/app.py
+++ b/vizro-core/examples/_dev/app.py
@@ -1,38 +1,33 @@
 """Dev app to try things out."""
 
+import numpy as np
 import vizro.models as vm
+import vizro.plotly.express as px
 from vizro import Vizro
 
-page_1 = vm.Page(title="Page 1", components=[vm.Card(text="Placeholder")])
-page_2 = vm.Page(title="Page 2", components=[vm.Card(text="Placeholder")])
-page_3 = vm.Page(title="Page 3", components=[vm.Card(text="Placeholder")])
-page_4 = vm.Page(title="Page 4", components=[vm.Card(text="Placeholder")])
-page_5 = vm.Page(title="Page 5", components=[vm.Card(text="Placeholder")])
-page_6 = vm.Page(title="Page 6", components=[vm.Card(text="Placeholder")])
-page_7 = vm.Page(title="Page 7", components=[vm.Card(text="Placeholder")])
-page_8 = vm.Page(title="Page 8", components=[vm.Card(text="Placeholder")])
-page_9 = vm.Page(title="Page 9", components=[vm.Card(text="Placeholder")])
-page_10 = vm.Page(title="Page 10", components=[vm.Card(text="Placeholder")])
+df = px.data.iris()
 
-dashboard = vm.Dashboard(
-    pages=[page_1, page_2, page_3, page_4, page_5, page_6, page_7, page_8, page_9, page_10],
-    navigation=vm.Navigation(
-        nav_selector=vm.NavBar(
-            items=[
-                vm.NavLink(label="Page 1", pages=["Page 1"], icon="Home"),
-                vm.NavLink(label="Page 1", pages=["Page 2"], icon="Home"),
-                vm.NavLink(label="Page 1", pages=["Page 3"], icon="Home"),
-                vm.NavLink(label="Page 1", pages=["Page 4"], icon="Home"),
-                vm.NavLink(label="Page 1", pages=["Page 5"], icon="Home"),
-                vm.NavLink(label="Page 1", pages=["Page 6"], icon="Home"),
-                vm.NavLink(label="Page 1", pages=["Page 7"], icon="Home"),
-                vm.NavLink(label="Page 1", pages=["Page 8"], icon="Home"),
-                vm.NavLink(label="Page 1", pages=["Page 9"], icon="Home"),
-                vm.NavLink(label="Page 1", pages=["Page 10"], icon="Home"),
-            ]
-        )
-    ),
+df["species_long"] = df["species"] + " is one common species you can select in the iris dataset."
+df["species_one_long"] = np.where(
+    df["species"] == "setosa", "setosa is one common species you can select in the iris dataset.", df["species"]
 )
+page = vm.Page(
+    title="",
+    components=[
+        vm.Graph(
+            id="graph_1",
+            figure=px.scatter(df, title="Title", x="sepal_width", y="sepal_length", color="species"),
+        ),
+    ],
+    controls=[
+        vm.Filter(column="species"),
+        vm.Filter(column="species_long"),
+        vm.Filter(column="species_one_long"),
+    ],
+)
+
+
+dashboard = vm.Dashboard(pages=[page])
 
 if __name__ == "__main__":
     Vizro().build(dashboard).run()

--- a/vizro-core/examples/_dev/app.py
+++ b/vizro-core/examples/_dev/app.py
@@ -6,11 +6,15 @@ import vizro.plotly.express as px
 from vizro import Vizro
 
 df = px.data.iris()
-
-df["species_long"] = df["species"] + " is one common species you can select in the iris dataset."
 df["species_one_long"] = np.where(
     df["species"] == "setosa", "setosa is one common species you can select in the iris dataset.", df["species"]
 )
+df["species_long"] = df["species"] + " is one common species you can select in the iris dataset."
+df["species_very_long"] = (
+    df["species"]
+    + " is one common species you can select in the iris dataset is one common species you can select in the iris data."
+)
+
 page = vm.Page(
     title="",
     components=[
@@ -23,6 +27,7 @@ page = vm.Page(
         vm.Filter(column="species"),
         vm.Filter(column="species_long"),
         vm.Filter(column="species_one_long"),
+        vm.Filter(column="species_very_long"),
     ],
 )
 

--- a/vizro-core/src/vizro/models/_components/form/dropdown.py
+++ b/vizro-core/src/vizro/models/_components/form/dropdown.py
@@ -71,6 +71,7 @@ class Dropdown(VizroBaseModel):
                     value=self.value if self.value is not None else default_value,
                     multi=self.multi,
                     persistence=True,
+                    optionHeight=32 if all(len(option) <= 37 for option in full_options) else 60,  # noqa: PLR2004
                     persistence_type="session",
                 ),
             ]

--- a/vizro-core/src/vizro/models/_components/form/dropdown.py
+++ b/vizro-core/src/vizro/models/_components/form/dropdown.py
@@ -73,7 +73,7 @@ class Dropdown(VizroBaseModel):
                     multi=self.multi,
                     persistence=True,
                     # 37 is the cut-off character length where the text inside the dropdown starts to wrap
-                    optionHeight=32 + 24 * math.floor(max(len(option) for option in full_options) / 37),
+                    optionHeight=32 + 24 * math.floor(max(len(str(option)) for option in full_options) / 37),
                     persistence_type="session",
                 ),
             ]

--- a/vizro-core/src/vizro/models/_components/form/dropdown.py
+++ b/vizro-core/src/vizro/models/_components/form/dropdown.py
@@ -1,3 +1,4 @@
+import math
 from typing import List, Literal, Optional, Union
 
 from dash import dcc, html
@@ -71,7 +72,8 @@ class Dropdown(VizroBaseModel):
                     value=self.value if self.value is not None else default_value,
                     multi=self.multi,
                     persistence=True,
-                    optionHeight=32 if all(len(option) <= 37 for option in full_options) else 60,  # noqa: PLR2004
+                    # 37 is the cut-off character length where the text inside the dropdown starts to wrap
+                    optionHeight=32 + 24 * math.floor(max(len(option) for option in full_options) / 37),
                     persistence_type="session",
                 ),
             ]

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_dropdown.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_dropdown.py
@@ -155,6 +155,7 @@ class TestDropdownBuild:
                 dcc.Dropdown(
                     id="dropdown_id",
                     options=["ALL", "A", "B", "C"],
+                    optionHeight=32,
                     value="ALL",
                     multi=True,
                     persistence=True,

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_dropdown.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_dropdown.py
@@ -173,6 +173,7 @@ class TestDropdownBuild:
                 dcc.Dropdown(
                     id="dropdown_id",
                     options=["A", "B", "C"],
+                    optionHeight=32,
                     value="A",
                     multi=False,
                     persistence=True,

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_dropdown.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_dropdown.py
@@ -184,3 +184,32 @@ class TestDropdownBuild:
         )
 
         assert_component_equal(dropdown, expected_dropdown)
+
+    @pytest.mark.parametrize(
+        "options, option_height",
+        [
+            (["A", "B", "C"], 32),
+            ([10, 20, 30], 32),
+            (["A text with a length of 36..........", "B", "C"], 32),
+            (["A text with a length of 37...........", "B", "C"], 56),
+            (["A text with a length of 37..........." + "A text with a length of 37...........", "B", "C"], 80),
+        ],
+    )
+    def test_dropdown_dynamic_option_height(self, options, option_height):
+        dropdown = Dropdown(id="dropdown_id", multi=False, options=options).build()
+        expected_dropdown = html.Div(
+            [
+                None,
+                dcc.Dropdown(
+                    id="dropdown_id",
+                    options=options,
+                    optionHeight=option_height,
+                    multi=False,
+                    value=options[0],
+                    persistence=True,
+                    persistence_type="session",
+                ),
+            ]
+        )
+
+        assert_component_equal(dropdown, expected_dropdown)


### PR DESCRIPTION
## Description
- Update `optionHeight` of `vm.Dropdown` dynamically based on character length

## Screenshot
![Screenshot 2024-07-08 at 18 59 17](https://github.com/mckinsey/vizro/assets/90609403/ba82f027-0509-4077-8747-3e39eeef5550)
![Screenshot 2024-07-08 at 18 59 08](https://github.com/mckinsey/vizro/assets/90609403/0f9f92db-c389-4ec4-86e9-b7f9c4cb68f3)
![Screenshot 2024-07-08 at 18 59 13](https://github.com/mckinsey/vizro/assets/90609403/dac82fd5-1fff-434f-9c65-f8646db321ce)

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
