### PR TITLE
[Bug] Fix dynamically calculated `optionHeight` for `Dropdown`

### DIFF
--- a/vizro-core/changelog.d/20240902_163350_huong_li_nguyen_fix_calc_dropdown_height.md
+++ b/vizro-core/changelog.d/20240902_163350_huong_li_nguyen_fix_calc_dropdown_height.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/changelog.d/20240902_163350_huong_li_nguyen_fix_calc_dropdown_height.md
+++ b/vizro-core/changelog.d/20240902_163350_huong_li_nguyen_fix_calc_dropdown_height.md
@@ -39,7 +39,6 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 - Fix dynamically calculated `optionHeight` for `Dropdown` when the options are provided as dictionaries. ([#672](https://github.com/mckinsey/vizro/pull/672))
 
-
 <!--
 ### Security
 

--- a/vizro-core/changelog.d/20240902_163350_huong_li_nguyen_fix_calc_dropdown_height.md
+++ b/vizro-core/changelog.d/20240902_163350_huong_li_nguyen_fix_calc_dropdown_height.md
@@ -37,7 +37,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Fixed
 
-- Fix dynamically calculated `optionHeight` for `Dropdown` when the options are provided as dictionaries. ([#672](https://github.com/mckinsey/vizro/pull/672))
+- Fix dynamically calculated row height for `Dropdown` when the options are provided as dictionaries. ([#672](https://github.com/mckinsey/vizro/pull/672))
 
 <!--
 ### Security

--- a/vizro-core/changelog.d/20240902_163350_huong_li_nguyen_fix_calc_dropdown_height.md
+++ b/vizro-core/changelog.d/20240902_163350_huong_li_nguyen_fix_calc_dropdown_height.md
@@ -34,12 +34,12 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 - A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
 
 -->
-<!--
+
 ### Fixed
 
-- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+- Fix dynamically calculated `optionHeight` for `Dropdown` when the options are provided as dictionaries. ([#672](https://github.com/mckinsey/vizro/pull/672))
 
--->
+
 <!--
 ### Security
 

--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -3,24 +3,29 @@
 import vizro.models as vm
 import vizro.plotly.express as px
 from vizro import Vizro
-from vizro.tables import dash_data_table
 
-df = px.data.iris()
 
+iris = px.data.iris()
 
 page = vm.Page(
-    title="Testasfsadfsadf",
-    layout=vm.Layout(
-        grid=[[0, 1, 2, 3]],
-    ),
+    title="My first page",
     components=[
-        vm.Graph(figure=px.scatter(df, x="sepal_width", y="sepal_length")),
-        vm.Graph(figure=px.scatter(df, x="sepal_width", y="sepal_length", title="Blah blah")),
-        vm.Table(figure=dash_data_table(df), title="My Table"),
         vm.Graph(
-            figure=px.scatter(
-                df, x="sepal_width", y="sepal_length", title="My Graph <br><span>This is a subtitle</span>"
-            )
+            id="scatter_chart",
+            figure=px.scatter(iris, title="My scatter chart", x="sepal_length", y="petal_width", color="species"),
+        ),
+    ],
+    controls=[
+        vm.Parameter(
+            targets=["scatter_chart.title"],
+            selector=vm.Dropdown(
+                options=[
+                    {"value": "Shipping Address State", "label": "State"},
+                    {"value": "Category", "label": "Category"},
+                    {"value": "Short_Title", "label": "Product item"},
+                ],
+                multi=False,
+            ),
         ),
     ],
 )
@@ -28,4 +33,4 @@ page = vm.Page(
 dashboard = vm.Dashboard(pages=[page])
 
 if __name__ == "__main__":
-    Vizro().build(dashboard).run(debug=True)
+    Vizro().build(dashboard).run()

--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -4,7 +4,6 @@ import vizro.models as vm
 import vizro.plotly.express as px
 from vizro import Vizro
 
-
 iris = px.data.iris()
 
 page = vm.Page(

--- a/vizro-core/src/vizro/models/_components/form/dropdown.py
+++ b/vizro-core/src/vizro/models/_components/form/dropdown.py
@@ -17,6 +17,27 @@ from vizro.models._models_utils import _log_call
 from vizro.models.types import MultiValueType, OptionsType, SingleValueType
 
 
+def _calculate_option_height(list_of_labels: List[str]) -> int:
+    """ "Calculates the height of the dropdown options based on the longest option."""
+    # 30 characters is roughly the number of "A" characters you can fit comfortably on a line in the dropdown.
+    # "A" is representative of a slightly wider than average character:
+    # https://stackoverflow.com/questions/3949422/which-letter-of-the-english-alphabet-takes-up-most-pixels
+    # We look at the longest option to find number_of_lines it requires. Option height is the same for all options
+    # and needs 24px for each line + 8px padding.
+
+    max_length = max(len(str(option)) for option in list_of_labels)
+    number_of_lines = math.ceil(max_length / 30)
+    option_height = 8 + 24 * number_of_lines
+    return option_height
+
+
+def _get_list_of_labels(full_options: OptionsType) -> List[str]:
+    if all(isinstance(option, dict) for option in full_options):
+        return [options_dict["label"] for options_dict in full_options]
+    else:
+        return full_options
+
+
 class Dropdown(VizroBaseModel):
     """Categorical single/multi-option selector `Dropdown`.
 
@@ -63,13 +84,8 @@ class Dropdown(VizroBaseModel):
     @_log_call
     def build(self):
         full_options, default_value = get_options_and_default(options=self.options, multi=self.multi)
-        # 30 characters is roughly the number of "A" characters you can fit comfortably on a line in the dropdown.
-        # "A" is representative of a slightly wider than average character:
-        # https://stackoverflow.com/questions/3949422/which-letter-of-the-english-alphabet-takes-up-most-pixels
-        # We look at the longest option to find number_of_lines it requires. Option height is the same for all options
-        # and needs 24px for each line + 8px padding.
-        number_of_lines = math.ceil(max(len(str(option)) for option in full_options) / 30)
-        option_height = 8 + 24 * number_of_lines
+        list_of_labels = _get_list_of_labels(full_options)
+        option_height = _calculate_option_height(list_of_labels)
 
         return html.Div(
             children=[

--- a/vizro-core/src/vizro/models/_components/form/dropdown.py
+++ b/vizro-core/src/vizro/models/_components/form/dropdown.py
@@ -17,12 +17,14 @@ from vizro.models._components.form._form_utils import get_options_and_default, v
 from vizro.models._models_utils import _log_call
 from vizro.models.types import MultiValueType, OptionsType, SingleValueType
 
+
 def _get_list_of_labels(full_options: OptionsType) -> Union[List[StrictBool], List[float], List[str], List[date]]:
     """Returns a list of labels from the selector options provided."""
     if all(isinstance(option, dict) for option in full_options):
         return [option["label"] for option in full_options]  # type: ignore[index]
     else:
         return full_options
+
 
 def _calculate_option_height(full_options: OptionsType) -> int:
     """Calculates the height of the dropdown options based on the longest option."""

--- a/vizro-core/src/vizro/models/_components/form/dropdown.py
+++ b/vizro-core/src/vizro/models/_components/form/dropdown.py
@@ -1,12 +1,13 @@
 import math
+from datetime import date
 from typing import List, Literal, Optional, Union
 
 from dash import dcc, html
 
 try:
-    from pydantic.v1 import Field, PrivateAttr, root_validator, validator
+    from pydantic.v1 import Field, PrivateAttr, StrictBool, root_validator, validator
 except ImportError:  # pragma: no cov
-    from pydantic import Field, PrivateAttr, root_validator, validator
+    from pydantic import Field, PrivateAttr, StrictBool, root_validator, validator
 
 import dash_bootstrap_components as dbc
 
@@ -17,8 +18,8 @@ from vizro.models._models_utils import _log_call
 from vizro.models.types import MultiValueType, OptionsType, SingleValueType
 
 
-def _calculate_option_height(list_of_labels: List[str]) -> int:
-    """ "Calculates the height of the dropdown options based on the longest option."""
+def _calculate_option_height(list_of_labels: Union[List[StrictBool], List[float], List[str], List[date]]) -> int:
+    """Calculates the height of the dropdown options based on the longest option."""
     # 30 characters is roughly the number of "A" characters you can fit comfortably on a line in the dropdown.
     # "A" is representative of a slightly wider than average character:
     # https://stackoverflow.com/questions/3949422/which-letter-of-the-english-alphabet-takes-up-most-pixels
@@ -31,9 +32,9 @@ def _calculate_option_height(list_of_labels: List[str]) -> int:
     return option_height
 
 
-def _get_list_of_labels(full_options: OptionsType) -> List[str]:
+def _get_list_of_labels(full_options: OptionsType) -> Union[List[StrictBool], List[float], List[str], List[date]]:
     if all(isinstance(option, dict) for option in full_options):
-        return [options_dict["label"] for options_dict in full_options]
+        return [option["label"] for option in full_options]  # type: ignore[index]
     else:
         return full_options
 

--- a/vizro-core/src/vizro/models/_components/form/dropdown.py
+++ b/vizro-core/src/vizro/models/_components/form/dropdown.py
@@ -17,26 +17,24 @@ from vizro.models._components.form._form_utils import get_options_and_default, v
 from vizro.models._models_utils import _log_call
 from vizro.models.types import MultiValueType, OptionsType, SingleValueType
 
+def _get_list_of_labels(full_options: OptionsType) -> Union[List[StrictBool], List[float], List[str], List[date]]:
+    """Returns a list of labels from the selector options provided."""
+    if all(isinstance(option, dict) for option in full_options):
+        return [option["label"] for option in full_options]  # type: ignore[index]
+    else:
+        return full_options
 
-def _calculate_option_height(list_of_labels: Union[List[StrictBool], List[float], List[str], List[date]]) -> int:
+def _calculate_option_height(full_options: OptionsType) -> int:
     """Calculates the height of the dropdown options based on the longest option."""
     # 30 characters is roughly the number of "A" characters you can fit comfortably on a line in the dropdown.
     # "A" is representative of a slightly wider than average character:
     # https://stackoverflow.com/questions/3949422/which-letter-of-the-english-alphabet-takes-up-most-pixels
     # We look at the longest option to find number_of_lines it requires. Option height is the same for all options
     # and needs 24px for each line + 8px padding.
-
+    list_of_labels = _get_list_of_labels(full_options)
     max_length = max(len(str(option)) for option in list_of_labels)
     number_of_lines = math.ceil(max_length / 30)
-    option_height = 8 + 24 * number_of_lines
-    return option_height
-
-
-def _get_list_of_labels(full_options: OptionsType) -> Union[List[StrictBool], List[float], List[str], List[date]]:
-    if all(isinstance(option, dict) for option in full_options):
-        return [option["label"] for option in full_options]  # type: ignore[index]
-    else:
-        return full_options
+    return 8 + 24 * number_of_lines
 
 
 class Dropdown(VizroBaseModel):
@@ -85,8 +83,7 @@ class Dropdown(VizroBaseModel):
     @_log_call
     def build(self):
         full_options, default_value = get_options_and_default(options=self.options, multi=self.multi)
-        list_of_labels = _get_list_of_labels(full_options)
-        option_height = _calculate_option_height(list_of_labels)
+        option_height = _calculate_option_height(full_options)
 
         return html.Div(
             children=[

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_dropdown.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_dropdown.py
@@ -194,6 +194,10 @@ class TestDropdownBuild:
             (["A" * 31, "B", "C"], 56),
             (["A" * 60, "B", "C"], 56),
             (["A" * 61, "B", "C"], 80),
+            ([{"label": "A" * 30, "value": "A"}, {"label": "B", "value": "B"}, {"label": "C", "value": "C"}], 32),
+            ([{"label": "A" * 31, "value": "A"}, {"label": "B", "value": "B"}, {"label": "C", "value": "C"}], 56),
+            ([{"label": "A" * 60, "value": "A"}, {"label": "B", "value": "B"}, {"label": "C", "value": "C"}], 56),
+            ([{"label": "A" * 61, "value": "A"}, {"label": "B", "value": "B"}, {"label": "C", "value": "C"}], 80),
         ],
     )
     def test_dropdown_dynamic_option_height(self, options, option_height):

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_dropdown.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_dropdown.py
@@ -201,6 +201,7 @@ class TestDropdownBuild:
         ],
     )
     def test_dropdown_dynamic_option_height(self, options, option_height):
+        default_value = options[0]["value"] if all(isinstance(option, dict) for option in options) else options[0]  # type: ignore[index]
         dropdown = Dropdown(id="dropdown_id", multi=False, options=options).build()
         expected_dropdown = html.Div(
             [
@@ -210,7 +211,7 @@ class TestDropdownBuild:
                     options=options,
                     optionHeight=option_height,
                     multi=False,
-                    value=options[0],
+                    value=default_value,
                     persistence=True,
                     persistence_type="session",
                 ),


### PR DESCRIPTION
## Description
- Fix dynamically calculated `optionHeight` for `Dropdown` if options are provided as dict
- Previously calculated didn't consider the input of dict, thus resulting in false row heights
- Added unit tests to reflect changes

## Screenshot

**Before**
![Screenshot 2024-09-02 at 16 18 08](https://github.com/user-attachments/assets/f3cb4d19-fbd6-4706-9752-2bdbcd4363f1)

**After**
![Screenshot 2024-09-02 at 16 48 58](https://github.com/user-attachments/assets/55aa1005-232f-4ed3-a440-38e0e8024dbc)


## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
