### PR TITLE
[Docs] Add user example to `examples` page

### DIFF
--- a/vizro-core/docs/pages/examples/your-examples.md
+++ b/vizro-core/docs/pages/examples/your-examples.md
@@ -28,4 +28,5 @@ If you have something you'd like us to include on the list, or spot something th
 * [Personal Vizro app demos by Vizro team member `huong-li-nguyen`](https://github.com/huong-li-nguyen/vizro-app-demos).
 * [Proof of concept example by `viiviandias`](https://github.com/viiviandias/poc-vizro/blob/main/brasil_stocks.ipynb).
 * [Amazon sales analysis by `Bottleneck44`](https://github.com/Bottleneck44/Amazon-Sales-Analysis/blob/main/Amazon-analysis.ipynb).
+* [Insight-AI: Chart and business insight generation by `micky091` using vizro-ai](https://github.com/micky0919/insight-ai)
 <!-- vale on -->


### PR DESCRIPTION
## Description
@stichbury - I wasn't sure where best to add it. It is a `vizro-ai` example. However, to create a separate examples page just for `vizro-ai` didn't make much sense to me, so I've added it where the other `vizro` user examples live. But let me know if you disagree.

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
