### PR TITLE
[CI] Do not use prereleases

### DIFF
--- a/vizro-ai/hatch.toml
+++ b/vizro-ai/hatch.toml
@@ -32,7 +32,6 @@ dependencies = [
 installer = "uv"
 
 [envs.default.env-vars]
-UV_PRERELEASE = "allow"
 VIZRO_AI_LOG_LEVEL = "DEBUG"
 
 [envs.default.scripts]

--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -35,7 +35,6 @@ dependencies = [
   "opencv-python",
   "pyhamcrest"
 ]
-env-vars = {UV_PRERELEASE = "allow"}
 installer = "uv"
 
 [envs.default.scripts]


### PR DESCRIPTION
## Description

Revert changes of #893. Plotly just released 6.0.0rc0 and it breaks lots of our tests. Let's not use prereleases any more...

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
