### PR TITLE
[Tidy] Proof of concept replacing ctd for filter and parameter

### DIFF
--- a/vizro-core/changelog.d/20241115_145305_antony.milne_remove_ctx.md
+++ b/vizro-core/changelog.d/20241115_145305_antony.milne_remove_ctx.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -41,6 +41,7 @@ page = vm.Page(
             ),
         ),
     ],
+    controls=[vm.Filter(column="pastry")],
 )
 
 dashboard = vm.Dashboard(pages=[page])

--- a/vizro-core/src/vizro/actions/_callback_mapping/_callback_mapping_utils.py
+++ b/vizro-core/src/vizro/actions/_callback_mapping/_callback_mapping_utils.py
@@ -28,13 +28,15 @@ def _get_matching_actions_by_function(
 
 
 # CALLBACK STATES --------------
-def _get_inputs_of_controls(page: Page, control_type: ControlType) -> list[State]:
+def _get_inputs_of_controls(page: Page, control_type: ControlType) -> dict[ModelID, State]:
     """Gets list of `States` for selected `control_type` of triggered `Page`."""
-    return [
-        State(component_id=control.selector.id, component_property=control.selector._input_property)
+    return {
+        control.selector.id: State(
+            component_id=control.selector.id, component_property=control.selector._input_property
+        )
         for control in page.controls
         if isinstance(control, control_type)
-    ]
+    }
 
 
 def _get_inputs_of_figure_interactions(
@@ -65,12 +67,14 @@ def _get_action_callback_inputs(action_id: ModelID) -> dict[str, list[Union[Stat
     page: Page = model_manager[model_manager._get_model_page_id(model_id=action_id)]
 
     action_input_mapping = {
-        "filters": _get_inputs_of_controls(page=page, control_type=Filter),
-        "parameters": _get_inputs_of_controls(page=page, control_type=Parameter),
+        "filters": _get_inputs_of_controls(
+            page=page, control_type=Filter
+        ),  # AM now looks like "filters": {"filter_id": ["iris", "versicolor"]}
+        "parameters": _get_inputs_of_controls(page=page, control_type=Parameter),  # AM: updated
         # TODO: Probably need to adjust other inputs to follow the same structure list[dict[str, State]]
         "filter_interaction": _get_inputs_of_figure_interactions(
             page=page, action_function=filter_interaction.__wrapped__
-        ),
+        ),  # AM: not updated yet
     }
     return action_input_mapping
 

--- a/vizro-core/src/vizro/actions/_callback_mapping/_get_action_callback_mapping.py
+++ b/vizro-core/src/vizro/actions/_callback_mapping/_get_action_callback_mapping.py
@@ -28,8 +28,8 @@ def _get_action_callback_mapping(
     action_callback_mapping: dict[str, Any] = {
         export_data.__wrapped__: {
             "inputs": _get_action_callback_inputs,
-            "components": _get_export_data_callback_components,
-            "outputs": _get_export_data_callback_outputs,
+            "components": _get_export_data_callback_components,  # AM. not updated
+            "outputs": _get_export_data_callback_outputs,  # AM. not updated
         },
         _filter.__wrapped__: {
             "inputs": _get_action_callback_inputs,

--- a/vizro-core/src/vizro/actions/_filter_action.py
+++ b/vizro-core/src/vizro/actions/_filter_action.py
@@ -30,8 +30,8 @@ def _filter(
         Dict mapping target component ids to modified charts/components e.g. {'my_scatter': Figure({})}
     """
     return _get_modified_page_figures(
-        ctds_filter=ctx.args_grouping["external"]["filters"],
+        filters=inputs["filters"],
         ctds_filter_interaction=ctx.args_grouping["external"]["filter_interaction"],
-        ctds_parameters=ctx.args_grouping["external"]["parameters"],
+        parameters=inputs["parameters"],
         targets=targets,
     )

--- a/vizro-core/src/vizro/actions/_on_page_load_action.py
+++ b/vizro-core/src/vizro/actions/_on_page_load_action.py
@@ -22,9 +22,10 @@ def _on_page_load(targets: list[ModelID], **inputs: dict[str, Any]) -> dict[Mode
         Dict mapping target chart ids to modified figures e.g. {'my_scatter': Figure({})}
 
     """
+
     return _get_modified_page_figures(
-        ctds_filter=ctx.args_grouping["external"]["filters"],
+        filters=inputs["filters"],
         ctds_filter_interaction=ctx.args_grouping["external"]["filter_interaction"],
-        ctds_parameters=ctx.args_grouping["external"]["parameters"],
+        parameters=inputs["parameters"],
         targets=targets,
     )

--- a/vizro-core/src/vizro/actions/_on_page_load_action.py
+++ b/vizro-core/src/vizro/actions/_on_page_load_action.py
@@ -22,7 +22,6 @@ def _on_page_load(targets: list[ModelID], **inputs: dict[str, Any]) -> dict[Mode
         Dict mapping target chart ids to modified figures e.g. {'my_scatter': Figure({})}
 
     """
-
     return _get_modified_page_figures(
         filters=inputs["filters"],
         ctds_filter_interaction=ctx.args_grouping["external"]["filter_interaction"],

--- a/vizro-core/src/vizro/actions/_parameter_action.py
+++ b/vizro-core/src/vizro/actions/_parameter_action.py
@@ -24,6 +24,9 @@ def _parameter(targets: list[str], **inputs: dict[str, Any]) -> dict[ModelID, An
     """
     target_ids: list[ModelID] = [target.split(".")[0] for target in targets]  # type: ignore[misc]
 
-    return _get_modified_page_figures(filters=inputs["filters"],
-                                      ctds_filter_interaction=ctx.args_grouping["external"]["filter_interaction"],
-                                      parameters=inputs["parameters"], targets=target_ids)
+    return _get_modified_page_figures(
+        filters=inputs["filters"],
+        ctds_filter_interaction=ctx.args_grouping["external"]["filter_interaction"],
+        parameters=inputs["parameters"],
+        targets=target_ids,
+    )

--- a/vizro-core/src/vizro/actions/_parameter_action.py
+++ b/vizro-core/src/vizro/actions/_parameter_action.py
@@ -24,9 +24,6 @@ def _parameter(targets: list[str], **inputs: dict[str, Any]) -> dict[ModelID, An
     """
     target_ids: list[ModelID] = [target.split(".")[0] for target in targets]  # type: ignore[misc]
 
-    return _get_modified_page_figures(
-        ctds_filter=ctx.args_grouping["external"]["filters"],
-        ctds_filter_interaction=ctx.args_grouping["external"]["filter_interaction"],
-        ctds_parameters=ctx.args_grouping["external"]["parameters"],
-        targets=target_ids,
-    )
+    return _get_modified_page_figures(filters=inputs["filters"],
+                                      ctds_filter_interaction=ctx.args_grouping["external"]["filter_interaction"],
+                                      parameters=inputs["parameters"], targets=target_ids)

--- a/vizro-core/src/vizro/actions/filter_interaction_action.py
+++ b/vizro-core/src/vizro/actions/filter_interaction_action.py
@@ -28,6 +28,9 @@ def filter_interaction(targets: Optional[list[ModelID]] = None, **inputs: dict[s
         Dict mapping target component ids to modified charts/components e.g. {'my_scatter': Figure({})}
 
     """
-    return _get_modified_page_figures(filters=inputs["filters"],
-                                      ctds_filter_interaction=ctx.args_grouping["external"]["filter_interaction"],
-                                      parameters=inputs["parameters"], targets=targets or [])
+    return _get_modified_page_figures(
+        filters=inputs["filters"],
+        ctds_filter_interaction=ctx.args_grouping["external"]["filter_interaction"],
+        parameters=inputs["parameters"],
+        targets=targets or [],
+    )

--- a/vizro-core/src/vizro/actions/filter_interaction_action.py
+++ b/vizro-core/src/vizro/actions/filter_interaction_action.py
@@ -28,9 +28,6 @@ def filter_interaction(targets: Optional[list[ModelID]] = None, **inputs: dict[s
         Dict mapping target component ids to modified charts/components e.g. {'my_scatter': Figure({})}
 
     """
-    return _get_modified_page_figures(
-        ctds_filter=ctx.args_grouping["external"]["filters"],
-        ctds_filter_interaction=ctx.args_grouping["external"]["filter_interaction"],
-        ctds_parameters=ctx.args_grouping["external"]["parameters"],
-        targets=targets or [],
-    )
+    return _get_modified_page_figures(filters=inputs["filters"],
+                                      ctds_filter_interaction=ctx.args_grouping["external"]["filter_interaction"],
+                                      parameters=inputs["parameters"], targets=targets or [])

--- a/vizro-core/src/vizro/models/_action/_action.py
+++ b/vizro-core/src/vizro/models/_action/_action.py
@@ -43,6 +43,19 @@ class Action(VizroBaseModel):
         regex="^[^.]+[.][^.]+$",
     )
 
+    # POPULATE THESE USING function.inputs etc. When? Can't be init/validator as need model_manager. Could be
+    # pre_build if no actions created during pre_build. Or needs to be final pre-build or in build
+    # Need to pass page or action_id or similar into CapturedActionCallable to calculate all controls or page or
+    # similar.
+    # inputs/outputs is only list[str] so far so would need to change to dict or change current dict to list to work
+    # with this
+    # can just put into private property _inputs that mimics inputs for now
+    # in future might use pattern matching
+    # for now function.inputs needs to be dynamically calculated property
+    # fine to copy and paste between different actions or have some code for inputs corresponding to all controls on
+    # page
+    # remove components as property and just put in dcc.Download global? Need one download object per file?
+
     # TODO: Problem: generic Action model shouldn't depend on details of particular actions like export_data.
     # Possible solutions: make a generic mapping of action functions to validation functions or the imports they
     # require, and make the code here look up the appropriate validation using the function as key


### PR DESCRIPTION
## Description

@petar-qb raising this PR just to see if you think it's a good idea as a change. I won't actually implement it until you've done your PR so you don't have to resolve any more conflicts.

I'm finally continuing work on #363 and this seems like a small refactor that will tidy things up some more before the conversion to classes, which will hopefully be the next PR I raise on this topic 🤞

So far this PR is just a proof of concept to show what the change would look like. I haven't fully rolled it out or updated tests yet but the simple demo app works exactly the same as before.

Basically we passed `filters` and `parameters` through `inputs` in the callbacks before but didn't actually use them anywhere and instead looked inside `ctx.args_grouping` to extract all the values and and component ids. The only actual properties used in the `CallbackTriggerDict` are `id` and `value`. We can instead pass through named states in the form `{<id>: State(...)}` to get the `id` passed in automatically so we don't need `ctx.args_grouping` for that. I don't think we'll ever need it for anything else. Here's what's in it to remind you:

```
class CallbackTriggerDict(TypedDict):
    """Represent dash.ctx.args_grouping item. Shortened as 'ctd' in the code.

    Args:
        id: The component ID. If it's a pattern matching ID, it will be a dict.
        property: The component property used in the callback.
        value: The value of the component property at the time the callback was fired.
        str_id: For pattern matching IDs, it's the stringified dict ID without white spaces.
        triggered: A boolean indicating whether this input triggered the callback.

    """

    id: ModelID
    property: Literal["clickData", "value", "n_clicks", "active_cell", "derived_viewport_data"]
    value: Optional[Any]
    str_id: str
    triggered: bool
```

The change here would achieve be half of what you suggest in this comment:
```
        # TODO-AV2-OQ: Consider the following inputs ctx form:
        #  ```
        #  return {
        #      target_1: {'filters': ..., 'parameters': ..., 'filter_interaction': ..., 'theme_selector': ...},
        #      target_2: {'filters': ..., 'parameters': ..., 'filter_interaction': ..., 'theme_selector': ...},
        #  }
        #  ```
        #  Pros:
        #  1. We don't need anymore to send all filter/parameters/filter_interaction inputs to the server
        #  2. Potentially we don't need to dig through the ctx in the _actions_utils.py which decreases the complexity
```

The other half is also captured by my more recent comment:
```
    # TODO: the structure here would be nicer if we could get just the ctds for a single target at one time,
    #  so you could do apply_filters on a target a pass only the ctds relevant for that target.
    #  Consider restructuring ctds to a more convenient form to make this possible.
```

## Screenshot

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
