### PR TITLE
[Docs] Add search console tag for verification

### DIFF
--- a/vizro-core/mkdocs.yml
+++ b/vizro-core/mkdocs.yml
@@ -144,6 +144,10 @@ plugins:
   - git-revision-date-localized:
       enable_creation_date: false
 
+extra:
+  meta:
+    - name: google-site-verification
+      content: "CYb3cxosCgsN2QDQVaSGQpMQCesqpsGQ3oTM02NtvkY"
 extra_css:
   - stylesheets/extra.css
 


### PR DESCRIPTION
## Description
As part of ticket 1377 on the internal repo.

Adding `CYb3cxosCgsN2QDQVaSGQpMQCesqpsGQ3oTM02NtvkY` as our tag to enable readthedocs to add it to our hosted docs for verification by Google search console.

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
