### PR TITLE
[Docs] Remove redundant suffix from pyCafe links

### DIFF
--- a/vizro-core/docs/pages/tutorials/first-dashboard.md
+++ b/vizro-core/docs/pages/tutorials/first-dashboard.md
@@ -2,9 +2,9 @@
 
 There is no setup needed for your first dashboard, thanks to the amazing [Py.Cafe](https://py.cafe/).
 
-Follow the [Edit live on Py.Cafe](https://py.cafe/vizro-official/vizro-iris-analysis-0) link and you can see the code of the below dashboard and experiment with it.
+Follow the [Edit live on Py.Cafe](https://py.cafe/vizro-official/vizro-iris-analysis) link and you can see the code of the below dashboard and experiment with it.
 
-<iframe src="https://py.cafe/embed/vizro-official/vizro-iris-analysis-0" width="100%" height="600px"></iframe>
+<iframe src="https://py.cafe/embed/vizro-official/vizro-iris-analysis" width="100%" height="600px"></iframe>
 
 <!-- vale off -->
 ## Can I break your code?

--- a/vizro-core/docs/pages/user-guides/assets.md
+++ b/vizro-core/docs/pages/user-guides/assets.md
@@ -102,7 +102,7 @@ For reference, see the [Vizro CSS files](https://github.com/mckinsey/vizro/tree/
         Vizro().build(dashboard).run()
         ```
 
-        <img src=https://py.cafe/logo.png alt="py.cafe logo" width="30"><b><a target="_blank" href="https://py.cafe/vizro-official/vizro-custom-header-colors-0">Run and edit this code in Py.Cafe</a></b>
+        <img src=https://py.cafe/logo.png alt="py.cafe logo" width="30"><b><a target="_blank" href="https://py.cafe/vizro-official/vizro-custom-header-colors">Run and edit this code in Py.Cafe</a></b>
 
     === "app.yaml"
         ```yaml

--- a/vizro-core/docs/pages/user-guides/run.md
+++ b/vizro-core/docs/pages/user-guides/run.md
@@ -6,7 +6,7 @@ This guide shows you how to launch your dashboard in different ways. By default,
 
 The easiest way to launch your dashboard is to edit the code live on [Py.Cafe](https://py.cafe/).
 
-Most of our examples have a link below the code, [Run and edit this code in Py.Cafe](https://py.cafe/vizro-official/vizro-iris-analysis-0), which you can follow to experiment with the code. This will lead you to an editor such as the one below, which displays the dashboard and the code side by side.
+Most of our examples have a link below the code, [Run and edit this code in Py.Cafe](https://py.cafe/vizro-official/vizro-iris-analysis), which you can follow to experiment with the code. This will lead you to an editor such as the one below, which displays the dashboard and the code side by side.
 
 <figure markdown="span">
   ![Py.Cafe editor](../../assets/user_guides/run/pycafe_editor.png)


### PR DESCRIPTION
## Description
I think the suffixes were previously there because there was a hick-up where previously deleted projects were not visible on pyCafe. So, it automatically added that suffix when the name was the same. This seems to be fixed now, so we can remove the suffix. I've already made sure that the projects exist and will remove the duplicated projects on pyCafe after the merge.

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
