### PR TITLE
[CI] Allow pre-releases

### DIFF
--- a/vizro-ai/hatch.toml
+++ b/vizro-ai/hatch.toml
@@ -32,6 +32,7 @@ dependencies = [
 installer = "uv"
 
 [envs.default.env-vars]
+UV_PRERELEASE = "allow"
 VIZRO_AI_LOG_LEVEL = "DEBUG"
 
 [envs.default.scripts]

--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -33,6 +33,7 @@ dependencies = [
   "PyGithub"
 ]
 installer = "uv"
+env-vars = {UV_PRERELEASE = "allow"}
 
 [envs.default.scripts]
 example = "hatch run examples:example {args:scratch_dev}"  # shortcut script to underlying example environment script.

--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -32,8 +32,8 @@ dependencies = [
   "pre-commit",
   "PyGithub"
 ]
-installer = "uv"
 env-vars = {UV_PRERELEASE = "allow"}
+installer = "uv"
 
 [envs.default.scripts]
 example = "hatch run examples:example {args:scratch_dev}"  # shortcut script to underlying example environment script.


### PR DESCRIPTION
## Description

Very small change that allows pre-releases to be installed in our CI environments.

This means e.g. if pydantic releases an alpha version that breaks something on our end then we'll know about it before they release the full version.

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
