### PR TITLE
[Bug] Dynamically change `title_pad_t` inside `vm.Graph` if subtitle is provided

### DIFF
--- a/vizro-core/changelog.d/20240815_131933_huong_li_nguyen_update_template.md
+++ b/vizro-core/changelog.d/20240815_131933_huong_li_nguyen_update_template.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/changelog.d/20240815_131933_huong_li_nguyen_update_template.md
+++ b/vizro-core/changelog.d/20240815_131933_huong_li_nguyen_update_template.md
@@ -34,12 +34,11 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 - A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
 
 -->
-<!--
+
 ### Fixed
 
-- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+- Update chart title padding dynamically to prevent subtitle cutoff. ([#632](https://github.com/mckinsey/vizro/pull/632))
 
--->
 <!--
 ### Security
 

--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -3,109 +3,26 @@
 import vizro.models as vm
 import vizro.plotly.express as px
 from vizro import Vizro
-from vizro.figures import kpi_card
-from vizro.models.types import capture
-from vizro.tables import dash_ag_grid, dash_data_table
+from vizro.tables import dash_data_table
 
 df = px.data.iris()
-
-
-# Graph
-@capture("graph")
-def my_graph_figure(data_frame, **kwargs):
-    """My custom figure."""
-    return px.scatter(data_frame, **kwargs)
-
-
-class MyGraph(vm.Graph):
-    """My custom class."""
-
-    def build(self):
-        """Custom build."""
-        graph_build_obj = super().build()
-        # DO SOMETHING
-        return graph_build_obj
-
-
-# Table
-@capture("table")
-def my_table_figure(data_frame, **kwargs):
-    """My custom figure."""
-    return dash_data_table(data_frame, **kwargs)()
-
-
-class MyTable(vm.Table):
-    """My custom class."""
-
-    pass
-
-
-# AgGrid
-@capture("ag_grid")
-def my_ag_grid_figure(data_frame, **kwargs):
-    """My custom figure."""
-    return dash_ag_grid(data_frame, **kwargs)()
-
-
-class MyAgGrid(vm.AgGrid):
-    """My custom class."""
-
-    pass
-
-
-# Figure
-@capture("figure")
-def my_kpi_card_figure(data_frame, **kwargs):
-    """My custom figure."""
-    return kpi_card(data_frame, **kwargs)()
-
-
-class MyFigure(vm.Figure):
-    """My custom class."""
-
-    pass
-
-
-# Action
-@capture("action")
-def my_action_function():
-    """My custom action."""
-    pass
-
-
-class MyAction(vm.Action):
-    """My custom class."""
-
-    pass
 
 
 page = vm.Page(
     title="Test",
     layout=vm.Layout(
-        grid=[[0, 1], [2, 3], [4, 5], [6, 7], [8, -1]],
-        col_gap="50px",
-        row_gap="50px",
+        grid=[[0, 1, 2]],
     ),
     components=[
         # Graph
-        MyGraph(figure=px.scatter(df, x="sepal_width", y="sepal_length", title="My Graph")),
-        MyGraph(figure=my_graph_figure(df, x="sepal_width", y="sepal_length", title="My Graph Custom Figure")),
-        # Table
-        MyTable(figure=dash_data_table(df), title="My Table"),
-        MyTable(figure=my_table_figure(df), title="My Table Custom Figure"),
-        # AgGrid
-        MyAgGrid(figure=dash_ag_grid(df), title="My AgGrid"),
-        MyAgGrid(figure=my_ag_grid_figure(df), title="My AgGrid Custom Figure"),
-        # Figure
-        MyFigure(figure=kpi_card(df, value_column="sepal_width", title="KPI Card")),
-        MyFigure(figure=my_kpi_card_figure(df, value_column="sepal_width", title="KPI Card Custom Figure")),
-        # Action
-        MyGraph(
-            figure=my_graph_figure(df, x="sepal_width", y="sepal_length", title="My Graph Custom Figure"),
-            actions=[MyAction(function=my_action_function())],
+        vm.Graph(figure=px.scatter(df, x="sepal_width", y="sepal_length", title="My Graph")),
+        vm.Table(figure=dash_data_table(df), title="My Table"),
+        vm.Graph(
+            figure=px.scatter(
+                df, x="sepal_width", y="sepal_length", title="My Graph <br><span>This is a subtitle</span>"
+            )
         ),
     ],
-    controls=[vm.Filter(column="species")],
 )
 
 dashboard = vm.Dashboard(pages=[page])

--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -11,11 +11,12 @@ df = px.data.iris()
 
 @capture("graph")
 def my_graph(data_frame):
+    """Just for test purposes."""
     fig = px.scatter(data_frame, x="sepal_width", y="sepal_length")
-    print(fig.layout.margin.t)  # This is None
-    print(fig.layout.template.layout.margin.t)  # This is 64 our default
+    # print(fig.layout.margin.t)  # This is None
+    # print(fig.layout.template.layout.margin.t)  # This is 64 our default
     fig.update_layout(margin_t=0)
-    print(fig.layout.margin.t)  # This is 0 now
+    # print(fig.layout.margin.t)  # This is 0 now
     return fig
 
 
@@ -25,7 +26,6 @@ page = vm.Page(
         grid=[[0, 1, 2]],
     ),
     components=[
-        # Graph
         vm.Graph(figure=my_graph(df)),
         vm.Table(figure=dash_data_table(df), title="My Table"),
         vm.Graph(

--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -4,9 +4,18 @@ import vizro.models as vm
 import vizro.plotly.express as px
 from vizro import Vizro
 from vizro.tables import dash_data_table
+from vizro.models.types import capture
 
 df = px.data.iris()
 
+@capture("graph")
+def my_graph(data_frame):
+    fig = px.scatter(data_frame, x="sepal_width", y="sepal_length")
+    print(fig.layout.margin.t)  # This is None
+    print(fig.layout.template.layout.margin.t)  # This is 64 our default
+    fig.update_layout(margin_t=0)
+    print(fig.layout.margin.t) # This is 0 now
+    return fig
 
 page = vm.Page(
     title="Test",
@@ -15,7 +24,7 @@ page = vm.Page(
     ),
     components=[
         # Graph
-        vm.Graph(figure=px.scatter(df, x="sepal_width", y="sepal_length", title="My Graph")),
+        vm.Graph(figure=my_graph(df)),
         vm.Table(figure=dash_data_table(df), title="My Table"),
         vm.Graph(
             figure=px.scatter(

--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -3,10 +3,11 @@
 import vizro.models as vm
 import vizro.plotly.express as px
 from vizro import Vizro
-from vizro.tables import dash_data_table
 from vizro.models.types import capture
+from vizro.tables import dash_data_table
 
 df = px.data.iris()
+
 
 @capture("graph")
 def my_graph(data_frame):
@@ -14,8 +15,9 @@ def my_graph(data_frame):
     print(fig.layout.margin.t)  # This is None
     print(fig.layout.template.layout.margin.t)  # This is 64 our default
     fig.update_layout(margin_t=0)
-    print(fig.layout.margin.t) # This is 0 now
+    print(fig.layout.margin.t)  # This is 0 now
     return fig
+
 
 page = vm.Page(
     title="Test",

--- a/vizro-core/src/vizro/models/_components/graph.py
+++ b/vizro-core/src/vizro/models/_components/graph.py
@@ -56,11 +56,12 @@ class Graph(VizroBaseModel):
         kwargs.setdefault("data_frame", data_manager[self["data_frame"]].load())
         fig = self.figure(**kwargs)
 
-        # Reduce top margin if no title is provided
+        # Reduce `margin_t` if no title is provided and `margin_t` is not explicitly set.
         if fig.layout.margin.t is None and fig.layout.title.text is None:
             fig.update_layout(margin_t=24)
 
-        # Add top title padding if subtitle is provided, otherwise it's being cut off
+        # Increase `title_pad_t` if subtitle is provided and `title_pad_t` is not explicitly set.
+        # Otherwise, the title is being cut off.
         if fig.layout.title.pad.t is None and fig.layout.title.text and "<br>" in fig.layout.title.text:
             fig.update_layout(title_pad_t=24)
 

--- a/vizro-core/src/vizro/models/_components/graph.py
+++ b/vizro-core/src/vizro/models/_components/graph.py
@@ -57,9 +57,13 @@ class Graph(VizroBaseModel):
         kwargs.setdefault("data_frame", data_manager[self["data_frame"]].load())
         fig = self.figure(**kwargs)
 
-        # Remove top margin if title is provided
+        # Reduce top margin if no title is provided
         if fig.layout.title.text is None:
             fig.update_layout(margin_t=24)
+
+        # Add top title padding if subtitle is provided, otherwise it's being cut off
+        if fig.layout.title.text and "<br>" in fig.layout.title.text:
+            fig.update_layout(title_pad_t=24)
 
         # Possibly we should enforce that __call__ can only be used within the context of a callback, but it's easy
         # to just swallow up the error here as it doesn't cause any problems.

--- a/vizro-core/src/vizro/models/_components/graph.py
+++ b/vizro-core/src/vizro/models/_components/graph.py
@@ -57,11 +57,11 @@ class Graph(VizroBaseModel):
         fig = self.figure(**kwargs)
 
         # Reduce top margin if no title is provided
-        if fig.layout.title.text is None:
+        if fig.layout.margin_t is None and fig.layout.title.text is None:
             fig.update_layout(margin_t=24)
 
         # Add top title padding if subtitle is provided, otherwise it's being cut off
-        if fig.layout.title.text and "<br>" in fig.layout.title.text:
+        if fig.layout.title_pad_t is None and fig.layout.title.text and "<br>" in fig.layout.title.text:
             fig.update_layout(title_pad_t=24)
 
         # Apply the template vizro_dark or vizro_light by setting fig.layout.template. This is exactly the same as

--- a/vizro-core/src/vizro/models/_components/graph.py
+++ b/vizro-core/src/vizro/models/_components/graph.py
@@ -57,11 +57,11 @@ class Graph(VizroBaseModel):
         fig = self.figure(**kwargs)
 
         # Reduce top margin if no title is provided
-        if fig.layout.margin_t is None and fig.layout.title.text is None:
+        if fig.layout.margin.t is None and fig.layout.title.text is None:
             fig.update_layout(margin_t=24)
 
         # Add top title padding if subtitle is provided, otherwise it's being cut off
-        if fig.layout.title_pad_t is None and fig.layout.title.text and "<br>" in fig.layout.title.text:
+        if fig.layout.title.pad.t is None and fig.layout.title.text and "<br>" in fig.layout.title.text:
             fig.update_layout(title_pad_t=24)
 
         # Apply the template vizro_dark or vizro_light by setting fig.layout.template. This is exactly the same as

--- a/vizro-core/tests/unit/vizro/models/_components/test_graph.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_graph.py
@@ -99,15 +99,22 @@ class TestDunderMethodsGraph:
         with pytest.raises(KeyError):
             graph["unknown_args"]
 
-    @pytest.mark.parametrize("title, expected", [(None, 24), ("Test", None)])
-    def test_title_margin_adjustment(self, gapminder, title, expected):
+    @pytest.mark.parametrize(
+        "title, margin_t, title_pad_t",
+        [(None, 24, None), ("Graph with title", None, None), ("Graph with title..<br> and subtitle", None, 24)],
+    )
+    def test_title_layout_adjustments(self, gapminder, title, margin_t, title_pad_t):
         graph = vm.Graph(figure=px.bar(data_frame=gapminder, x="year", y="pop", title=title)).__call__()
 
-        assert graph.layout.margin.t == expected
+        assert graph.layout.margin.t == margin_t
+        assert graph.layout.title.pad.t == title_pad_t
+
+        # These are our defaults for the layout defined in `_templates.common_values`
         assert graph.layout.template.layout.margin.t == 64
         assert graph.layout.template.layout.margin.l == 24
         assert graph.layout.template.layout.margin.b == 64
         assert graph.layout.template.layout.margin.r == 24
+        assert graph.layout.template.layout.title.pad.t == 7
 
     def test_update_theme_outside_callback(self, standard_px_chart):
         graph = vm.Graph(figure=standard_px_chart).__call__()


### PR DESCRIPTION
## Description
In the past, including a subtitle with the chart resulted in it being cut off, causing confusion. Two users have already reported this issue internally. To address it, we've been using a post-update call `fig.update_layout(title_pad_t=24)`

I wanted to discuss the possibility of permanently incorporating this solution into our `vm.Graph`. Directly encoding it into the template is challenging due to the way Plotly charts function. Any changes to the template disrupt the alignment between the graph and table titles, which is essential for the dashboard.


## Screenshot
**Before:**
![Screenshot 2024-08-15 at 13 21 25](https://github.com/user-attachments/assets/5129279a-26f8-4275-9e29-1724023fdf04)

**After:**
![Screenshot 2024-08-15 at 13 23 16](https://github.com/user-attachments/assets/2260a2f4-b75e-48b4-964d-33ba446bae9d)

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
