### PR TITLE
[Fix] Remove double loading of data

### DIFF
--- a/vizro-core/changelog.d/20241010_135707_antony.milne_double_loading.md
+++ b/vizro-core/changelog.d/20241010_135707_antony.milne_double_loading.md
@@ -1,0 +1,47 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+
+### Fixed
+
+- Remove unnecessarily repeated loading of data. ([#802](https://github.com/mckinsey/vizro/pull/802))
+
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/changelog.d/new_fragment.md.j2
+++ b/vizro-core/changelog.d/new_fragment.md.j2
@@ -8,7 +8,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 <!--
 ### {{ cat }}
 
-- A bullet item for the {{ cat }} category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX ([#1](https://github.com/mckinsey/vizro/pull/1))
+- A bullet item for the {{ cat }} category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
 
 -->
 {% endfor -%}

--- a/vizro-core/src/vizro/models/_components/ag_grid.py
+++ b/vizro-core/src/vizro/models/_components/ag_grid.py
@@ -65,7 +65,11 @@ class AgGrid(VizroBaseModel):
 
     # Convenience wrapper/syntactic sugar.
     def __call__(self, **kwargs):
-        kwargs.setdefault("data_frame", data_manager[self["data_frame"]].load())
+        # This default value is not actually used anywhere at the moment since __call__ is always used with data_frame
+        # specified. It's here since we want to use __call__ without arguments more in future.
+        # If the functionality of process_callable_data_frame moves to CapturedCallable then this would move there too.
+        if "data_frame" not in kwargs:
+            kwargs["data_frame"] = data_manager[self["data_frame"]].load()
         figure = self.figure(**kwargs)
         figure.id = self._input_component_id
         return figure

--- a/vizro-core/src/vizro/models/_components/figure.py
+++ b/vizro-core/src/vizro/models/_components/figure.py
@@ -37,7 +37,11 @@ class Figure(VizroBaseModel):
     _validate_callable = validator("figure", allow_reuse=True, always=True)(_process_callable_data_frame)
 
     def __call__(self, **kwargs):
-        kwargs.setdefault("data_frame", data_manager[self["data_frame"]].load())
+        # This default value is not actually used anywhere at the moment since __call__ is always used with data_frame
+        # specified. It's here since we want to use __call__ without arguments more in future.
+        # If the functionality of process_callable_data_frame moves to CapturedCallable then this would move there too.
+        if "data_frame" not in kwargs:
+            kwargs["data_frame"] = data_manager[self["data_frame"]].load()
         figure = self.figure(**kwargs)
         return figure
 

--- a/vizro-core/src/vizro/models/_components/graph.py
+++ b/vizro-core/src/vizro/models/_components/graph.py
@@ -70,9 +70,10 @@ class Graph(VizroBaseModel):
     # Convenience wrapper/syntactic sugar.
     def __call__(self, **kwargs):
         # This default value is not actually used anywhere at the moment since __call__ is always used with data_frame
-        # specified. It's here to match Table and AgGrid and because we might want to use __call__ more in future.
+        # specified. It's here since we want to use __call__ without arguments more in future.
         # If the functionality of process_callable_data_frame moves to CapturedCallable then this would move there too.
-        kwargs.setdefault("data_frame", data_manager[self["data_frame"]].load())
+        if "data_frame" not in kwargs:
+            kwargs["data_frame"] = data_manager[self["data_frame"]].load()
         fig = self.figure(**kwargs)
         fig = self._optimise_fig_layout_for_dashboard(fig)
 

--- a/vizro-core/src/vizro/models/_components/table.py
+++ b/vizro-core/src/vizro/models/_components/table.py
@@ -64,7 +64,11 @@ class Table(VizroBaseModel):
 
     # Convenience wrapper/syntactic sugar.
     def __call__(self, **kwargs):
-        kwargs.setdefault("data_frame", data_manager[self["data_frame"]].load())
+        # This default value is not actually used anywhere at the moment since __call__ is always used with data_frame
+        # specified. It's here since we want to use __call__ without arguments more in future.
+        # If the functionality of process_callable_data_frame moves to CapturedCallable then this would move there too.
+        if "data_frame" not in kwargs:
+            kwargs["data_frame"] = data_manager[self["data_frame"]].load()
         figure = self.figure(**kwargs)
         figure.id = self._input_component_id
         return figure


### PR DESCRIPTION
## Description

A special treat for @petar-qb to find when he's feeling better 😀 Probably the easiest optimisation we could have made. Thank you to him for spotting this horrible inefficiency that I had written in the code!

Functionally this is exactly the same as before. It's just better performing. Previously doing `kwargs.setdefault` always ran the `.load()` function. Now we only want to run it if it's strictly required (which in Vizro at the moment it actually never is, but I saw someone doing `graph()` the other day so they were using it, and maybe we will in future).

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
