### PR TITLE
[Fix] Hotfix py.cafe docs integration

### DIFF
--- a/vizro-core/changelog.d/20240820_192710_maximilian_schulz.md
+++ b/vizro-core/changelog.d/20240820_192710_maximilian_schulz.md
@@ -37,7 +37,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Fixed
 
-- Fix py.cafe docs integration by pinning `ruff` dependency for mkdocs plugin. ([#1](https://github.com/mckinsey/vizro/pull/1))
+- Fix py.cafe docs integration by pinning `ruff` dependency for mkdocs plugin. ([#640](https://github.com/mckinsey/vizro/pull/640))
 
 <!--
 ### Security

--- a/vizro-core/changelog.d/20240820_192710_maximilian_schulz.md
+++ b/vizro-core/changelog.d/20240820_192710_maximilian_schulz.md
@@ -1,0 +1,47 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+
+### Fixed
+
+- Fix py.cafe docs integration by pinning `ruff` dependency for mkdocs plugin. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/mkdocs.yml
+++ b/vizro-core/mkdocs.yml
@@ -110,6 +110,7 @@ markdown_extensions:
               type: vizro
               requirements: |
                 vizro
+                ruff==0.6.1  # mock
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.mark


### PR DESCRIPTION
## Description
Pin `ruff` in mkdocs plugin. This fixes the docs integration for the time being

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
