### PR TITLE
[CI] Make vizro-qa tests url visible

### DIFF
--- a/.github/workflows/vizro-qa-tests-trigger.yml
+++ b/.github/workflows/vizro-qa-tests-trigger.yml
@@ -42,8 +42,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Tests trigger
         run: |
-          export INPUT_OWNER=${{ secrets.VIZRO_QA_ORG }}
-          export INPUT_REPO=${{ secrets.VIZRO_QA_REPO }}
+          export INPUT_OWNER=mckinsey
+          export INPUT_REPO=vizro-qa
           if [ "${{ matrix.label }}" == "integration tests" ]; then
             export INPUT_WORKFLOW_FILE_NAME=${{ secrets.VIZRO_QA_INTEGRATION_TESTS_WORKFLOW }}
           elif [ "${{ matrix.label }}" == "notebooks test" ]; then


### PR DESCRIPTION
## Description
Link to the tests results can be found in every tests run here: https://github.com/mckinsey/vizro/actions/runs/10996907875

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
