### PR TITLE
[Bug] Fixed the Bedrock model name error

### DIFF
--- a/vizro-ai/changelog.d/20250115_002943_lingyi_zhang_bedrock_model_name_error.md
+++ b/vizro-ai/changelog.d/20250115_002943_lingyi_zhang_bedrock_model_name_error.md
@@ -34,12 +34,11 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 - A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
 
 -->
-<!--
+
 ### Fixed
 
 - Fixed the "Model name could not be retrieved" error when using with AWS Bedrock. ([#953](https://github.com/mckinsey/vizro/pull/953))
 
--->
 <!--
 ### Security
 

--- a/vizro-ai/changelog.d/20250115_002943_lingyi_zhang_bedrock_model_name_error.md
+++ b/vizro-ai/changelog.d/20250115_002943_lingyi_zhang_bedrock_model_name_error.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- Fixed the "Model name could not be retrieved" error when using with AWS Bedrock. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-ai/changelog.d/20250115_002943_lingyi_zhang_bedrock_model_name_error.md
+++ b/vizro-ai/changelog.d/20250115_002943_lingyi_zhang_bedrock_model_name_error.md
@@ -37,7 +37,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 <!--
 ### Fixed
 
-- Fixed the "Model name could not be retrieved" error when using with AWS Bedrock. ([#1](https://github.com/mckinsey/vizro/pull/1))
+- Fixed the "Model name could not be retrieved" error when using with AWS Bedrock. ([#953](https://github.com/mckinsey/vizro/pull/953))
 
 -->
 <!--

--- a/vizro-ai/docs/pages/user-guides/customize-vizro-ai.md
+++ b/vizro-ai/docs/pages/user-guides/customize-vizro-ai.md
@@ -120,4 +120,4 @@ Consider upgrading to, in the case of OpenAI the `gpt-4o` and `gpt-4` model seri
 
 ### Dashboard generation
 
-At the time of writing we find that cheaper models only work for basic dashboards. For a reasonably complex dashboard we recommend the flagship models of the leading vendors, for example `gpt-4o` or `claude-3-5-sonnet-latest`.
+At the time of writing we find that cheaper models only work for basic dashboards. For a reasonably complex dashboard we recommend the flagship models of the leading vendors, for example `gpt-4o`.

--- a/vizro-ai/hatch.toml
+++ b/vizro-ai/hatch.toml
@@ -27,6 +27,7 @@ dependencies = [
   "langchain-community",
   "langchain_mistralai",
   "langchain-anthropic",
+  "langchain-aws",
   "pre-commit"
 ]
 installer = "uv"
@@ -39,6 +40,7 @@ example = "cd examples; python example.py"
 example-create-dashboard = "cd examples; python example_dashboard.py"
 example-ui = "cd examples/dashboard_ui; python app.py"
 lint = "pre-commit run {args} --all-files"
+notebook = "cd examples; jupyter notebook"
 pip = '"{env:HATCH_UV}" pip {args}'
 prep-release = [
   "hatch version release",

--- a/vizro-ai/src/vizro_ai/_llm_models.py
+++ b/vizro-ai/src/vizro_ai/_llm_models.py
@@ -1,4 +1,3 @@
-from contextlib import suppress
 from typing import Optional, Union
 
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -72,19 +71,6 @@ def _get_llm_model(model: Optional[Union[BaseChatModel, str]] = None) -> BaseCha
     raise ValueError(
         f"Model {model} not found! List of available model can be found at https://vizro.readthedocs.io/projects/vizro-ai/en/latest/pages/user-guides/customize-vizro-ai/#supported-models"
     )
-
-
-def _get_model_name(model: BaseChatModel) -> str:
-    methods = [
-        lambda: model.model_name,  # OpenAI models
-        lambda: model.model,  # Anthropic models
-    ]
-
-    for method in methods:
-        with suppress(AttributeError):
-            return method()
-
-    raise ValueError("Model name could not be retrieved")
 
 
 if __name__ == "__main__":

--- a/vizro-ai/src/vizro_ai/_vizro_ai.py
+++ b/vizro-ai/src/vizro_ai/_vizro_ai.py
@@ -8,7 +8,7 @@ import vizro.models as vm
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import HumanMessage
 
-from vizro_ai._llm_models import _get_llm_model, _get_model_name
+from vizro_ai._llm_models import _get_llm_model
 from vizro_ai.dashboard._graph.dashboard_creation import _create_and_compile_graph
 from vizro_ai.dashboard._pydantic_output import _get_pydantic_model  # TODO: make general, ie remove from dashboard
 from vizro_ai.dashboard.utils import DashboardOutputs, _extract_overall_imports_and_code, _register_data
@@ -50,12 +50,10 @@ class VizroAI:
         self.components_instances = {}
 
         # TODO add pending URL link to docs
-        model_name = _get_model_name(self.model)
         logger.info(
-            f"You have selected {model_name},"
-            f"Engaging with LLMs (Large Language Models) carries certain risks. "
-            f"Users are advised to become familiar with these risks to make informed decisions, "
-            f"and visit this page for detailed information: "
+            "Engaging with LLMs (Large Language Models) carries certain risks. "
+            "Users are advised to become familiar with these risks to make informed decisions, "
+            "and visit this page for detailed information: "
             "https://vizro-ai.readthedocs.io/en/latest/pages/explanation/disclaimer/"
         )
 


### PR DESCRIPTION
## Description

`_get_model_name` raises "Model name could not be retrieved" when used with AWS Bedrock, because `ChatBedrock` class doesn't have corresponding property for model name retrieval.

The proposed fix is to drop `_get_model_name` entirely to prevent similar mismatch from models we haven't used. Also, `_get_model_name` is not a necessary step. If there is a need to know the model name, we can explicitly call the property.

e.g.,
```
from langchain_anthropic import ChatAnthropic
llm = ChatAnthropic(
        model="claude-3-5-sonnet-latest",
        api_key = os.environ.get("ANTHROPIC_API_KEY"),
        base_url= os.environ.get("ANTHROPIC_API_BASE")
    )
llm.model
```
will render 'claude-3-5-sonnet-latest'

Before this bug is fixed, users could use `ChatBedrockConverse` instead of `ChatBedrock`.
https://python.langchain.com/v0.2/docs/integrations/chat/bedrock/#bedrock-converse-api


## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
