### PR TITLE
[Bug] Fix dependency issue due to template update

### DIFF
--- a/vizro-core/changelog.d/20240911_164757_huong_li_nguyen_fix_plotly_dependency_issue.md
+++ b/vizro-core/changelog.d/20240911_164757_huong_li_nguyen_fix_plotly_dependency_issue.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+
+### Fixed
+
+- Fix incompatibility with older `plotly versions` due to chart template update. ([#695](https://github.com/mckinsey/vizro/pull/695))
+
+
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/changelog.d/20240911_164757_huong_li_nguyen_fix_plotly_dependency_issue.md
+++ b/vizro-core/changelog.d/20240911_164757_huong_li_nguyen_fix_plotly_dependency_issue.md
@@ -39,7 +39,6 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 - Fix incompatibility with older `plotly versions` due to chart template update. ([#695](https://github.com/mckinsey/vizro/pull/695))
 
-
 <!--
 ### Security
 

--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -112,7 +112,7 @@ scripts = {lint = "SKIP=gitleaks pre-commit run {args:--all-files}"}
 extra-dependencies = [
   "pydantic==1.10.13",
   "dash==2.17.1",
-  "plotly==5.14.0"
+  "plotly==5.14.1"
 ]
 
 [publish.index]

--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -111,8 +111,7 @@ scripts = {lint = "SKIP=gitleaks pre-commit run {args:--all-files}"}
 [envs.lower-bounds]
 extra-dependencies = [
   "pydantic==1.10.13",
-  "dash==2.17.1",
-  "plotly==5.14.1"
+  "dash==2.17.1"
 ]
 
 [publish.index]

--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -111,8 +111,7 @@ scripts = {lint = "SKIP=gitleaks pre-commit run {args:--all-files}"}
 [envs.lower-bounds]
 extra-dependencies = [
   "pydantic==1.10.13",
-  "dash==2.17.1",
-  "plotly==5.0.0"
+  "dash==2.17.1"
 ]
 
 [publish.index]

--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -112,7 +112,7 @@ scripts = {lint = "SKIP=gitleaks pre-commit run {args:--all-files}"}
 extra-dependencies = [
   "pydantic==1.10.13",
   "dash==2.17.1",
-  "plotly==4.14.3"
+  "plotly==5.0.0"
 ]
 
 [publish.index]

--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -111,7 +111,8 @@ scripts = {lint = "SKIP=gitleaks pre-commit run {args:--all-files}"}
 [envs.lower-bounds]
 extra-dependencies = [
   "pydantic==1.10.13",
-  "dash==2.17.1"
+  "dash==2.17.1",
+  "plotly==5.14.0"
 ]
 
 [publish.index]

--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -111,7 +111,8 @@ scripts = {lint = "SKIP=gitleaks pre-commit run {args:--all-files}"}
 [envs.lower-bounds]
 extra-dependencies = [
   "pydantic==1.10.13",
-  "dash==2.17.1"
+  "dash==2.17.1",
+  "plotly==4.14.3"
 ]
 
 [publish.index]

--- a/vizro-core/src/vizro/_themes/_templates/template_dark.py
+++ b/vizro-core/src/vizro/_themes/_templates/template_dark.py
@@ -38,8 +38,11 @@ def create_template_dark() -> Template:
     template_dark["layout"]["ternary"]["baxis"]["linecolor"] = COLORS["WHITE_30"]
     template_dark["layout"]["ternary"]["caxis"]["gridcolor"] = COLORS["WHITE_12"]
     template_dark["layout"]["ternary"]["caxis"]["linecolor"] = COLORS["WHITE_30"]
+    if "map" in template_dark["layout"]:
+        # "map" only available in plotly>=5.24.0, will replace "mapbox" soon. Until then, we need to set both.
+        # We need the if statement here in case the user is using an older version of plotly.
+        template_dark["layout"]["map"]["style"] = "carto-darkmatter"
     template_dark["layout"]["mapbox"]["style"] = "carto-darkmatter"
-    template_dark["layout"]["map"]["style"] = "carto-darkmatter"
     template_dark["layout"]["coloraxis"]["colorbar"]["tickcolor"] = COLORS["WHITE_30"]
     template_dark["layout"]["coloraxis"]["colorbar"]["tickfont"]["color"] = COLORS["WHITE_55"]
     template_dark["layout"]["coloraxis"]["colorbar"]["title"]["font"]["color"] = COLORS["WHITE_55"]

--- a/vizro-core/src/vizro/_themes/_templates/template_light.py
+++ b/vizro-core/src/vizro/_themes/_templates/template_light.py
@@ -39,7 +39,10 @@ def create_template_light() -> Template:
     template_light["layout"]["ternary"]["baxis"]["linecolor"] = COLORS["BLACK_30"]
     template_light["layout"]["ternary"]["caxis"]["gridcolor"] = COLORS["BLACK_12"]
     template_light["layout"]["ternary"]["caxis"]["linecolor"] = COLORS["BLACK_30"]
-    template_light["layout"]["map"]["style"] = "carto-positron"
+    if "map" in template_light["layout"]:
+        # "map" only available in plotly>=5.24.0, will replace "mapbox" soon. Until then, we need to set both.
+        # We need the if statement here in case the user is using an older version of plotly.
+        template_light["layout"]["map"]["style"] = "carto-positron"
     template_light["layout"]["mapbox"]["style"] = "carto-positron"
     template_light["layout"]["coloraxis"]["colorbar"]["tickcolor"] = COLORS["BLACK_30"]
     template_light["layout"]["coloraxis"]["colorbar"]["tickfont"]["color"] = COLORS["BLACK_55"]


### PR DESCRIPTION
## Description
Due to changes in our chart template from this PR https://github.com/mckinsey/vizro/pull/677, our latest vizro version `0.1.22` was not compatible with `plotly<5.24.0`.

This is fixed in this PR now by a conditional check. We currently need to ensure that both `map_style` and `mapbox` work. In the future `map_style` will replace `mapbox` but until then we should ensure compatibility with older plotly versions as well.

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
