### PR TITLE
[Bug] Fix display of marks in `vm.Slider` and `vm.RangeSlider`

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -21,6 +21,6 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/labeler@v4
+      - uses: actions/labeler@v5
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/vizro-core/changelog.d/20240801_152834_huong_li_nguyen_fix_slider_type.md
+++ b/vizro-core/changelog.d/20240801_152834_huong_li_nguyen_fix_slider_type.md
@@ -37,7 +37,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Fixed
 
-- Fix display of marks in `vm.Slider` and `vm.RangeSlider` by converting floats to integers when possible. ([#609](https://github.com/mckinsey/vizro/pull/609))
+- Fix display of marks in `vm.Slider` and `vm.RangeSlider` by converting floats to integers when possible. ([#613](https://github.com/mckinsey/vizro/pull/613))
 
 <!--
 ### Security

--- a/vizro-core/changelog.d/20240801_152834_huong_li_nguyen_fix_slider_type.md
+++ b/vizro-core/changelog.d/20240801_152834_huong_li_nguyen_fix_slider_type.md
@@ -1,0 +1,47 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+
+### Fixed
+
+- Fix display of marks in `vm.Slider` and `vm.RangeSlider` by converting floats to integers when possible. ([#609](https://github.com/mckinsey/vizro/pull/609))
+
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -27,6 +27,9 @@ b = dict(min=0, max=2, step=0.1, marks={0: "a", 1: "x", 2: "y"})  # noqa: C408
 # Mixed float and int: This works in Vizro, while it only partially works in Dash
 c = dict(min=0, max=1, step=0.1, marks={0: "a", 0.5: "x", 1.0: "y"})  # noqa: C408
 
+# User example
+e = dict(min=0, max=1, step=0.01, marks={0: "0%", 0.21: "MARKET", 1.0: "100%"})  # noqa: C408
+
 # Other test example: https://github.com/mckinsey/vizro/pull/266
 d = dict(min=2, max=5, step=1, value=3)  # noqa: C408
 
@@ -35,17 +38,18 @@ page = vm.Page(
     components=[
         vm.Container(
             title="vm.Sliders",
-            layout=vm.Layout(grid=[[0, 1, 2, 3]]),
-            components=[vm.Slider(**a), vm.Slider(**b), vm.Slider(**c), vm.Slider(**d)],
+            layout=vm.Layout(grid=[[0, 1, 2, 3, 4]]),
+            components=[vm.Slider(**a), vm.Slider(**b), vm.Slider(**c), vm.Slider(**d), vm.Slider(**e)],
         ),
         vm.Container(
             title="dcc.Sliders",
-            layout=vm.Layout(grid=[[0, 1, 2, 3]]),
+            layout=vm.Layout(grid=[[0, 1, 2, 3, 4]]),
             components=[
                 PureDashSlider(kwargs=a),
                 PureDashSlider(kwargs=b),
                 PureDashSlider(kwargs=c),
                 PureDashSlider(kwargs=d),
+                PureDashSlider(kwargs=e),
             ],
         ),
     ],

--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -8,10 +8,13 @@ from vizro import Vizro
 
 
 class PureDashSlider(vm.VizroBaseModel):
+    """Simple Dash Slider."""
+
     type: Literal["simple_slider"] = "simple_slider"
     kwargs: Any
 
     def build(self):
+        """Pure Slider component."""
         return dcc.Slider(**self.kwargs)
 
 

--- a/vizro-core/schemas/0.1.20.dev0.json
+++ b/vizro-core/schemas/0.1.20.dev0.json
@@ -857,14 +857,7 @@
           "default": {},
           "type": "object",
           "additionalProperties": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "object"
-              }
-            ]
+            "type": "string"
           }
         },
         "value": {
@@ -932,14 +925,7 @@
           "default": {},
           "type": "object",
           "additionalProperties": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "object"
-              }
-            ]
+            "type": "string"
           }
         },
         "value": {

--- a/vizro-core/src/vizro/models/_components/form/_form_utils.py
+++ b/vizro-core/src/vizro/models/_components/form/_form_utils.py
@@ -105,6 +105,12 @@ def validate_step(cls, step, values):
 def set_default_marks(cls, marks, values):
     if not marks and values.get("step") is None:
         marks = None
+
+    # Dash has a bug where marks provided as floats that can be converted to integers are not displayed.
+    # So we need to convert the floats to integers if possible.
+    # https://github.com/plotly/dash-core-components/issues/159#issuecomment-380581043
+    if marks:
+        marks = {int(k) if k.is_integer() else k: v for k, v in marks.items()}
     return marks
 
 

--- a/vizro-core/src/vizro/models/_components/form/range_slider.py
+++ b/vizro-core/src/vizro/models/_components/form/range_slider.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Dict, List, Literal, Optional
 
 from dash import ClientsideFunction, Input, Output, State, clientside_callback, dcc, html
 
@@ -43,7 +43,7 @@ class RangeSlider(VizroBaseModel):
     min: Optional[float] = Field(None, description="Start value for slider.")
     max: Optional[float] = Field(None, description="End value for slider.")
     step: Optional[float] = Field(None, description="Step-size for marks on slider.")
-    marks: Optional[Dict[int, Union[str, Dict[str, Any]]]] = Field({}, description="Marks to be displayed on slider.")
+    marks: Optional[Dict[float, str]] = Field({}, description="Marks to be displayed on slider.")
     value: Optional[List[float]] = Field(
         None, description="Default start and end value for slider", min_items=2, max_items=2
     )

--- a/vizro-core/src/vizro/models/_components/form/slider.py
+++ b/vizro-core/src/vizro/models/_components/form/slider.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Dict, List, Literal, Optional
 
 from dash import ClientsideFunction, Input, Output, State, clientside_callback, dcc, html
 
@@ -43,7 +43,7 @@ class Slider(VizroBaseModel):
     min: Optional[float] = Field(None, description="Start value for slider.")
     max: Optional[float] = Field(None, description="End value for slider.")
     step: Optional[float] = Field(None, description="Step-size for marks on slider.")
-    marks: Optional[Dict[int, Union[str, Dict[str, Any]]]] = Field({}, description="Marks to be displayed on slider.")
+    marks: Optional[Dict[float, str]] = Field({}, description="Marks to be displayed on slider.")
     value: Optional[float] = Field(None, description="Default value for slider.")
     title: str = Field("", description="Title to be displayed.")
     actions: List[Action] = []

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_range_slider.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_range_slider.py
@@ -229,15 +229,19 @@ class TestRangeSliderInstantiation:
         "marks, expected",
         [
             ({i: str(i) for i in range(0, 10, 5)}, {i: str(i) for i in range(0, 10, 5)}),
-            ({15: 15, 25: 25}, {15.0: "15", 25.0: "25"}),
-            ({"15": 15, "25": 25}, {15.0: "15", 25.0: "25"}),
+            ({15: 15, 25: 25}, {15: "15", 25: "25"}),  # all int
+            ({15.5: 15.5, 25.5: 25.5}, {15.5: "15.5", 25.5: "25.5"}),  # all floats
+            ({15.0: 15, 25.0: 25}, {15: "15", 25: "25"}),  # all floats, but convertible to int
+            ({"15": 15, "25": 25}, {15: "15", 25: "25"}),  # all string
             (None, None),
         ],
     )
     def test_valid_marks(self, marks, expected):
         range_slider = vm.RangeSlider(min=0, max=10, marks=marks)
-
         assert range_slider.marks == expected
+
+        if marks:
+            assert all(type(key) is type(next(iter(expected.keys()))) for key in range_slider.marks)
 
     def test_invalid_marks(self):
         with pytest.raises(ValidationError, match="2 validation errors for RangeSlider"):

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_range_slider.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_range_slider.py
@@ -231,7 +231,7 @@ class TestRangeSliderInstantiation:
             ({i: str(i) for i in range(0, 10, 5)}, {i: str(i) for i in range(0, 10, 5)}),
             ({15: 15, 25: 25}, {15: "15", 25: "25"}),  # all int
             ({15.5: 15.5, 25.5: 25.5}, {15.5: "15.5", 25.5: "25.5"}),  # all floats
-            ({15.0: 15, 25.5: 25.5}, {15: "15", 25.5: "25.5"}),  # all floats, but convertible to int
+            ({15.0: 15, 25.5: 25.5}, {15.0: "15", 25.5: "25.5"}),  # mixed floats
             ({"15": 15, "25": 25}, {15: "15", 25: "25"}),  # all string
             (None, None),
         ],
@@ -241,7 +241,9 @@ class TestRangeSliderInstantiation:
         assert range_slider.marks == expected
 
         if marks:
-            assert all(type(key) is type(next(iter(expected.keys()))) for key in range_slider.marks)
+            assert [type(result_key) for result_key in range_slider.marks] == [
+                type(expected_key) for expected_key in expected
+            ]
 
     def test_invalid_marks(self):
         with pytest.raises(ValidationError, match="2 validation errors for RangeSlider"):

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_range_slider.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_range_slider.py
@@ -231,7 +231,7 @@ class TestRangeSliderInstantiation:
             ({i: str(i) for i in range(0, 10, 5)}, {i: str(i) for i in range(0, 10, 5)}),
             ({15: 15, 25: 25}, {15: "15", 25: "25"}),  # all int
             ({15.5: 15.5, 25.5: 25.5}, {15.5: "15.5", 25.5: "25.5"}),  # all floats
-            ({15.0: 15, 25.5: 25.5}, {15.0: "15", 25.5: "25.5"}),  # mixed floats
+            ({15.0: 15, 25.5: 25.5}, {15: "15", 25.5: "25.5"}),  # mixed floats
             ({"15": 15, "25": 25}, {15: "15", 25: "25"}),  # all string
             (None, None),
         ],

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_range_slider.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_range_slider.py
@@ -231,7 +231,7 @@ class TestRangeSliderInstantiation:
             ({i: str(i) for i in range(0, 10, 5)}, {i: str(i) for i in range(0, 10, 5)}),
             ({15: 15, 25: 25}, {15: "15", 25: "25"}),  # all int
             ({15.5: 15.5, 25.5: 25.5}, {15.5: "15.5", 25.5: "25.5"}),  # all floats
-            ({15.0: 15, 25.0: 25}, {15: "15", 25: "25"}),  # all floats, but convertible to int
+            ({15.0: 15, 25.5: 25.5}, {15: "15", 25.5: "25.5"}),  # all floats, but convertible to int
             ({"15": 15, "25": 25}, {15: "15", 25: "25"}),  # all string
             (None, None),
         ],

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_slider.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_slider.py
@@ -122,7 +122,7 @@ class TestSliderInstantiation:
             ({i: str(i) for i in range(0, 10, 5)}, {i: str(i) for i in range(0, 10, 5)}),
             ({15: 15, 25: 25}, {15: "15", 25: "25"}),  # all int
             ({15.5: 15.5, 25.5: 25.5}, {15.5: "15.5", 25.5: "25.5"}),  # all floats
-            ({15.0: 15, 25.0: 25}, {15: "15", 25: "25"}),  # all floats, but convertible to int
+            ({15.0: 15, 25.5: 25.5}, {15: "15", 25.5: "25.5"}),  # all floats, but convertible to int
             ({"15": 15, "25": 25}, {15: "15", 25: "25"}),  # all string
             (None, None),
         ],

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_slider.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_slider.py
@@ -132,7 +132,7 @@ class TestSliderInstantiation:
         assert slider.marks == expected
 
         if marks:
-            assert all(type(key) == type(list(expected.keys())[0]) for key in slider.marks)
+            assert all(type(key) is type(next(iter(expected.keys()))) for key in slider.marks)
 
     def test_invalid_marks(self):
         with pytest.raises(ValidationError, match="2 validation errors for Slider"):

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_slider.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_slider.py
@@ -120,15 +120,19 @@ class TestSliderInstantiation:
         "marks, expected",
         [
             ({i: str(i) for i in range(0, 10, 5)}, {i: str(i) for i in range(0, 10, 5)}),
-            ({15: 15, 25: 25}, {15.0: "15", 25.0: "25"}),
-            ({"15": 15, "25": 25}, {15.0: "15", 25.0: "25"}),
+            ({15: 15, 25: 25}, {15: "15", 25: "25"}),  # all int
+            ({15.5: 15.5, 25.5: 25.5}, {15.5: "15.5", 25.5: "25.5"}),  # all floats
+            ({15.0: 15, 25.0: 25}, {15: "15", 25: "25"}),  # all floats, but convertible to int
+            ({"15": 15, "25": 25}, {15: "15", 25: "25"}),  # all string
             (None, None),
         ],
     )
     def test_valid_marks(self, marks, expected):
         slider = vm.Slider(min=0, max=10, marks=marks)
-
         assert slider.marks == expected
+
+        if marks:
+            assert all(type(key) == type(list(expected.keys())[0]) for key in slider.marks)
 
     def test_invalid_marks(self):
         with pytest.raises(ValidationError, match="2 validation errors for Slider"):

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_slider.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_slider.py
@@ -122,7 +122,7 @@ class TestSliderInstantiation:
             ({i: str(i) for i in range(0, 10, 5)}, {i: str(i) for i in range(0, 10, 5)}),
             ({15: 15, 25: 25}, {15: "15", 25: "25"}),  # all int
             ({15.5: 15.5, 25.5: 25.5}, {15.5: "15.5", 25.5: "25.5"}),  # all floats
-            ({15.0: 15, 25.5: 25.5}, {15: "15", 25.5: "25.5"}),  # all floats, but convertible to int
+            ({15.0: 15, 25.5: 25.5}, {15: "15", 25.5: "25.5"}),  # mixed floats
             ({"15": 15, "25": 25}, {15: "15", 25: "25"}),  # all string
             (None, None),
         ],
@@ -132,7 +132,9 @@ class TestSliderInstantiation:
         assert slider.marks == expected
 
         if marks:
-            assert all(type(key) is type(next(iter(expected.keys()))) for key in slider.marks)
+            assert [type(result_key) for result_key in slider.marks] == [
+                type(expected_key) for expected_key in expected
+            ]
 
     def test_invalid_marks(self):
         with pytest.raises(ValidationError, match="2 validation errors for Slider"):


### PR DESCRIPTION
## Description
Closes: https://github.com/mckinsey/vizro/issues/612: Previously, our marks were converted to integers, leading to incorrect value displays. This, combined with an existing bug in Dash, caused the marks to be displayed incorrectly.

- Fix typing inside `vm.Slider` and `vm.RangeSlider`
- Added a validator to consistently format floats to integers when possible, thus circumventing this Dash bug: https://github.com/plotly/dash-core-components/issues/159#issuecomment-380581043)

@nadijagraca - I noticed that we previously had the typing `marks: Optional[Dict[float, str]]`, but it was changed in this PR: https://github.com/mckinsey/vizro/issues/230. Do you remember the reason for this change? I couldn't reproduce the original bug that the PR fixes, so I'm uncertain if reverting to the original typing will cause any issues. Could you also take a look? 🤔

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
