### PR TITLE
[CI] Change prettier from mirror to hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,10 +32,18 @@ repos:
           - tomli
 
   # Linter for json, yaml, md, css and more
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: local
     hooks:
       - id: prettier
+        name: prettier
+        description: ""
+        entry: prettier --write --ignore-unknown
+        language: node
+        "types": [text]
+        args: []
+        require_serial: false
+        additional_dependencies: ["prettier@3.3.3"]
+        minimum_pre_commit_version: "0"
 
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
     rev: v2.14.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,19 +31,15 @@ repos:
         additional_dependencies:
           - tomli
 
-  # Linter for json, yaml, md, css and more
   - repo: local
     hooks:
       - id: prettier
         name: prettier
-        description: ""
+        description: Linter for json, yaml, md, css and more
         entry: prettier --write --ignore-unknown
         language: node
         "types": [text]
-        args: []
-        require_serial: false
         additional_dependencies: ["prettier@3.3.3"]
-        minimum_pre_commit_version: "0"
 
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
     rev: v2.14.0


### PR DESCRIPTION
## Description
Prettier mirror repo which we are currently using is archived: https://github.com/pre-commit/mirrors-prettier
Changed prettier usage for pre-commit from mirror to hook.

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
