### PR TITLE
[Tidy] Improve validation error message if `CapturedCallable` is directly provided

### DIFF
--- a/vizro-core/changelog.d/20240718_151233_huong_li_nguyen_validation_error_captured.md
+++ b/vizro-core/changelog.d/20240718_151233_huong_li_nguyen_validation_error_captured.md
@@ -39,7 +39,6 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 - Improve validation error message if `CapturedCallable` is directly provided. ([#587](https://github.com/mckinsey/vizro/pull/587))
 
-
 <!--
 ### Security
 

--- a/vizro-core/changelog.d/20240718_151233_huong_li_nguyen_validation_error_captured.md
+++ b/vizro-core/changelog.d/20240718_151233_huong_li_nguyen_validation_error_captured.md
@@ -16,12 +16,11 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 - A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
 
 -->
-<!--
+
 ### Added
 
-- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+- Added validation error message if `CapturedCallable` is directly provided. ([#590](https://github.com/mckinsey/vizro/pull/590))
 
--->
 <!--
 ### Changed
 
@@ -34,11 +33,12 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 - A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
 
 -->
-
+<!--
 ### Fixed
 
-- Improve validation error message if `CapturedCallable` is directly provided. ([#590](https://github.com/mckinsey/vizro/pull/590))
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
 
+-->
 <!--
 ### Security
 

--- a/vizro-core/changelog.d/20240718_151233_huong_li_nguyen_validation_error_captured.md
+++ b/vizro-core/changelog.d/20240718_151233_huong_li_nguyen_validation_error_captured.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+
+### Fixed
+
+- Improve validation error message if `CapturedCallable` is directly provided. ([#587](https://github.com/mckinsey/vizro/pull/587))
+
+
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/changelog.d/20240718_151233_huong_li_nguyen_validation_error_captured.md
+++ b/vizro-core/changelog.d/20240718_151233_huong_li_nguyen_validation_error_captured.md
@@ -37,7 +37,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Fixed
 
-- Improve validation error message if `CapturedCallable` is directly provided. ([#587](https://github.com/mckinsey/vizro/pull/587))
+- Improve validation error message if `CapturedCallable` is directly provided. ([#590](https://github.com/mckinsey/vizro/pull/590))
 
 <!--
 ### Security

--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -16,10 +16,9 @@ df_kpi = pd.DataFrame(
 
 
 home = vm.Page(
-    title="value_error.discriminated_union.missing_discriminator",
+    title="Page Title",
     components=[
-        # vm.Card(text="I am a Card"),
-        kpi_card(data_frame=df_kpi, value_column="Actual", title="KPI with value"),
+        vm.Figure(figure=kpi_card(data_frame=df_kpi, value_column="Actual", title="KPI with value")),
     ],
 )
 

--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -1,67 +1,31 @@
 """Example app to show all features of Vizro."""
 
-# check out https://github.com/mckinsey/vizro for more info about Vizro
-# and checkout https://vizro.readthedocs.io/en/stable/ for documentation
-
+import pandas as pd
 import vizro.models as vm
-import vizro.plotly.express as px
 from vizro import Vizro
+from vizro.figures import kpi_card
 
-df = px.data.iris()
+# data from the demo app
+df_kpi = pd.DataFrame(
+    {
+        "Actual": [100, 200, 700],
+        "Reference": [100, 300, 500],
+        "Category": ["A", "B", "C"],
+    }
+)
 
-page = vm.Page(
-    title="Vizro on PyCafe",
-    layout=vm.Layout(
-        grid=[[0, 0, 0, 1, 2, 3], [4, 4, 4, 4, 4, 4], [4, 4, 4, 4, 4, 4], [5, 5, 5, 5, 5, 5], [5, 5, 5, 5, 5, 5]],
-        row_min_height="175px",
-    ),
+
+home = vm.Page(
+    title="value_error.discriminated_union.missing_discriminator",
     components=[
-        vm.Card(
-            text="""
-        ### What is Vizro?
-
-        Vizro is a toolkit for creating modular data visualization applications.
-        """
-        ),
-        vm.Card(
-            text="""
-                ### Github
-
-                Checkout Vizro's github page.
-            """,
-            href="https://github.com/mckinsey/vizro",
-        ),
-        vm.Card(
-            text="""
-                ### Docs
-
-                Visit the documentation for codes examples, tutorials and API reference.
-            """,
-            href="https://vizro.readthedocs.io/",
-        ),
-        vm.Card(
-            text="""
-                ### Nav Link
-
-                Click this for page 2.
-            """,
-            href="/page2",
-        ),
-        vm.Graph(id="scatter_chart", figure=px.scatter(df, x="sepal_length", y="petal_width", color="species")),
-        vm.Graph(id="hist_chart", figure=px.histogram(df, x="sepal_width", color="species")),
-    ],
-    controls=[
-        vm.Filter(column="species", selector=vm.Dropdown(value=["ALL"])),
-        vm.Filter(column="petal_length"),
-        vm.Filter(column="sepal_width"),
+        # vm.Card(text="I am a Card"),
+        kpi_card(data_frame=df_kpi, value_column="Actual", title="KPI with value"),
     ],
 )
 
-page2 = vm.Page(
-    title="Page2", components=[vm.Graph(id="hist_chart2", figure=px.histogram(df, x="sepal_width", color="species"))]
-)
 
-dashboard = vm.Dashboard(pages=[page, page2])
+dashboard = vm.Dashboard(pages=[home])
+
 
 if __name__ == "__main__":
     Vizro().build(dashboard).run()

--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -18,6 +18,7 @@ df_kpi = pd.DataFrame(
 home = vm.Page(
     title="Page Title",
     components=[
+        # kpi_card(data_frame=df_kpi, value_column="Actual", title="KPI with value"),
         vm.Figure(figure=kpi_card(data_frame=df_kpi, value_column="Actual", title="KPI with value")),
     ],
 )

--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -2,8 +2,11 @@
 
 import pandas as pd
 import vizro.models as vm
+import vizro.plotly.express as px
 from vizro import Vizro
 from vizro.figures import kpi_card
+
+gapminder = px.data.gapminder()
 
 # data from the demo app
 df_kpi = pd.DataFrame(

--- a/vizro-core/src/vizro/figures/kpi_cards.py
+++ b/vizro-core/src/vizro/figures/kpi_cards.py
@@ -56,6 +56,12 @@ def kpi_card(  # noqa: PLR0913
     Returns:
          A Dash Bootstrap Components card (`dbc.Card`) containing the formatted KPI value.
 
+    Examples:
+        Wrap inside `vm.Figure` to use as a component inside `vm.Page` or `vm.Container`.
+        >>> import vizro.models as vm
+        >>> from vizro.figures import kpi_card
+        >>> vm.Page(title="Page", components=[vm.Figure(figure=kpi_card(...))])
+
     """
     title = title or f"{agg_func} {value_column}".title()
     value = data_frame[value_column].agg(agg_func)
@@ -118,6 +124,12 @@ def kpi_card_reference(  # noqa: PLR0913
 
     Returns:
         A Dash Bootstrap Components card (`dbc.Card`) containing the formatted KPI value and reference.
+
+    Examples:
+        Wrap inside `vm.Figure` to use as a component inside `vm.Page` or `vm.Container`.
+        >>> import vizro.models as vm
+        >>> from vizro.figures import kpi_card_reference
+        >>> vm.Page(title="Page", components=[vm.Figure(figure=kpi_card_reference(...))])
 
     """
     title = title or f"{agg_func} {value_column}".title()

--- a/vizro-core/src/vizro/models/_components/_form.py
+++ b/vizro-core/src/vizro/models/_components/_form.py
@@ -12,7 +12,7 @@ except ImportError:  # pragma: no cov
 from vizro.models import VizroBaseModel
 from vizro.models._components.form import Checklist, Dropdown, RadioItems, RangeSlider, Slider
 from vizro.models._layout import set_layout
-from vizro.models._models_utils import _log_call, _validate_min_length
+from vizro.models._models_utils import _log_call, validate_components
 from vizro.models.types import _FormComponentType
 
 if TYPE_CHECKING:
@@ -34,7 +34,7 @@ class Form(VizroBaseModel):
     layout: Layout = None  # type: ignore[assignment]
 
     # Re-used validators
-    _validate_components = validator("components", allow_reuse=True, always=True)(_validate_min_length)
+    _validate_components = validator("components", allow_reuse=True, always=True, pre=True)(validate_components)
     _validate_layout = validator("layout", allow_reuse=True, always=True)(set_layout)
 
     @_log_call

--- a/vizro-core/src/vizro/models/_components/_form.py
+++ b/vizro-core/src/vizro/models/_components/_form.py
@@ -12,7 +12,7 @@ except ImportError:  # pragma: no cov
 from vizro.models import VizroBaseModel
 from vizro.models._components.form import Checklist, Dropdown, RadioItems, RangeSlider, Slider
 from vizro.models._layout import set_layout
-from vizro.models._models_utils import _log_call, validate_components
+from vizro.models._models_utils import _log_call, validate_components_type, validate_min_length
 from vizro.models.types import _FormComponentType
 
 if TYPE_CHECKING:
@@ -34,7 +34,8 @@ class Form(VizroBaseModel):
     layout: Layout = None  # type: ignore[assignment]
 
     # Re-used validators
-    _validate_components = validator("components", allow_reuse=True, always=True, pre=True)(validate_components)
+    _validate_components_type = validator("components", allow_reuse=True, always=True, pre=True)(validate_components_type)
+    _validate_components_length = validator("components", allow_reuse=True, always=True)(validate_min_length)
     _validate_layout = validator("layout", allow_reuse=True, always=True)(set_layout)
 
     @_log_call

--- a/vizro-core/src/vizro/models/_components/_form.py
+++ b/vizro-core/src/vizro/models/_components/_form.py
@@ -34,7 +34,9 @@ class Form(VizroBaseModel):
     layout: Layout = None  # type: ignore[assignment]
 
     # Re-used validators
-    _check_captured_callable = validator("components", allow_reuse=True, always=True, pre=True)(check_captured_callable)
+    _check_captured_callable = validator("components", allow_reuse=True, each_item=True, pre=True)(
+        check_captured_callable
+    )
     _validate_components_length = validator("components", allow_reuse=True, always=True)(validate_min_length)
     _validate_layout = validator("layout", allow_reuse=True, always=True)(set_layout)
 

--- a/vizro-core/src/vizro/models/_components/_form.py
+++ b/vizro-core/src/vizro/models/_components/_form.py
@@ -12,7 +12,7 @@ except ImportError:  # pragma: no cov
 from vizro.models import VizroBaseModel
 from vizro.models._components.form import Checklist, Dropdown, RadioItems, RangeSlider, Slider
 from vizro.models._layout import set_layout
-from vizro.models._models_utils import _log_call, validate_components_type, validate_min_length
+from vizro.models._models_utils import _log_call, check_captured_callable, validate_min_length
 from vizro.models.types import _FormComponentType
 
 if TYPE_CHECKING:
@@ -34,7 +34,7 @@ class Form(VizroBaseModel):
     layout: Layout = None  # type: ignore[assignment]
 
     # Re-used validators
-    _validate_components_type = validator("components", allow_reuse=True, always=True, pre=True)(validate_components_type)
+    _check_captured_callable = validator("components", allow_reuse=True, always=True, pre=True)(check_captured_callable)
     _validate_components_length = validator("components", allow_reuse=True, always=True)(validate_min_length)
     _validate_layout = validator("layout", allow_reuse=True, always=True)(set_layout)
 

--- a/vizro-core/src/vizro/models/_components/_form.py
+++ b/vizro-core/src/vizro/models/_components/_form.py
@@ -37,7 +37,7 @@ class Form(VizroBaseModel):
     _check_captured_callable = validator("components", allow_reuse=True, each_item=True, pre=True)(
         check_captured_callable
     )
-    _validate_components_length = validator("components", allow_reuse=True, always=True)(validate_min_length)
+    _validate_min_length = validator("components", allow_reuse=True, always=True)(validate_min_length)
     _validate_layout = validator("layout", allow_reuse=True, always=True)(set_layout)
 
     @_log_call

--- a/vizro-core/src/vizro/models/_components/container.py
+++ b/vizro-core/src/vizro/models/_components/container.py
@@ -39,7 +39,7 @@ class Container(VizroBaseModel):
     _check_captured_callable = validator("components", allow_reuse=True, each_item=True, pre=True)(
         check_captured_callable
     )
-    _validate_components_length = validator("components", allow_reuse=True, always=True)(validate_min_length)
+    _validate_min_length = validator("components", allow_reuse=True, always=True)(validate_min_length)
     _validate_layout = validator("layout", allow_reuse=True, always=True)(set_layout)
 
     @_log_call

--- a/vizro-core/src/vizro/models/_components/container.py
+++ b/vizro-core/src/vizro/models/_components/container.py
@@ -11,7 +11,7 @@ except ImportError:  # pragma: no cov
 
 from vizro.models import VizroBaseModel
 from vizro.models._layout import set_layout
-from vizro.models._models_utils import _log_call, _validate_min_length
+from vizro.models._models_utils import _log_call, validate_components
 from vizro.models.types import ComponentType
 
 if TYPE_CHECKING:
@@ -36,7 +36,7 @@ class Container(VizroBaseModel):
     layout: Layout = None  # type: ignore[assignment]
 
     # Re-used validators
-    _validate_components = validator("components", allow_reuse=True, always=True)(_validate_min_length)
+    _validate_components = validator("components", allow_reuse=True, always=True, pre=True)(validate_components)
     _validate_layout = validator("layout", allow_reuse=True, always=True)(set_layout)
 
     @_log_call

--- a/vizro-core/src/vizro/models/_components/container.py
+++ b/vizro-core/src/vizro/models/_components/container.py
@@ -36,7 +36,9 @@ class Container(VizroBaseModel):
     layout: Layout = None  # type: ignore[assignment]
 
     # Re-used validators
-    _check_captured_callable = validator("components", allow_reuse=True, always=True, pre=True)(check_captured_callable)
+    _check_captured_callable = validator("components", allow_reuse=True, each_item=True, pre=True)(
+        check_captured_callable
+    )
     _validate_components_length = validator("components", allow_reuse=True, always=True)(validate_min_length)
     _validate_layout = validator("layout", allow_reuse=True, always=True)(set_layout)
 

--- a/vizro-core/src/vizro/models/_components/container.py
+++ b/vizro-core/src/vizro/models/_components/container.py
@@ -11,7 +11,7 @@ except ImportError:  # pragma: no cov
 
 from vizro.models import VizroBaseModel
 from vizro.models._layout import set_layout
-from vizro.models._models_utils import _log_call, validate_components_type, validate_min_length
+from vizro.models._models_utils import _log_call, check_captured_callable, validate_min_length
 from vizro.models.types import ComponentType
 
 if TYPE_CHECKING:
@@ -36,7 +36,7 @@ class Container(VizroBaseModel):
     layout: Layout = None  # type: ignore[assignment]
 
     # Re-used validators
-    _validate_components_type = validator("components", allow_reuse=True, always=True, pre=True)(validate_components_type)
+    _check_captured_callable = validator("components", allow_reuse=True, always=True, pre=True)(check_captured_callable)
     _validate_components_length = validator("components", allow_reuse=True, always=True)(validate_min_length)
     _validate_layout = validator("layout", allow_reuse=True, always=True)(set_layout)
 

--- a/vizro-core/src/vizro/models/_components/container.py
+++ b/vizro-core/src/vizro/models/_components/container.py
@@ -11,7 +11,7 @@ except ImportError:  # pragma: no cov
 
 from vizro.models import VizroBaseModel
 from vizro.models._layout import set_layout
-from vizro.models._models_utils import _log_call, validate_components
+from vizro.models._models_utils import _log_call, validate_components_type, validate_min_length
 from vizro.models.types import ComponentType
 
 if TYPE_CHECKING:
@@ -36,7 +36,8 @@ class Container(VizroBaseModel):
     layout: Layout = None  # type: ignore[assignment]
 
     # Re-used validators
-    _validate_components = validator("components", allow_reuse=True, always=True, pre=True)(validate_components)
+    _validate_components_type = validator("components", allow_reuse=True, always=True, pre=True)(validate_components_type)
+    _validate_components_length = validator("components", allow_reuse=True, always=True)(validate_min_length)
     _validate_layout = validator("layout", allow_reuse=True, always=True)(set_layout)
 
     @_log_call

--- a/vizro-core/src/vizro/models/_components/tabs.py
+++ b/vizro-core/src/vizro/models/_components/tabs.py
@@ -11,7 +11,7 @@ except ImportError:  # pragma: no cov
     from pydantic import validator
 
 from vizro.models import VizroBaseModel
-from vizro.models._models_utils import _log_call, _validate_min_length
+from vizro.models._models_utils import _log_call, validate_min_length
 
 if TYPE_CHECKING:
     from vizro.models._components import Container
@@ -29,7 +29,7 @@ class Tabs(VizroBaseModel):
     type: Literal["tabs"] = "tabs"
     tabs: List[Container]
 
-    _validate_tabs = validator("tabs", allow_reuse=True, always=True)(_validate_min_length)
+    _validate_tabs = validator("tabs", allow_reuse=True, always=True)(validate_min_length)
 
     @_log_call
     def build(self):

--- a/vizro-core/src/vizro/models/_models_utils.py
+++ b/vizro-core/src/vizro/models/_models_utils.py
@@ -1,6 +1,8 @@
 import logging
 from functools import wraps
 
+from vizro.models.types import CapturedCallable
+
 logger = logging.getLogger(__name__)
 
 
@@ -15,8 +17,26 @@ def _log_call(method):
     return _wrapper
 
 
+
 # Validators for reuse
 def _validate_min_length(cls, field):
     if not field:
         raise ValueError("Ensure this value has at least 1 item.")
+
+def validate_components(cls, field):
+    _validate_min_length(cls, field)
+
+    # Validate CapturedCallable has been directly provided.
+    mode_to_error = {
+        "figure": "A callable of mode `figure` has been provided. Please wrap it inside the `vm.Figure(figure=...)`.",
+        "table": "A callable of mode `table` has been provided. Please wrap it inside the `vm.Table(figure=...)`.",
+        "ag_grid": "A callable of mode `ag_grid` has been provided. Please wrap it inside the `vm.AgGrid(figure=...)`.",
+        "graph": "A callable of mode `graph` has been provided. Please wrap it inside the `vm.AgGrid(figure=...)`.",
+    }
+
+    for component in field:
+        if isinstance(component, CapturedCallable):
+            error_message = mode_to_error.get(f"{component._mode}", None)
+            if error_message:
+                raise ValueError(error_message)
     return field

--- a/vizro-core/src/vizro/models/_models_utils.py
+++ b/vizro-core/src/vizro/models/_models_utils.py
@@ -18,21 +18,21 @@ def _log_call(method):
 
 
 # Validators for reuse
-# TODO: change field to value
-def validate_min_length(cls, field):
-    if not field:
+def validate_min_length(cls, value):
+    if not value:
         raise ValueError("Ensure this value has at least 1 item.")
-    return field
+    return value
 
 
-def check_captured_callable(cls, field):
-    if not isinstance(field, (CapturedCallable, _SupportsCapturedCallable)):
-        return field
+def check_captured_callable(cls, value):
+    if isinstance(value, CapturedCallable):
+        captured_callable = value
+    elif isinstance(value, _SupportsCapturedCallable):
+        captured_callable = value._captured_callable
+    else:
+        return value
 
-    if isinstance(field, _SupportsCapturedCallable):
-        field = field._captured_callable
-
-    mode = field._mode
-    model = field._model
-
-    raise ValueError(f"A callable of mode `{mode}` has been provided. Please wrap it inside the `{model}(figure=...)`.")
+    raise ValueError(
+        f"A callable of mode `{captured_callable._mode}` has been provided. Please wrap it inside the "
+        f"`{captured_callable._model}(figure=...)`."
+    )

--- a/vizro-core/src/vizro/models/_models_utils.py
+++ b/vizro-core/src/vizro/models/_models_utils.py
@@ -34,5 +34,5 @@ def check_captured_callable(cls, value):
 
     raise ValueError(
         f"A callable of mode `{captured_callable._mode}` has been provided. Please wrap it inside the "
-        f"`{captured_callable._model}(figure=...)`."
+        f"`{captured_callable._model_example}`."
     )

--- a/vizro-core/src/vizro/models/_models_utils.py
+++ b/vizro-core/src/vizro/models/_models_utils.py
@@ -33,6 +33,6 @@ def check_captured_callable(cls, value):
         return value
 
     raise ValueError(
-        f"A callable of mode `{captured_callable._mode}` has been provided. Please wrap it inside the "
+        f"A callable of mode `{captured_callable._mode}` has been provided. Please wrap it inside "
         f"`{captured_callable._model_example}`."
     )

--- a/vizro-core/src/vizro/models/_models_utils.py
+++ b/vizro-core/src/vizro/models/_models_utils.py
@@ -1,7 +1,7 @@
 import logging
 from functools import wraps
 
-from vizro.models.types import CapturedCallable
+from vizro.models.types import CapturedCallable, _DashboardReadyFigure
 
 logger = logging.getLogger(__name__)
 
@@ -33,8 +33,12 @@ def check_captured_callable(cls, field):
     }
 
     for component in field:
-        if isinstance(component, CapturedCallable):
-            error_message = mode_to_error.get(f"{component._mode}", None)
+        if isinstance(component, (_DashboardReadyFigure, CapturedCallable)):
+            mode = (
+                component._captured_callable._mode if isinstance(component, _DashboardReadyFigure) else component._mode
+            )
+            error_message = mode_to_error.get(mode)
             if error_message:
                 raise ValueError(error_message)
+
     return field

--- a/vizro-core/src/vizro/models/_models_utils.py
+++ b/vizro-core/src/vizro/models/_models_utils.py
@@ -24,7 +24,7 @@ def validate_min_length(cls, field):
     return field
 
 
-def validate_components_type(cls, field):
+def check_captured_callable(cls, field):
     mode_to_error = {
         "figure": "A callable of mode `figure` has been provided. Please wrap it inside the `vm.Figure(figure=...)`.",
         "table": "A callable of mode `table` has been provided. Please wrap it inside the `vm.Table(figure=...)`.",

--- a/vizro-core/src/vizro/models/_models_utils.py
+++ b/vizro-core/src/vizro/models/_models_utils.py
@@ -17,21 +17,19 @@ def _log_call(method):
     return _wrapper
 
 
-
 # Validators for reuse
-def _validate_min_length(cls, field):
+def validate_min_length(cls, field):
     if not field:
         raise ValueError("Ensure this value has at least 1 item.")
+    return field
 
-def validate_components(cls, field):
-    _validate_min_length(cls, field)
 
-    # Validate CapturedCallable has been directly provided.
+def validate_components_type(cls, field):
     mode_to_error = {
         "figure": "A callable of mode `figure` has been provided. Please wrap it inside the `vm.Figure(figure=...)`.",
         "table": "A callable of mode `table` has been provided. Please wrap it inside the `vm.Table(figure=...)`.",
         "ag_grid": "A callable of mode `ag_grid` has been provided. Please wrap it inside the `vm.AgGrid(figure=...)`.",
-        "graph": "A callable of mode `graph` has been provided. Please wrap it inside the `vm.AgGrid(figure=...)`.",
+        "graph": "A callable of mode `graph` has been provided. Please wrap it inside the `vm.Graph(figure=...)`.",
     }
 
     for component in field:

--- a/vizro-core/src/vizro/models/_page.py
+++ b/vizro-core/src/vizro/models/_page.py
@@ -16,7 +16,7 @@ from vizro.managers._model_manager import DuplicateIDError, ModelID
 from vizro.models import Action, Layout, VizroBaseModel
 from vizro.models._action._actions_chain import ActionsChain, Trigger
 from vizro.models._layout import set_layout
-from vizro.models._models_utils import _log_call, validate_components_type, validate_min_length
+from vizro.models._models_utils import _log_call, check_captured_callable, validate_min_length
 
 from .types import ComponentType, ControlType
 
@@ -52,7 +52,7 @@ class Page(VizroBaseModel):
     actions: List[ActionsChain] = []
 
     # Re-used validators
-    _validate_components_type = validator("components", allow_reuse=True, always=True, pre=True)(validate_components_type)
+    _check_captured_callable = validator("components", allow_reuse=True, always=True, pre=True)(check_captured_callable)
     _validate_components_length = validator("components", allow_reuse=True, always=True)(validate_min_length)
     _validate_layout = validator("layout", allow_reuse=True, always=True)(set_layout)
 

--- a/vizro-core/src/vizro/models/_page.py
+++ b/vizro-core/src/vizro/models/_page.py
@@ -16,7 +16,7 @@ from vizro.managers._model_manager import DuplicateIDError, ModelID
 from vizro.models import Action, Layout, VizroBaseModel
 from vizro.models._action._actions_chain import ActionsChain, Trigger
 from vizro.models._layout import set_layout
-from vizro.models._models_utils import _log_call, validate_components
+from vizro.models._models_utils import _log_call, validate_components_type, validate_min_length
 
 from .types import ComponentType, ControlType
 
@@ -52,7 +52,8 @@ class Page(VizroBaseModel):
     actions: List[ActionsChain] = []
 
     # Re-used validators
-    _validate_components = validator("components", allow_reuse=True, always=True, pre=True)(validate_components)
+    _validate_components_type = validator("components", allow_reuse=True, always=True, pre=True)(validate_components_type)
+    _validate_components_length = validator("components", allow_reuse=True, always=True)(validate_min_length)
     _validate_layout = validator("layout", allow_reuse=True, always=True)(set_layout)
 
     @root_validator(pre=True)

--- a/vizro-core/src/vizro/models/_page.py
+++ b/vizro-core/src/vizro/models/_page.py
@@ -55,7 +55,7 @@ class Page(VizroBaseModel):
     _check_captured_callable = validator("components", allow_reuse=True, each_item=True, pre=True)(
         check_captured_callable
     )
-    _validate_components_length = validator("components", allow_reuse=True, always=True)(validate_min_length)
+    _validate_min_length = validator("components", allow_reuse=True, always=True)(validate_min_length)
     _validate_layout = validator("layout", allow_reuse=True, always=True)(set_layout)
 
     @root_validator(pre=True)

--- a/vizro-core/src/vizro/models/_page.py
+++ b/vizro-core/src/vizro/models/_page.py
@@ -16,7 +16,7 @@ from vizro.managers._model_manager import DuplicateIDError, ModelID
 from vizro.models import Action, Layout, VizroBaseModel
 from vizro.models._action._actions_chain import ActionsChain, Trigger
 from vizro.models._layout import set_layout
-from vizro.models._models_utils import _log_call, _validate_min_length
+from vizro.models._models_utils import _log_call, validate_components
 
 from .types import ComponentType, ControlType
 
@@ -52,7 +52,7 @@ class Page(VizroBaseModel):
     actions: List[ActionsChain] = []
 
     # Re-used validators
-    _validate_components = validator("components", allow_reuse=True, always=True)(_validate_min_length)
+    _validate_components = validator("components", allow_reuse=True, always=True, pre=True)(validate_components)
     _validate_layout = validator("layout", allow_reuse=True, always=True)(set_layout)
 
     @root_validator(pre=True)

--- a/vizro-core/src/vizro/models/_page.py
+++ b/vizro-core/src/vizro/models/_page.py
@@ -52,7 +52,9 @@ class Page(VizroBaseModel):
     actions: List[ActionsChain] = []
 
     # Re-used validators
-    _check_captured_callable = validator("components", allow_reuse=True, always=True, pre=True)(check_captured_callable)
+    _check_captured_callable = validator("components", allow_reuse=True, each_item=True, pre=True)(
+        check_captured_callable
+    )
     _validate_components_length = validator("components", allow_reuse=True, always=True)(validate_min_length)
     _validate_layout = validator("layout", allow_reuse=True, always=True)(set_layout)
 

--- a/vizro-core/src/vizro/models/types.py
+++ b/vizro-core/src/vizro/models/types.py
@@ -96,8 +96,9 @@ class CapturedCallable:
             self.__bound_arguments.update(self.__bound_arguments[var_keyword_param])
             del self.__bound_arguments[var_keyword_param]
 
-        # This is used to check that the mode of the capture decorator matches the inserted captured callable.
+        # Used in later validations of the captured callable.
         self._mode = None
+        self._model_example = None
 
     def __call__(self, *args, **kwargs):
         """Run the `function` with the initially bound arguments overridden by `**kwargs`.
@@ -283,7 +284,7 @@ class capture:
 
     def __init__(self, mode: Literal["graph", "action", "table", "ag_grid", "figure"]):
         """Decorator to capture a function call."""
-        # mode and model are used in later validations of the captured callable.
+        # mode and model_example are used in later validations of the captured callable.
         self._mode = mode
         model_examples = {
             "graph": "vm.Graph(figure=...)",

--- a/vizro-core/src/vizro/models/types.py
+++ b/vizro-core/src/vizro/models/types.py
@@ -285,14 +285,14 @@ class capture:
         """Decorator to capture a function call."""
         # mode and model are used in later validations of the captured callable.
         self._mode = mode
-        mode_to_model = {
-            "graph": "vm.Graph",
-            "action": "vm.Action",
-            "table": "vm.Table",
-            "ag_grid": "vm.AgGrid",
-            "figure": "vm.Figure",
+        model_examples = {
+            "graph": "vm.Graph(figure=...)",
+            "action": "vm.Action(function=...)",
+            "table": "vm.Table(figure=...)",
+            "ag_grid": "vm.AgGrid(figure=...)",
+            "figure": "vm.Figure(figure=...)",
         }
-        self._model = mode_to_model[mode]
+        self._model_example = model_examples[mode]
 
     def __call__(self, func, /):
         """Produces a CapturedCallable or _DashboardReadyFigure.
@@ -316,7 +316,7 @@ class capture:
                 # positional or keyword, this is much more robust than trying to get it out of arg or kwargs ourselves.
                 captured_callable: CapturedCallable = CapturedCallable(func, *args, **kwargs)
                 captured_callable._mode = self._mode
-                captured_callable._model = self._model
+                captured_callable._model_example = self._model_example
 
                 try:
                     captured_callable["data_frame"]
@@ -344,7 +344,7 @@ class capture:
                 # Note this is basically the same as partial(func, *args, **kwargs)
                 captured_callable: CapturedCallable = CapturedCallable(func, *args, **kwargs)
                 captured_callable._mode = self._mode
-                captured_callable._model = self._model
+                captured_callable._model_example = self._model_example
                 return captured_callable
 
             return wrapped
@@ -357,7 +357,7 @@ class capture:
 
                 captured_callable: CapturedCallable = CapturedCallable(func, *args, **kwargs)
                 captured_callable._mode = self._mode
-                captured_callable._model = self._model
+                captured_callable._model_example = self._model_example
 
                 try:
                     captured_callable["data_frame"]

--- a/vizro-core/src/vizro/models/types.py
+++ b/vizro-core/src/vizro/models/types.py
@@ -283,7 +283,16 @@ class capture:
 
     def __init__(self, mode: Literal["graph", "action", "table", "ag_grid", "figure"]):
         """Decorator to capture a function call."""
+        # mode and model are used in later validations of the captured callable.
         self._mode = mode
+        mode_to_model = {
+            "graph": "vm.Graph",
+            "action": "vm.Action",
+            "table": "vm.Table",
+            "ag_grid": "vm.AgGrid",
+            "figure": "vm.Figure",
+        }
+        self._model = mode_to_model[mode]
 
     def __call__(self, func, /):
         """Produces a CapturedCallable or _DashboardReadyFigure.
@@ -307,6 +316,7 @@ class capture:
                 # positional or keyword, this is much more robust than trying to get it out of arg or kwargs ourselves.
                 captured_callable: CapturedCallable = CapturedCallable(func, *args, **kwargs)
                 captured_callable._mode = self._mode
+                captured_callable._model = self._model
 
                 try:
                     captured_callable["data_frame"]
@@ -334,6 +344,7 @@ class capture:
                 # Note this is basically the same as partial(func, *args, **kwargs)
                 captured_callable: CapturedCallable = CapturedCallable(func, *args, **kwargs)
                 captured_callable._mode = self._mode
+                captured_callable._model = self._model
                 return captured_callable
 
             return wrapped
@@ -346,6 +357,7 @@ class capture:
 
                 captured_callable: CapturedCallable = CapturedCallable(func, *args, **kwargs)
                 captured_callable._mode = self._mode
+                captured_callable._model = self._model
 
                 try:
                     captured_callable["data_frame"]

--- a/vizro-core/src/vizro/tables/_dash_ag_grid.py
+++ b/vizro-core/src/vizro/tables/_dash_ag_grid.py
@@ -48,7 +48,15 @@ _DATA_TYPE_DEFINITIONS = {
 
 @capture("ag_grid")
 def dash_ag_grid(data_frame: pd.DataFrame, **kwargs) -> dag.AgGrid:
-    """Implementation of `dash_ag_grid.AgGrid` with sensible defaults to be used in [`AgGrid`][vizro.models.AgGrid]."""
+    """Implementation of `dash_ag_grid.AgGrid` with sensible defaults to be used in [`AgGrid`][vizro.models.AgGrid].
+
+    Examples
+        Wrap inside `vm.AgGrid` to use as a component inside `vm.Page` or `vm.Container`.
+        >>> import vizro.models as vm
+        >>> from vizro.tables import dash_ag_grid
+        >>> vm.Page(title="Page", components=[vm.AgGrid(figure=dash_ag_grid(...))])
+
+    """
     defaults = {
         "className": "ag-theme-quartz-dark ag-theme-vizro",
         "columnDefs": [{"field": col} for col in data_frame.columns],

--- a/vizro-core/src/vizro/tables/_dash_table.py
+++ b/vizro-core/src/vizro/tables/_dash_table.py
@@ -9,7 +9,15 @@ from vizro.tables._utils import _set_defaults_nested
 
 @capture("table")
 def dash_data_table(data_frame: pd.DataFrame, **kwargs) -> dash_table.DataTable:
-    """Standard `dash_table.DataTable` with sensible defaults to be used in [`Table`][vizro.models.Table]."""
+    """Standard `dash_table.DataTable` with sensible defaults to be used in [`Table`][vizro.models.Table].
+
+    Examples
+        Wrap inside `vm.Table` to use as a component inside `vm.Page` or `vm.Container`.
+        >>> import vizro.models as vm
+        >>> from vizro.table import dash_data_table
+        >>> vm.Page(title="Page", components=[vm.Table(figure=dash_data_table(...))])
+
+    """
     defaults = {
         "columns": [{"name": col, "id": col} for col in data_frame.columns],
         "style_as_list_view": True,

--- a/vizro-core/tests/unit/vizro/conftest.py
+++ b/vizro-core/tests/unit/vizro/conftest.py
@@ -5,6 +5,7 @@ import pytest
 import vizro.models as vm
 import vizro.plotly.express as px
 from vizro import Vizro
+from vizro.figures import kpi_card
 from vizro.tables import dash_ag_grid, dash_data_table
 
 
@@ -59,6 +60,16 @@ def dash_data_table_with_id(gapminder):
 @pytest.fixture
 def standard_go_chart(gapminder):
     return go.Figure(data=go.Scatter(x=gapminder["gdpPercap"], y=gapminder["lifeExp"], mode="markers"))
+
+
+@pytest.fixture
+def standard_kpi_card(gapminder):
+    return kpi_card(
+        data_frame=gapminder,
+        value_column="lifeExp",
+        agg_func="mean",
+        value_format="{value:.3f}",
+    )
 
 
 @pytest.fixture

--- a/vizro-core/tests/unit/vizro/models/_components/test_figure.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_figure.py
@@ -27,12 +27,12 @@ def kpi_card_with_str_dataframe():
 
 
 class TestFigureInstantiation:
-    def test_create_figure_mandatory_only(self, kpi_card_with_dataframe):
-        figure = vm.Figure(figure=kpi_card_with_dataframe)
+    def test_create_figure_mandatory_only(self, standard_kpi_card):
+        figure = vm.Figure(figure=standard_kpi_card)
 
         assert hasattr(figure, "id")
         assert figure.type == "figure"
-        assert figure.figure == kpi_card_with_dataframe
+        assert figure.figure == standard_kpi_card
 
     def test_captured_callable_invalid(self, standard_go_chart):
         with pytest.raises(
@@ -56,15 +56,15 @@ class TestFigureInstantiation:
 
 
 class TestDunderMethodsFigure:
-    def test_getitem_known_args(self, kpi_card_with_dataframe):
-        figure = vm.Figure(figure=kpi_card_with_dataframe)
+    def test_getitem_known_args(self, standard_kpi_card):
+        figure = vm.Figure(figure=standard_kpi_card)
         assert figure["value_column"] == "lifeExp"
         assert figure["agg_func"] == "mean"
         assert figure["value_format"] == "{value:.3f}"
         assert figure["type"] == "figure"
 
-    def test_getitem_unknown_args(self, kpi_card_with_dataframe):
-        figure = vm.Figure(figure=kpi_card_with_dataframe)
+    def test_getitem_unknown_args(self, standard_kpi_card):
+        figure = vm.Figure(figure=standard_kpi_card)
         with pytest.raises(KeyError):
             figure["unknown_args"]
 
@@ -75,14 +75,14 @@ class TestProcessFigureDataFrame:
         figure = vm.Figure(figure=kpi_card_with_str_dataframe)
         assert data_manager[figure["data_frame"]].load().equals(gapminder)
 
-    def test_process_figure_data_frame_df(self, kpi_card_with_dataframe, gapminder):
-        figure = vm.Figure(figure=kpi_card_with_dataframe)
+    def test_process_figure_data_frame_df(self, standard_kpi_card, gapminder):
+        figure = vm.Figure(figure=standard_kpi_card)
         assert data_manager[figure["data_frame"]].load().equals(gapminder)
 
 
 class TestFigureBuild:
-    def test_figure_build(self, kpi_card_with_dataframe, gapminder):
-        figure = vm.Figure(id="figure-id", figure=kpi_card_with_dataframe).build()
+    def test_figure_build(self, standard_kpi_card, gapminder):
+        figure = vm.Figure(id="figure-id", figure=standard_kpi_card).build()
 
         expected_figure = dcc.Loading(
             html.Div(

--- a/vizro-core/tests/unit/vizro/models/_components/test_figure.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_figure.py
@@ -17,16 +17,6 @@ from vizro.managers import data_manager
 
 
 @pytest.fixture
-def kpi_card_with_dataframe(gapminder):
-    return kpi_card(
-        data_frame=gapminder,
-        value_column="lifeExp",
-        agg_func="mean",
-        value_format="{value:.3f}",
-    )
-
-
-@pytest.fixture
 def kpi_card_with_str_dataframe():
     return kpi_card(
         data_frame="gapminder",

--- a/vizro-core/tests/unit/vizro/models/conftest.py
+++ b/vizro-core/tests/unit/vizro/models/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 import vizro.models as vm
-from vizro.figures import kpi_card
 from vizro.models.types import capture
 
 
@@ -16,13 +15,3 @@ def identity_action_function():
 @pytest.fixture(params=[vm.Container, vm.Page])
 def model_with_layout(request):
     return request.param
-
-
-@pytest.fixture
-def kpi_card_with_dataframe(gapminder):
-    return kpi_card(
-        data_frame=gapminder,
-        value_column="lifeExp",
-        agg_func="mean",
-        value_format="{value:.3f}",
-    )

--- a/vizro-core/tests/unit/vizro/models/conftest.py
+++ b/vizro-core/tests/unit/vizro/models/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 import vizro.models as vm
+from vizro.figures import kpi_card
 from vizro.models.types import capture
 
 
@@ -15,3 +16,13 @@ def identity_action_function():
 @pytest.fixture(params=[vm.Container, vm.Page])
 def model_with_layout(request):
     return request.param
+
+
+@pytest.fixture
+def kpi_card_with_dataframe(gapminder):
+    return kpi_card(
+        data_frame=gapminder,
+        value_column="lifeExp",
+        agg_func="mean",
+        value_format="{value:.3f}",
+    )

--- a/vizro-core/tests/unit/vizro/models/test_models_utils.py
+++ b/vizro-core/tests/unit/vizro/models/test_models_utils.py
@@ -11,9 +11,16 @@ import vizro.models as vm
 
 
 class TestSharedValidators:
-    def test_set_components_validator(self, model_with_layout):
+    def test_validate_min_length(self, model_with_layout):
         with pytest.raises(ValidationError, match="Ensure this value has at least 1 item."):
             model_with_layout(title="Title", components=[])
+
+    def test_validate_components_type(self, model_with_layout, standard_px_chart):
+        with pytest.raises(
+            ValidationError,
+            match="A callable of mode `graph` has been provided. " "Please wrap it inside the `vm.Graph(figure=...)`.",
+        ):
+            model_with_layout(title="Title", components=[standard_px_chart])
 
     def test_check_for_valid_component_types(self, model_with_layout):
         with pytest.raises(

--- a/vizro-core/tests/unit/vizro/models/test_models_utils.py
+++ b/vizro-core/tests/unit/vizro/models/test_models_utils.py
@@ -20,19 +20,19 @@ class TestSharedValidators:
         [
             (
                 "standard_px_chart",
-                "A callable of mode `graph` has been provided. Please wrap it inside the `vm.Graph(figure=...)`",
+                "A callable of mode `graph` has been provided. Please wrap it inside `vm.Graph(figure=...)`",
             ),
             (
                 "standard_ag_grid",
-                "A callable of mode `ag_grid` has been provided. Please wrap it inside the `vm.AgGrid(figure=...)`",
+                "A callable of mode `ag_grid` has been provided. Please wrap it inside `vm.AgGrid(figure=...)`",
             ),
             (
                 "standard_dash_table",
-                "A callable of mode `table` has been provided. Please wrap it inside the `vm.Table(figure=...)`",
+                "A callable of mode `table` has been provided. Please wrap it inside `vm.Table(figure=...)`",
             ),
             (
                 "standard_kpi_card",
-                "A callable of mode `figure` has been provided. Please wrap it inside the `vm.Figure(figure=...)`",
+                "A callable of mode `figure` has been provided. Please wrap it inside `vm.Figure(figure=...)`",
             ),
         ],
     )

--- a/vizro-core/tests/unit/vizro/models/test_models_utils.py
+++ b/vizro-core/tests/unit/vizro/models/test_models_utils.py
@@ -15,7 +15,7 @@ class TestSharedValidators:
         with pytest.raises(ValidationError, match="Ensure this value has at least 1 item."):
             model_with_layout(title="Title", components=[])
 
-    def test_validate_components_type(self, model_with_layout, standard_px_chart):
+    def test_check_captured_callable(self, model_with_layout, standard_px_chart):
         with pytest.raises(
             ValidationError,
             match="A callable of mode `graph` has been provided. " "Please wrap it inside the `vm.Graph(figure=...)`.",

--- a/vizro-core/tests/unit/vizro/models/test_models_utils.py
+++ b/vizro-core/tests/unit/vizro/models/test_models_utils.py
@@ -15,12 +15,14 @@ class TestSharedValidators:
         with pytest.raises(ValidationError, match="Ensure this value has at least 1 item."):
             model_with_layout(title="Title", components=[])
 
-    def test_check_captured_callable(self, model_with_layout, standard_px_chart):
+    def test_check_captured_callable(self, model_with_layout, kpi_card_with_dataframe):
         with pytest.raises(
             ValidationError,
-            match="A callable of mode `graph` has been provided. " "Please wrap it inside the `vm.Graph(figure=...)`.",
+            match=re.escape(
+                "A callable of mode `figure` has been provided. Please wrap it inside the `vm.Figure(figure=...)`."
+            ),
         ):
-            model_with_layout(title="Title", components=[standard_px_chart])
+            model_with_layout(title="Title", components=[kpi_card_with_dataframe])
 
     def test_check_for_valid_component_types(self, model_with_layout):
         with pytest.raises(

--- a/vizro-core/tests/unit/vizro/models/test_models_utils.py
+++ b/vizro-core/tests/unit/vizro/models/test_models_utils.py
@@ -15,14 +15,30 @@ class TestSharedValidators:
         with pytest.raises(ValidationError, match="Ensure this value has at least 1 item."):
             model_with_layout(title="Title", components=[])
 
-    def test_check_captured_callable(self, model_with_layout, kpi_card_with_dataframe):
-        with pytest.raises(
-            ValidationError,
-            match=re.escape(
-                "A callable of mode `figure` has been provided. Please wrap it inside the `vm.Figure(figure=...)`."
+    @pytest.mark.parametrize(
+        "captured_callable, error_message",
+        [
+            (
+                "standard_px_chart",
+                "A callable of mode `graph` has been provided. Please wrap it inside the `vm.Graph(figure=...)`",
             ),
-        ):
-            model_with_layout(title="Title", components=[kpi_card_with_dataframe])
+            (
+                "standard_ag_grid",
+                "A callable of mode `ag_grid` has been provided. Please wrap it inside the `vm.AgGrid(figure=...)`",
+            ),
+            (
+                "standard_dash_table",
+                "A callable of mode `table` has been provided. Please wrap it inside the `vm.Table(figure=...)`",
+            ),
+            (
+                "standard_kpi_card",
+                "A callable of mode `figure` has been provided. Please wrap it inside the `vm.Figure(figure=...)`",
+            ),
+        ],
+    )
+    def test_check_captured_callable(self, model_with_layout, captured_callable, error_message, request):
+        with pytest.raises(ValidationError, match=re.escape(error_message)):
+            model_with_layout(title="Title", components=[request.getfixturevalue(captured_callable)])
 
     def test_check_for_valid_component_types(self, model_with_layout):
         with pytest.raises(


### PR DESCRIPTION
## Description
- Improve validation error if CapturedCallable is directly provided as a  `component`
- Context: https://github.com/mckinsey/vizro/issues/588

Thanks to @objectivitydrx for raising the bug and making a suggestion to improve our docs! 📝 🚀 

## Screenshot
![Screenshot 2024-07-18 at 15 40 20](https://github.com/user-attachments/assets/d85d5c96-e49c-4f56-8cc6-e26979a25fab)

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
