### PR TITLE
[Docs] Add PyCafe documentation links

### DIFF
--- a/vizro-core/docs/pages/tutorials/explore-components.md
+++ b/vizro-core/docs/pages/tutorials/explore-components.md
@@ -6,7 +6,7 @@ If you haven't yet done so, you may want to review the [first dashboard tutorial
 
 ## 1. (Optional) Install Vizro and get ready to run your code
 
-The code for this tutorial is all available for you to experiment with in [PyCafe](https://py.cafe/) so there is no need to install Vizro and run it locally.
+The code for this tutorial is all available for you to experiment with in [PyCafe](https://py.cafe/) so there is no need to install Vizro and run it locally. For more about how this works, check out the [PyCafe documentation](https://py.cafe/docs/apps/vizro).
 
 However, if you prefer working in a Notebook or Python script, you should [install Vizro](../user-guides/install.md).
 

--- a/vizro-core/docs/pages/tutorials/first-dashboard.md
+++ b/vizro-core/docs/pages/tutorials/first-dashboard.md
@@ -35,14 +35,14 @@ Click on the **Run and edit this code in PyCafe** link below to live-edit the da
     [FirstDash]: ../../assets/tutorials/dashboard/first-dashboard.png
 
 <!-- vale off -->
-## Can I break your code?
+## Can I break this code?
 <!-- vale on -->
 When you click the link to "Edit live on PyCafe" the dashboard is running inside your browser. Any changes you make are local and you don't need to worry about breaking the code for others. Nobody else sees the changes you make unless you save a copy of the project as your own Vizro PyCafe project.
 
 <!-- vale off -->
 ## How can I make my own dashboards?
 <!-- vale on -->
-You can use [PyCafe](https://py.cafe/snippet/vizro/v1) to experiment with your own Vizro dashboards by dropping code onto a new project.
+You can use PyCafe to experiment with your own Vizro dashboards by dropping code onto a new project. Check out the [PyCafe documentation](https://py.cafe/docs/apps/vizro) for more information.
 
 If you need inspiration or a starting point, we make all our examples available for you to try out on PyCafe. Throughout our documentation, follow the "**Run and edit this code in PyCafe**" link below the code snippets to open them in PyCafe.
 

--- a/vizro-core/docs/pages/user-guides/install.md
+++ b/vizro-core/docs/pages/user-guides/install.md
@@ -1,8 +1,8 @@
 # How to install Vizro
 
-Thanks to [PyCafe](https://py.cafe/) you can create Vizro dashboards without installing Vizro locally, as you can see from the [first dashboard tutorial](../tutorials/first-dashboard.md).
+Thanks to [PyCafe](https://py.cafe/) you can create Vizro dashboards without installing Vizro locally, as you can see from the [first dashboard tutorial](../tutorials/first-dashboard.md) (you can find out more about [working with PyCafe and Vizro](https://py.cafe/docs/apps/vizro) from the PyCafe documentation).
 
-However, if you prefer to work locally, this guide shows you how to install Vizro, how to verify the installation succeeded and find the version of Vizro, and how to update Vizro.
+If you prefer to work locally, this guide shows you how to install Vizro, how to verify the installation succeeded and find the version of Vizro, and how to update Vizro.
 
 We recommend that you create a virtual environment for each Vizro project you work on to isolate its Python dependencies from other projects. If you already have a virtual environment you can skip the next section and [install Vizro](#install-vizro). Otherwise, read on!
 


### PR DESCRIPTION
## Description
Adding in a set of links to PyCafe documentation to point readers to it if they want more info about how to use PyCafe.


## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
