### PR TITLE
[Docs] Remove setting of `pio.templates.default` on import 

### DIFF
--- a/vizro-core/changelog.d/20240802_160643_antony.milne_no_more_global_theme.md
+++ b/vizro-core/changelog.d/20240802_160643_antony.milne_no_more_global_theme.md
@@ -22,12 +22,11 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 - A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
 
 -->
-<!--
+
 ### Changed
 
-- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+- Importing Vizro no longer alters the default plotly template. ([#615](https://github.com/mckinsey/vizro/pull/615))
 
--->
 <!--
 ### Deprecated
 

--- a/vizro-core/docs/pages/user-guides/graph.md
+++ b/vizro-core/docs/pages/user-guides/graph.md
@@ -66,15 +66,3 @@ To add a [`Graph`][vizro.models.Graph] to your page, do the following:
 
 
 In the Python example we directly inserted the pandas DataFrame `df` into `figure=px.scatter_matrix(df, ...)`. This is [one way to supply data to a chart](data.md#supply-directly). For the YAML version, we [refer to the data source by name](data.md#reference-by-name) as `data_frame: iris`. For a full explanation of the different methods you can use to send data to your dashboard, see [our guide to using data in Vizro](data.md).
-
-
-## Plotly default template
-
-When importing Vizro, we automatically set the `plotly` [default template](https://plotly.com/python/templates/#specifying-a-default-themes) to a custom designed template. If you want to reset the default, run the following:
-
-```py
-import plotly.io as pio
-pio.templates.default = "plotly"
-```
-
-As an alternative, enter your desired template into any `plotly.express` chart as `template="plotly"` on a case-by-case basis. Note that we do not recommend the above steps for use in dashboards, as other templates will look out-of-sync with our overall dashboard design.

--- a/vizro-core/docs/pages/user-guides/themes.md
+++ b/vizro-core/docs/pages/user-guides/themes.md
@@ -1,12 +1,11 @@
 # How to use themes
 
 This guide shows you how to use themes. Themes are pre-designed collections of stylings that are applied to entire charts and dashboards.
-The themes provided by Vizro are induced with our design best practices that make charts and dashboards look visually consistent and professional.
+The themes provided by Vizro are infused with our design best practices that make charts and dashboards look visually consistent and professional.
 
 ## Themes in dashboards
-The [`Dashboard`][vizro.models.Dashboard] model accepts the `theme` argument, where you can currently choose between
-a `vizro_dark` and a `vizro_light` theme. This theme will be applied on the entire dashboard and its charts/components. During run-time
-you can still switch between the themes via the toggle button in the upper-right corner of the dashboard.
+The [`Dashboard`][vizro.models.Dashboard] model accepts an optional `theme` argument, where you can choose between
+a `vizro_dark` and a `vizro_light` theme. If not specified then `theme` defaults to `vizro_dark`. The theme will be applied to the entire dashboard and its charts/components when a user first loads your dashboard. Regardless of the theme applied on first load, users can always switch between light and dark themes via the toggle button in the upper-right corner of the dashboard.
 
 !!! example "Change theme"
     === "app.py"
@@ -33,7 +32,7 @@ you can still switch between the themes via the toggle button in the upper-right
         Vizro().build(dashboard).run()
         ```
     === "app.yaml"
-        ```yaml hl_lines="11"
+        ```yaml hl_lines="12"
         # Still requires a .py to add data to the data manager and parse YAML configuration
         # See yaml_version example
         pages:
@@ -58,35 +57,27 @@ you can still switch between the themes via the toggle button in the upper-right
 
 
 ## Themes in plotly charts
-You can also use our templates for plotly charts outside the dashboard.
-Our `vizro_dark` and `vizro_light` theme are automatically registered to `plotly.io.templates` when importing Vizro.
-Consult the plotly documentation for [more details on how templates work in plotly.express](https://plotly.com/python/templates/#theming-and-templates).
+
+You can also use our templates for plotly charts outside the dashboard. This is useful in a few contexts:
+
+* Creation of standalone charts to be used independently of a Vizro dashboard. 
+* Rapid development of charts for eventual use in a Vizro dashboard, for example in a Jupyter notebook.
+
+!!! note
+
+    Using `import vizro.plotly.express as px` is equivalent to using `import plotly.express as px`,
+    but with the added benefit of being able to integrate the resulting chart code into a Vizro dashboard.
+    Vizro offers a minimal layer on top of Plotly's existing charting library, allowing you to seamlessly use all the
+    existing charts and functionalities provided by plotly.express without any modifications.
+
+Our `vizro_dark` and `vizro_light` themes are automatically registered to `plotly.io.templates` when importing Vizro.
+Consult the plotly documentation for [more details on how templates work in plotly](https://plotly.com/python/templates/#theming-and-templates).
+
+By default, plots imported from `vizro.plotly.express` have the `vizro_dark` theme applied. This can be altered either globally or for individual plots.
 
 ### Set themes for all charts
-The default plotly.io template is set to be `vizro_dark` as soon as you `import vizro`:
 
-```py
-import plotly.io as pio
-import vizro
-pio.templates
-```
-
-
-```text title="Result"
-Templates configuration
------------------------
-    Default template: 'vizro_dark'
-    Available templates:
-        ['ggplot2', 'seaborn', 'simple_white', 'plotly',
-         'plotly_white', 'plotly_dark', 'presentation', 'xgridoff',
-         'ygridoff', 'gridon', 'none', 'vizro_dark', 'vizro_light']
-```
-
-
-All plotly charts run after the `import vizro` command will therefore have the `vizro_dark` template automatically
-applied without further configuration.
-
-To change the default plotly template globally, run:
+To change the theme to `vizro_light` for all charts, run:
 
 ```python
 import plotly.io as pio
@@ -107,9 +98,3 @@ px.scatter_matrix(df,
                   template="vizro_light")
 ```
 
-!!! note
-
-    Please note that using `import vizro.plotly.express as px` is equivalent to using `import plotly.express as px`,
-    but with the added benefit of being able to integrate the resulting chart code into a Vizro dashboard.
-    Vizro offers a minimal layer on top of Plotly's existing charting library, allowing you to seamlessly use all the
-    existing charts and functionalities provided by plotly.express without any modifications.

--- a/vizro-core/docs/pages/user-guides/themes.md
+++ b/vizro-core/docs/pages/user-guides/themes.md
@@ -60,7 +60,7 @@ a `vizro_dark` and a `vizro_light` theme. If not specified then `theme` defaults
 
 You can also use our templates for plotly charts outside the dashboard. This is useful in a few contexts:
 
-* Creation of standalone charts to be used independently of a Vizro dashboard. 
+* Creation of standalone charts to be used independently of a Vizro dashboard.
 * Rapid development of charts for eventual use in a Vizro dashboard, for example in a Jupyter notebook.
 
 !!! note
@@ -97,4 +97,3 @@ px.scatter_matrix(df,
                   color="species",
                   template="vizro_light")
 ```
-

--- a/vizro-core/docs/pages/user-guides/themes.md
+++ b/vizro-core/docs/pages/user-guides/themes.md
@@ -5,7 +5,7 @@ The themes provided by Vizro are infused with our design best practices that mak
 
 ## Themes in dashboards
 The [`Dashboard`][vizro.models.Dashboard] model accepts an optional `theme` argument, where you can choose between
-a `vizro_dark` and a `vizro_light` theme. If not specified then `theme` defaults to `vizro_dark`. The theme will be applied to the entire dashboard and its charts/components when a user first loads your dashboard. Regardless of the theme applied on first load, users can always switch between light and dark themes via the toggle button in the upper-right corner of the dashboard.
+a `vizro_dark` and a `vizro_light` theme. If not specified then `theme` defaults to `vizro_dark`. The theme is applied to the entire dashboard and its charts/components when a user first loads your dashboard. Regardless of the theme applied on first load, users can always switch between light and dark themes via the toggle button in the upper-right corner of the dashboard.
 
 !!! example "Change theme"
     === "app.py"

--- a/vizro-core/src/vizro/_vizro.py
+++ b/vizro-core/src/vizro/_vizro.py
@@ -86,7 +86,7 @@ class Vizro:
             self.dash.title = dashboard.title
 
         # Set global template to vizro_light or vizro_dark.
-        # The choice between these is generally meaningless because chart colours in the two are identical, and
+        # The choice between these is generally meaningless because chart colors in the two are identical, and
         # everything else gets overridden in the post-fig creation layout.template update in Graph.__call__ and the
         # clientside theme selector callback.
         # Note this setting of global template isn't undone anywhere. If we really wanted to then we could try and

--- a/vizro-core/src/vizro/_vizro.py
+++ b/vizro-core/src/vizro/_vizro.py
@@ -91,8 +91,11 @@ class Vizro:
         # clientside theme selector callback.
         # Note this setting of global template isn't undone anywhere. If we really wanted to then we could try and
         # put in some teardown code, but it would probably never be 100% reliable. Vizro._reset can't do this well
-        # either because it's a staticmethod. Remember this template setting can't go in run() though since it's needed
-        # even in deployment.
+        # either because it's a staticmethod so can't access self.old_theme (though we could use a global variable to
+        # store it). Remember this template setting can't go in run() though since it's needed even in deployment.
+        # Probably the best solution if we do want to fix this would be to have two separate paths that are followed:
+        # 1. In deployment (or just outside Jupyter?), set the theme here and never revert it.
+        # 2. In other contexts, use context manager in run method.
         pio.templates.default = dashboard.theme
 
         # Note that model instantiation and pre_build are independent of Dash.


### PR DESCRIPTION
## Description

Just some quick edits to the docs for #615. This isn't meant to fully explain how everything works but just make sure everything in the docs is correct and up to date.

---

In future we should write more about these, and I'll make a separate ticket for that:
- Theme switching applies template to charts affecting `fig.layout.template` and nothing else
- How to modify vizro_dark/light themes e.g. to alter a colour (could do as dictionary assignment or maybe some clever merge)
- Arguments like `color_discrete_map` etc. specified in plots takes precedence over the templates
- Example of how `plotly.express` colours do not change between themes due to how theme switching works. Possible solutions:
  - Recommended: use colours that work with both themes (how do users find these?)
  - Advanced user: build figure without plotly.express or use plotly.express as then `to_templated`

See #615 for many examples and explanation to understand how this works.

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
