### PR TITLE
[Deps] Increase dash lower bound from 2.17.1 to 2.18.0

### DIFF
--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -114,7 +114,7 @@ VIZRO_LOG_LEVEL = "DEBUG"
 [envs.lower-bounds]
 extra-dependencies = [
   "pydantic==1.10.16",
-  "dash==2.17.1",
+  "dash==2.18.0",
   "plotly==5.12.0",
   "pandas==2.0.0",
   "numpy==1.23.0"  # Need numpy<2 to work with pandas==2.0.0. See https://stackoverflow.com/questions/78634235/.

--- a/vizro-core/pyproject.toml
+++ b/vizro-core/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13"
 ]
 dependencies = [
-  "dash>=2.17.1,<3",  # 2.17.1 needed for no_output fix in clientside_callback
+  "dash>=2.18.0,<3",  # 2.18.0 needed as the 'id' attribute is exposed for dcc.Loading
   "dash_bootstrap_components",
   "dash-ag-grid>=31.0.0",
   "pandas>=2",


### PR DESCRIPTION
## Description
Increased as we use `dcc.Loading.id` for targeting dynamic filters, but this is enabled in https://github.com/plotly/dash/releases/tag/v2.18.0. 

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

  - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
  - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
  - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
  - I have not referenced individuals, products or companies in any commits, directly or indirectly.
  - I have not added data or restricted code in any commits, directly or indirectly.
