### PR TITLE
[Docs] Update references from Py.Cafe to PyCafe

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -36,7 +36,7 @@ body:
   - type: textarea
     attributes:
       label: How to Reproduce
-      description: Provide steps to reproduce this bug. You can also [use a py.cafe link](https://py.cafe/snippet/vizro/v1) to share your example.
+      description: Provide steps to reproduce this bug. You can also [use a PyCafe link](https://py.cafe/snippet/vizro/v1) to share your example.
       placeholder: |
         1. Get package from '...'
         2. Then run '...'
@@ -50,7 +50,7 @@ body:
       description: >-
         If you can, provide the output of the steps above, including the commands
         themselves and Vizro's output/traceback etc.  If possible,
-        provide a screenshot highlighting the issue or [link to a py.cafe example](https://py.cafe/snippet/vizro/v1).
+        provide a screenshot highlighting the issue or [link to a PyCafe example](https://py.cafe/snippet/vizro/v1).
 
         If you want to present output from multiple commands, prefix
         the line containing the command with `$ `. Ensure that

--- a/.github/ISSUE_TEMPLATE/general-question.yml
+++ b/.github/ISSUE_TEMPLATE/general-question.yml
@@ -22,7 +22,7 @@ body:
     attributes:
       label: Code/Examples
       description: >-
-        Post any supporting code around your question here or as a [py.cafe link](https://py.cafe/snippet/vizro/v1).
+        Post any supporting code around your question here or as a [PyCafe link](https://py.cafe/snippet/vizro/v1).
         Don't forget to include the package version, if it's relevant.
 
   - type: dropdown

--- a/.vale/styles/Microsoft/Headings.yml
+++ b/.vale/styles/Microsoft/Headings.yml
@@ -72,7 +72,7 @@ exceptions:
   - Pandas
   - Plotly
   - Pydantic
-  - Py.Cafe
+  - PyCafe
   - Python
   - QuantumBlack
   - QuantumBlack Labs

--- a/.vale/styles/Microsoft/Terms.yml
+++ b/.vale/styles/Microsoft/Terms.yml
@@ -53,3 +53,4 @@ swap:
   utilizing: using
   utilising: using
   dataset: data (or data source)
+  Py.Cafe: PyCafe #change based on reccomendation from PyCafe team

--- a/vizro-core/changelog.d/20241004_203832_47538780+LydiaPitts_750_PyCafe_fix.md
+++ b/vizro-core/changelog.d/20241004_203832_47538780+LydiaPitts_750_PyCafe_fix.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/docs/pages/explanation/authors.md
+++ b/vizro-core/docs/pages/explanation/authors.md
@@ -36,6 +36,7 @@ Natalia Kurakina,
 [Juan Luis Cano Rodríguez](https://github.com/astrojuanlu),
 [Anna Xiong](https://github.com/Anna-Xiong),
 [Chiara Pullem](https://github.com/chiara-sophie)
+[Lydia Pitts](https://github.com/LydiaPitts)
 
 with thanks to Sam Bourton and Kevin Staight for sponsorship, inspiration and guidance,
 

--- a/vizro-core/docs/pages/tutorials/explore-components.md
+++ b/vizro-core/docs/pages/tutorials/explore-components.md
@@ -6,7 +6,7 @@ If you haven't yet done so, you may want to review the [first dashboard tutorial
 
 ## 1. (Optional) Install Vizro and get ready to run your code
 
-The code for this tutorial is all available for you to experiment with in [Py.Cafe](https://py.cafe/) so there is no need to install Vizro and run it locally.
+The code for this tutorial is all available for you to experiment with in [PyCafe](https://py.cafe/) so there is no need to install Vizro and run it locally.
 
 However, if you prefer working in a Notebook or Python script, you should [install Vizro](../user-guides/install.md).
 

--- a/vizro-core/docs/pages/tutorials/first-dashboard.md
+++ b/vizro-core/docs/pages/tutorials/first-dashboard.md
@@ -1,8 +1,8 @@
 # A first dashboard
 
-There is no setup needed for your first dashboard, thanks to the amazing [Py.Cafe](https://py.cafe/).
+There is no setup needed for your first dashboard, thanks to the amazing [PyCafe](https://py.cafe/).
 
-Click on the **Run and edit this code in Py.Cafe** link below to live-edit the dashboard.
+Click on the **Run and edit this code in PyCafe** link below to live-edit the dashboard.
 
 !!! example "First dashboard"
     === "app.py"
@@ -37,14 +37,14 @@ Click on the **Run and edit this code in Py.Cafe** link below to live-edit the d
 <!-- vale off -->
 ## Can I break your code?
 <!-- vale on -->
-When you click the link to "Edit live on Py.Cafe" the dashboard is running inside your browser. Any changes you make are local and you don't need to worry about breaking the code for others. Nobody else sees the changes you make unless you save a copy of the project as your own Vizro py.cafe project.
+When you click the link to "Edit live on PyCafe" the dashboard is running inside your browser. Any changes you make are local and you don't need to worry about breaking the code for others. Nobody else sees the changes you make unless you save a copy of the project as your own Vizro PyCafe project.
 
 <!-- vale off -->
 ## How can I make my own dashboards?
 <!-- vale on -->
-You can use [Py.Cafe](https://py.cafe/snippet/vizro/v1) to experiment with your own Vizro dashboards by dropping code onto a new project.
+You can use [PyCafe](https://py.cafe/snippet/vizro/v1) to experiment with your own Vizro dashboards by dropping code onto a new project.
 
-If you need inspiration or a starting point, we make all our examples available for you to try out on Py.Cafe. Throughout our documentation, follow the "**Run and edit this code in Py.Cafe**" link below the code snippets to open them in Py.Cafe.
+If you need inspiration or a starting point, we make all our examples available for you to try out on PyCafe. Throughout our documentation, follow the "**Run and edit this code in PyCafe**" link below the code snippets to open them in PyCafe.
 
 ## Where next?
 You are now ready to explore Vizro further, by working through the ["Explore Vizro" tutorial](explore-components.md) or by consulting the [how-to guides](../user-guides/dashboard.md).

--- a/vizro-core/docs/pages/user-guides/card-button.md
+++ b/vizro-core/docs/pages/user-guides/card-button.md
@@ -226,7 +226,7 @@ accessibility of your app. Providing an image ALT text is optional.
         Vizro().build(dashboard).run()
         ```
 
-        <img src=https://py.cafe/logo.png alt="py.cafe logo" width="30"><b><a target="_blank" href="https://py.cafe/vizro-official/vizro-placing-images">Run and edit this code in Py.Cafe</a></b>
+        <img src=https://py.cafe/logo.png alt="PyCafe logo" width="30"><b><a target="_blank" href="https://py.cafe/vizro-official/vizro-placing-images">Run and edit this code in PyCafe</a></b>
 
 
     === "app.yaml"
@@ -306,7 +306,7 @@ and give an attribute selector to select images with that matching URL hash.
         Vizro().build(dashboard).run()
         ```
 
-        <img src=https://py.cafe/logo.png alt="py.cafe logo" width="30"><b><a target="_blank" href="https://py.cafe/vizro-official/vizro-styling-images">Run and edit this code in Py.Cafe</a></b>
+        <img src=https://py.cafe/logo.png alt="PyCafe logo" width="30"><b><a target="_blank" href="https://py.cafe/vizro-official/vizro-styling-images">Run and edit this code in PyCafe</a></b>
 
     === "app.yaml"
         ```yaml
@@ -382,7 +382,7 @@ Use the following pre-defined URL hashes in your image path to apply Vizro's def
         Vizro().build(dashboard).run()
         ```
 
-        <img src=https://py.cafe/logo.png alt="py.cafe logo" width="30"><b><a target="_blank" href="https://py.cafe/vizro-official/vizro-floating-images-explorer">Run and edit this code in Py.Cafe</a></b>
+        <img src=https://py.cafe/logo.png alt="PyCafe logo" width="30"><b><a target="_blank" href="https://py.cafe/vizro-official/vizro-floating-images-explorer">Run and edit this code in PyCafe</a></b>
 
     === "app.yaml"
         ```yaml

--- a/vizro-core/docs/pages/user-guides/custom-components.md
+++ b/vizro-core/docs/pages/user-guides/custom-components.md
@@ -472,7 +472,7 @@ As mentioned above, custom components can trigger action. To enable the custom c
 
         Vizro().build(dashboard).run()
         ```
-        <img src=https://py.cafe/logo.png alt="py.cafe logo" width="30"><b><a target="_blank" href="https://py.cafe/vizro-official/vizro-custom-carousel-component">Run and edit this code in Py.Cafe</a></b>
+        <img src=https://py.cafe/logo.png alt="PyCafe logo" width="30"><b><a target="_blank" href="https://py.cafe/vizro-official/vizro-custom-carousel-component">Run and edit this code in PyCafe</a></b>
     === "yaml"
         ```yaml
         # Custom components are currently only possible via python configuration

--- a/vizro-core/docs/pages/user-guides/custom-css.md
+++ b/vizro-core/docs/pages/user-guides/custom-css.md
@@ -127,7 +127,7 @@ overwrites in the `assets` folder.
         Vizro().build(dashboard).run()
         ```
 
-        <img src=https://py.cafe/logo.png alt="py.cafe logo" width="30"><b><a target="_blank" href="https://py.cafe/vizro-official/vizro-custom-header-colors">Run and edit this code in Py.Cafe</a></b>
+        <img src=https://py.cafe/logo.png alt="PyCafe logo" width="30"><b><a target="_blank" href="https://py.cafe/vizro-official/vizro-custom-header-colors">Run and edit this code in PyCafe</a></b>
 
     === "app.yaml"
         ```yaml
@@ -192,7 +192,7 @@ Suppose you want to hide the page title on one page only. Here's how you can ach
         Vizro().build(dashboard).run()
         ```
 
-        <img src=https://py.cafe/logo.png alt="py.cafe logo" width="30"><b><a target="_blank" href="https://py.cafe/vizro-official/vizro-multi-page-example">Run and edit this code in Py.Cafe</a></b>
+        <img src=https://py.cafe/logo.png alt="PyCafe logo" width="30"><b><a target="_blank" href="https://py.cafe/vizro-official/vizro-multi-page-example">Run and edit this code in PyCafe</a></b>
 
     === "app.yaml"
         ```yaml
@@ -279,7 +279,7 @@ It's essential to understand the relationship between the targeted CSS class or 
         Vizro().build(dashboard).run()
         ```
 
-        <img src=https://py.cafe/logo.png alt="py.cafe logo" width="30"><b><a target="_blank" href="https://py.cafe/vizro-official/vizro-custom-card-styling">Run and edit this code in Py.Cafe</a></b>
+        <img src=https://py.cafe/logo.png alt="PyCafe logo" width="30"><b><a target="_blank" href="https://py.cafe/vizro-official/vizro-custom-card-styling">Run and edit this code in PyCafe</a></b>
 
     === "app.yaml"
         ```yaml
@@ -413,7 +413,7 @@ To do this, you need to change the container's CSS class. Using the DevTool, as 
         Vizro().build(dashboard).run()
         ```
 
-        <img src=https://py.cafe/logo.png alt="py.cafe logo" width="30"><b><a target="_blank" href="https://py.cafe/vizro-official/vizro-style-a-container">Run and edit this code in Py.Cafe</a></b>
+        <img src=https://py.cafe/logo.png alt="PyCafe logo" width="30"><b><a target="_blank" href="https://py.cafe/vizro-official/vizro-style-a-container">Run and edit this code in PyCafe</a></b>
 
     === "app.yaml"
         ```yaml

--- a/vizro-core/docs/pages/user-guides/custom-figures.md
+++ b/vizro-core/docs/pages/user-guides/custom-figures.md
@@ -245,7 +245,7 @@ number of cards displayed dynamically adjusts based on a `vm.Parameter`.
            The parameter targets the `n_rows` argument of the `multiple_cards` function, determining the number of rows
            taken from the data.
 
-        <img src=https://py.cafe/logo.png alt="py.cafe logo" width="30"><b><a target="_blank" href="https://py.cafe/vizro-official/vizro-dynamic-cards">Run and edit this code in Py.Cafe</a></b>
+        <img src=https://py.cafe/logo.png alt="PyCafe logo" width="30"><b><a target="_blank" href="https://py.cafe/vizro-official/vizro-dynamic-cards">Run and edit this code in PyCafe</a></b>
 
     === "styling.css"
         ```css

--- a/vizro-core/docs/pages/user-guides/install.md
+++ b/vizro-core/docs/pages/user-guides/install.md
@@ -1,6 +1,6 @@
 # How to install Vizro
 
-Thanks to [Py.Cafe](https://py.cafe/) you can create Vizro dashboards without installing Vizro locally, as you can see from the [first dashboard tutorial](../tutorials/first-dashboard.md).
+Thanks to [PyCafe](https://py.cafe/) you can create Vizro dashboards without installing Vizro locally, as you can see from the [first dashboard tutorial](../tutorials/first-dashboard.md).
 
 However, if you prefer to work locally, this guide shows you how to install Vizro, how to verify the installation succeeded and find the version of Vizro, and how to update Vizro.
 

--- a/vizro-core/docs/pages/user-guides/run.md
+++ b/vizro-core/docs/pages/user-guides/run.md
@@ -2,18 +2,18 @@
 
 This guide shows you how to launch your dashboard in different ways. By default, your dashboard apps run on localhost port 8050 so is accessible at [http://127.0.0.1:8050/](http://127.0.0.1:8050/).
 
-## Py.Cafe
+## PyCafe
 
-The easiest way to launch your dashboard is to edit the code live on [Py.Cafe](https://py.cafe/).
+The easiest way to launch your dashboard is to edit the code live on [PyCafe](https://py.cafe/).
 
-Most of our examples have a link below the code, [Run and edit this code in Py.Cafe](https://py.cafe/vizro-official/vizro-iris-analysis), which you can follow to experiment with the code. This opens an editor such as the one below, which displays the dashboard and the code side by side.
+Most of our examples have a link below the code, [Run and edit this code in PyCafe](https://py.cafe/vizro-official/vizro-iris-analysis), which you can follow to experiment with the code. This opens an editor such as the one below, which displays the dashboard and the code side by side.
 
 <figure markdown="span">
-  ![Py.Cafe editor](../../assets/user_guides/run/pycafe_editor.png)
+  ![PyCafe editor](../../assets/user_guides/run/pycafe_editor.png)
   <figcaption>Enter your dashboard code on the left, and see the results immediately reflected in the app on the right.</figcaption>
 </figure>
 
-You can use [Py.Cafe](https://py.cafe/snippet/vizro/v1) snippet mode to experiment with your own Vizro dashboards by dropping code into a new project.
+You can use [PyCafe](https://py.cafe/snippet/vizro/v1) snippet mode to experiment with your own Vizro dashboards by dropping code into a new project.
 
 
 ## Default built-in Flask development server

--- a/vizro-core/examples/visual-vocabulary/pages/__init__.py
+++ b/vizro-core/examples/visual-vocabulary/pages/__init__.py
@@ -2,4 +2,4 @@
 # TODO: think about the best way to do code examples, e.g.
 # - do we want full dashboard example or plot-only example?
 # - or both? Could be done using a toggle switch or multiple tabs.
-# - a link to py.cafe showing the dashboard code?
+# - a link to PyCafe showing the dashboard code?


### PR DESCRIPTION
## Description
Fix for https://github.com/mckinsey/vizro/issues/750 "Correct all mentions of Py.Cafe"
- Updates reference from Py.Cafe to PyCafe to describe their organization
- Mantians references to https://py.cafe/ to talk about the site itself

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
