### PR TITLE
[CI] Trigger vizro-qa fix

### DIFF
--- a/.github/workflows/vizro-qa-tests-trigger.yml
+++ b/.github/workflows/vizro-qa-tests-trigger.yml
@@ -17,6 +17,7 @@ jobs:
     name: Vizro QA ${{ matrix.label }} trigger
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - label: integration tests
@@ -30,6 +31,7 @@ jobs:
     name: Vizro QA ${{ matrix.label }} trigger
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - label: integration tests

--- a/.github/workflows/vizro-qa-tests-trigger.yml
+++ b/.github/workflows/vizro-qa-tests-trigger.yml
@@ -47,5 +47,5 @@ jobs:
           fi
           export INPUT_GITHUB_TOKEN=${{ secrets.VIZRO_SVC_PAT }}
           export INPUT_REF=main
-          export INPUT_CLIENT_PAYLOAD={"branch": "${{ github.head_ref }}"}
+          export INPUT_CLIENT_PAYLOAD='{"branch": "${{ github.head_ref }}"}'
           tools/trigger-workflow-and-wait.sh

--- a/.github/workflows/vizro-qa-tests-trigger.yml
+++ b/.github/workflows/vizro-qa-tests-trigger.yml
@@ -48,6 +48,6 @@ jobs:
             export INPUT_WORKFLOW_FILE_NAME=${{ secrets.VIZRO_QA_NOTEBOOKS_TESTS_WORKFLOW }}
           fi
           export INPUT_GITHUB_TOKEN=${{ secrets.VIZRO_SVC_PAT }}
-          export INPUT_REF=${{ github.head_ref }}
+          export INPUT_REF=main # because we should send existent branch to dispatch workflow
           export INPUT_CLIENT_PAYLOAD='{"branch": "${{ github.head_ref }}"}'
           tools/trigger-workflow-and-wait.sh

--- a/.github/workflows/vizro-qa-tests-trigger.yml
+++ b/.github/workflows/vizro-qa-tests-trigger.yml
@@ -46,6 +46,6 @@ jobs:
             export INPUT_WORKFLOW_FILE_NAME=${{ secrets.VIZRO_QA_NOTEBOOKS_TESTS_WORKFLOW }}
           fi
           export INPUT_GITHUB_TOKEN=${{ secrets.VIZRO_SVC_PAT }}
-          export INPUT_REF=main
+          export INPUT_REF=${{ github.head_ref }}
           export INPUT_CLIENT_PAYLOAD='{"branch": "${{ github.head_ref }}"}'
           tools/trigger-workflow-and-wait.sh

--- a/.github/workflows/vizro-qa-tests-trigger.yml
+++ b/.github/workflows/vizro-qa-tests-trigger.yml
@@ -46,5 +46,6 @@ jobs:
             export INPUT_WORKFLOW_FILE_NAME=${{ secrets.VIZRO_QA_NOTEBOOKS_TESTS_WORKFLOW }}
           fi
           export INPUT_GITHUB_TOKEN=${{ secrets.VIZRO_SVC_PAT }}
-          export INPUT_REF=${{ github.head_ref }}
+          export INPUT_REF=main
+          export INPUT_CLIENT_PAYLOAD={"branch": "${{ github.head_ref }}"}
           tools/trigger-workflow-and-wait.sh


### PR DESCRIPTION
## Description
Small fix for vizro-qa tests trigger.
The problem occurred because it tried to trigger non-existent branch. By default it would trigger main branch and in the vizro-qa tests logic it will checkout appropriate branch.

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
