### PR TITLE
[Bug] External links for vm.Card now open in the full body

### DIFF
--- a/vizro-core/changelog.d/20240716_091858_maximilian_schulz_try_out_link_target.md
+++ b/vizro-core/changelog.d/20240716_091858_maximilian_schulz_try_out_link_target.md
@@ -1,0 +1,47 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+
+### Fixed
+
+- Internal and external links for `href` in `vm.Card` now behave correctly on py.cafe ([#579](https://github.com/mckinsey/vizro/pull/579))
+
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/changelog.d/20240716_091858_maximilian_schulz_try_out_link_target.md
+++ b/vizro-core/changelog.d/20240716_091858_maximilian_schulz_try_out_link_target.md
@@ -37,7 +37,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Fixed
 
-- Internal and external links for `href` in `vm.Card` now behave correctly on py.cafe ([#579](https://github.com/mckinsey/vizro/pull/579))
+- Internal and external links for `href` in `vm.Card` now behave correctly on py.cafe ([#585](https://github.com/mckinsey/vizro/pull/585))
 
 <!--
 ### Security

--- a/vizro-core/changelog.d/20240716_091858_maximilian_schulz_try_out_link_target.md
+++ b/vizro-core/changelog.d/20240716_091858_maximilian_schulz_try_out_link_target.md
@@ -37,7 +37,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Fixed
 
-- Internal and external links for `href` in `vm.Card` now behave correctly on py.cafe ([#585](https://github.com/mckinsey/vizro/pull/585))
+- External `href` links in `vm.Card` now open in a new browser tab. ([#585](https://github.com/mckinsey/vizro/pull/585))
 
 <!--
 ### Security

--- a/vizro-core/changelog.d/20240716_091858_maximilian_schulz_try_out_link_target.md
+++ b/vizro-core/changelog.d/20240716_091858_maximilian_schulz_try_out_link_target.md
@@ -37,7 +37,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Fixed
 
-- External `href` links in `vm.Card` now open in a new browser tab. ([#585](https://github.com/mckinsey/vizro/pull/585))
+- External `href` links in `vm.Card` now open in the full body of the window as opposed to in the same frame as they were clicked. ([#585](https://github.com/mckinsey/vizro/pull/585))
 
 <!--
 ### Security

--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -1,38 +1,66 @@
-"""Dev app to try things out."""
+"""Example app to show all features of Vizro."""
 
-import numpy as np
+# check out https://github.com/mckinsey/vizro for more info about Vizro
+# and checkout https://vizro.readthedocs.io/en/stable/ for documentation
+
 import vizro.models as vm
 import vizro.plotly.express as px
 from vizro import Vizro
 
 df = px.data.iris()
-df["species_one_long"] = np.where(
-    df["species"] == "setosa", "setosa is one common species you can select in the iris dataset.", df["species"]
-)
-df["species_long"] = df["species"] + " is one common species you can select in the iris dataset."
-df["species_very_long"] = (
-    df["species"]
-    + " is one common species you can select in the iris dataset is one common species you can select in the iris data."
-)
 
 page = vm.Page(
-    title="",
+    title="Vizro on PyCafe",
+    layout=vm.Layout(
+        grid=[[0, 0, 0, 1, 2, 3], [4, 4, 4, 4, 4, 4], [4, 4, 4, 4, 4, 4], [5, 5, 5, 5, 5, 5], [5, 5, 5, 5, 5, 5]],
+        row_min_height="175px",
+    ),
     components=[
-        vm.Graph(
-            id="graph_1",
-            figure=px.scatter(df, title="Title", x="sepal_width", y="sepal_length", color="species"),
+        vm.Card(
+            text="""
+        ### What is Vizro?
+
+        Vizro is a toolkit for creating modular data visualization applications.
+        """
         ),
+        vm.Card(
+            text="""
+                ### Github
+
+                Checkout Vizro's github page.
+            """,
+            href="https://github.com/mckinsey/vizro",
+        ),
+        vm.Card(
+            text="""
+                ### Docs
+
+                Visit the documentation for codes examples, tutorials and API reference.
+            """,
+            href="https://vizro.readthedocs.io/",
+        ),
+        vm.Card(
+            text="""
+                ### Nav Link
+
+                Click this for page 2.
+            """,
+            href="/page2",
+        ),
+        vm.Graph(id="scatter_chart", figure=px.scatter(df, x="sepal_length", y="petal_width", color="species")),
+        vm.Graph(id="hist_chart", figure=px.histogram(df, x="sepal_width", color="species")),
     ],
     controls=[
-        vm.Filter(column="species"),
-        vm.Filter(column="species_long"),
-        vm.Filter(column="species_one_long"),
-        vm.Filter(column="species_very_long"),
+        vm.Filter(column="species", selector=vm.Dropdown(value=["ALL"])),
+        vm.Filter(column="petal_length"),
+        vm.Filter(column="sepal_width"),
     ],
 )
 
+page2 = vm.Page(
+    title="Page2", components=[vm.Graph(id="hist_chart2", figure=px.histogram(df, x="sepal_width", color="species"))]
+)
 
-dashboard = vm.Dashboard(pages=[page])
+dashboard = vm.Dashboard(pages=[page, page2])
 
-if __name__ == "__main__":
-    Vizro().build(dashboard).run()
+Vizro().build(dashboard).run()

--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -63,4 +63,5 @@ page2 = vm.Page(
 
 dashboard = vm.Dashboard(pages=[page, page2])
 
-Vizro().build(dashboard).run()
+if __name__ == "__main__":
+    Vizro().build(dashboard).run()

--- a/vizro-core/src/vizro/models/_components/card.py
+++ b/vizro-core/src/vizro/models/_components/card.py
@@ -39,6 +39,7 @@ class Card(VizroBaseModel):
             dbc.NavLink(
                 children=text,
                 href=get_relative_path(self.href) if self.href.startswith("/") else self.href,
+                target="_blank",
             )
             if self.href
             else text

--- a/vizro-core/src/vizro/models/_components/card.py
+++ b/vizro-core/src/vizro/models/_components/card.py
@@ -39,7 +39,7 @@ class Card(VizroBaseModel):
             dbc.NavLink(
                 children=text,
                 href=get_relative_path(self.href) if self.href.startswith("/") else self.href,
-                target="_blank",
+                target="_top",
             )
             if self.href
             else text

--- a/vizro-core/tests/unit/vizro/models/_components/test_card.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_card.py
@@ -53,7 +53,7 @@ class TestBuildMethod:
             dbc.NavLink(
                 dcc.Markdown(id="card_id", children="Hello", dangerously_allow_html=False),
                 href="https://www.google.com",
-                target="_blank",
+                target="_top",
             ),
             className="card-nav",
         )

--- a/vizro-core/tests/unit/vizro/models/_components/test_card.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_card.py
@@ -53,6 +53,7 @@ class TestBuildMethod:
             dbc.NavLink(
                 dcc.Markdown(id="card_id", children="Hello", dangerously_allow_html=False),
                 href="https://www.google.com",
+                target="_blank",
             ),
             className="card-nav",
         )


### PR DESCRIPTION
## Description
Previously when clicking `vm.Card` used as a `NavCard`, ie with `href` enabled, would lead to external links opening in the same tab, but not in a new tab, on py.cafe. This is now fixed.

Adding some more info (thanks @petar-qb ):
- More info on what `target="_blank"` does - [see link](https://www.w3schools.com/tags/att_a_target.asp)
- It looks from the docs that `dbc.NavLink` works out when to format links and when not: https://dash-bootstrap-components.opensource.faculty.ai/docs/components/nav/

P.S. It is debatable whether this is really a bug or a feature, but given that it broke things on py.cafe, I will leave the Bug tag - happy to have it changed though

P.P.S Based on @antonymilne new suggestion I changed the PR title to reflect the new approach - external links now open in the full body


## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
