### PR TITLE
[Bug] Fix a false positive in integration test

### DIFF
--- a/vizro-ai/changelog.d/20240730_121955_lingyi_zhang_fix_false_positive.md
+++ b/vizro-ai/changelog.d/20240730_121955_lingyi_zhang_fix_false_positive.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-ai/tests/integration/test_example.py
+++ b/vizro-ai/tests/integration/test_example.py
@@ -43,9 +43,15 @@ def test_chart_with_explanation():
     assert_that(
         resp.business_insights,
         any_of(
-            contains_string("GDP per capita in the United States"),
-            contains_string("GDP in the United States"),
-            contains_string("GDP in the US"),
+            contains_string("GDP per capita"),
+            contains_string("GDP"),
+        ),
+    )
+    assert_that(
+        resp.business_insights,
+        any_of(
+            contains_string("United States"),
+            contains_string("US"),
         ),
     )
     assert_that(


### PR DESCRIPTION
## Description
This test often failed due to a false positive like this:
```
>       assert_that(
            resp.business_insights,
            any_of(
                contains_string("GDP per capita in the United States"),
                contains_string("GDP in the United States"),
                contains_string("GDP in the US"),
            ),
        )
E       AssertionError: 
E       Expected: (a string containing 'GDP per capita in the United States' or a string containing 'GDP in the United States' or a string containing 'GDP in the US')
E            but: was 'The code snippet generates a bar chart showing the composition of GDP per capita in the US over the years. It provides a visual representation of how GDP per capita has changed annually in the US.'
```


## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
