### PR TITLE
[Feat] Add 4o-mini to model list

### DIFF
--- a/vizro-ai/changelog.d/20240809_143321_lingyi_zhang_4o_mini.md
+++ b/vizro-ai/changelog.d/20240809_143321_lingyi_zhang_4o_mini.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-ai/docs/pages/user-guides/customize-vizro-ai.md
+++ b/vizro-ai/docs/pages/user-guides/customize-vizro-ai.md
@@ -19,6 +19,8 @@ Vizro-AI currently supports the following [OpenAI models](https://platform.opena
     - gpt-3.5-turbo-1106
     - gpt-3.5-turbo-0125
     - gpt-4o-2024-05-13
+    - gpt-4o-mini-2024-07-18
+    - gpt-4o-mini
 
 === "Anthropic"
 
@@ -33,9 +35,9 @@ These models offer different levels of performance and cost to Vizro-AI users.
 
 ### Chart generation
 
-For chart creation with OpenAI, the **gpt-3.5** model series have lower price points and faster speeds for providing answers, but do not offer sophisticated charting.
+For chart creation with OpenAI, the **gpt-4o-mini** and **gpt-3.5** model series have lower price points and faster speeds for providing answers, but do not offer sophisticated charting.
 
-Consider upgrading to the **gpt-4** and **gpt-4o** model series for more demanding tasks. While they are part of a more capable GPT model series, they come at a higher cost.
+Consider upgrading to the **gpt-4o** and **gpt-4** model series for more demanding tasks. While they are part of a more capable GPT model series, they come at a higher cost.
 
 Refer to the [OpenAI documentation for more about model capabilities](https://platform.openai.com/docs/models/overview) and [pricing](https://openai.com/pricing).
 
@@ -46,8 +48,9 @@ Refer to the [OpenAI documentation for more about model capabilities](https://pl
 === "OpenAI"
 
     - gpt-3.5-turbo `default`: Ideal for smaller requests and simple specifications. However, due to the complexity of dashboard creation, `gpt-3.5-turbo` often produces incomplete responses for larger tasks.
-    - gpt-4-turbo: Excels in dashboard creation tasks, providing the most stable and complete responses.
-    - gpt-4o: Similar performance in terms of the quality of generated content. Compared to gpt-4-turbo, gpt-4o is much faster and cheaper.
+    - gpt-4o: Most ideal for dashboard generation tasks. Excels in dashboard creation tasks, providing stable and complete responses. Compared to gpt-4-turbo, gpt-4o is much faster and cheaper.
+    - gpt-4-turbo: Excels in dashboard creation tasks, providing stable and complete responses.
+    - gpt-4o-mini: Ideal for smaller requests and simple specifications. Most cost-effective. However, due to the complexity of dashboard creation, its performance is not stable.
 
 
 === "Anthropic"

--- a/vizro-ai/docs/pages/user-guides/customize-vizro-ai.md
+++ b/vizro-ai/docs/pages/user-guides/customize-vizro-ai.md
@@ -35,9 +35,9 @@ These models offer different levels of performance and cost to Vizro-AI users.
 
 ### Chart generation
 
-For chart creation with OpenAI, the **gpt-4o-mini** and **gpt-3.5** model series have lower price points and faster speeds for providing answers, but do not offer sophisticated charting.
+For basic chart creation with OpenAI, the **gpt-4o-mini** and **gpt-3.5** model series have lower price points and faster speeds, but they do not offer sophisticated charting.
 
-Consider upgrading to the **gpt-4o** and **gpt-4** model series for more demanding tasks. While they are part of a more capable GPT model series, they come at a higher cost.
+Consider upgrading to the **gpt-4o** and **gpt-4** model series for more demanding tasks. The downside of using these models is that they come at a higher cost.
 
 Refer to the [OpenAI documentation for more about model capabilities](https://platform.openai.com/docs/models/overview) and [pricing](https://openai.com/pricing).
 
@@ -48,9 +48,9 @@ Refer to the [OpenAI documentation for more about model capabilities](https://pl
 === "OpenAI"
 
     - gpt-3.5-turbo `default`: Ideal for smaller requests and simple specifications. However, due to the complexity of dashboard creation, `gpt-3.5-turbo` often produces incomplete responses for larger tasks.
-    - gpt-4o: Most ideal for dashboard generation tasks. Excels in dashboard creation tasks, providing stable and complete responses. Compared to gpt-4-turbo, gpt-4o is much faster and cheaper.
+    - gpt-4o: Most ideal for dashboard generation tasks, providing stable and complete responses. Compared to gpt-4-turbo, it is much faster and cheaper.
     - gpt-4-turbo: Excels in dashboard creation tasks, providing stable and complete responses.
-    - gpt-4o-mini: Ideal for smaller requests and simple specifications. Most cost-effective. However, due to the complexity of dashboard creation, its performance is not stable.
+    - gpt-4o-mini: Ideal for smaller requests and simple specifications. Most cost-effective. However, due to the complexity of dashboard creation, its performance is not guaranteed to be reliable.
 
 
 === "Anthropic"

--- a/vizro-ai/src/vizro_ai/_llm_models.py
+++ b/vizro-ai/src/vizro_ai/_llm_models.py
@@ -18,6 +18,8 @@ SUPPORTED_MODELS = {
         "gpt-3.5-turbo",
         "gpt-4o-2024-05-13",
         "gpt-4o",
+        "gpt-4o-mini",
+        "gpt-4o-mini-2024-07-18",
     ],
 }
 

--- a/vizro-ai/src/vizro_ai/dashboard/_graph/dashboard_creation.py
+++ b/vizro-ai/src/vizro_ai/dashboard/_graph/dashboard_creation.py
@@ -80,7 +80,11 @@ def _store_df_info(state: GraphState, config: RunnableConfig) -> Dict[str, AllDf
                 ).dataset
             except DebugFailure as e:
                 logger.warning(f"Failed in name generation {e}")
-                df_name = f"df_{len(current_df_names)}"
+                df_name = f"df_{len(current_df_names)+1}"
+
+            # fallback to a less descriptive but unique name if llm fails
+            if df_name in current_df_names:
+                df_name = f"df_{len(current_df_names)+1}"
 
             current_df_names.append(df_name)
 

--- a/vizro-ai/src/vizro_ai/dashboard/_response_models/layout.py
+++ b/vizro-ai/src/vizro_ai/dashboard/_response_models/layout.py
@@ -19,7 +19,8 @@ def _convert_to_grid(layout_grid_template_areas: List[str], component_ids: List[
 
     for row in layout_grid_template_areas:
         grid_row = []
-        for cell in row.split():
+        for raw_cell in row.split():
+            cell = raw_cell.strip("'\"")
             if cell == ".":
                 grid_row.append(-1)
             else:


### PR DESCRIPTION
## Description
Did some quick experiments on dashboard tasks. 4o-mini can create simple dashboard. When requirements become complex, the dashboard generated doesn't look nice. 

Already noticed that 4o-mini performed consistently worse in 2 sub-tasks:
1. understand the "grid-template-areas" for layout plan
2. follow the instruction to give datasets unique names

It still worth adding it to the list though, because it's cheap and can perform simple dashboard tasks.

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
