### PR TITLE
[Tidy] Move prettierignore and stylelintignore to pre-commit config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,9 +6,7 @@
   "postAttachCommand": "cd vizro-core && hr examples:example",
   "customizations": {
     "vscode": {
-      "extensions": [
-        "ms-python.python"
-      ]
+      "extensions": ["ms-python.python"]
     }
   },
   "build": {
@@ -18,7 +16,7 @@
     "8050": {
       "label": "scratch_dev example"
     }
-  },
+  }
   // It would be nice if the Python interpreter were automatically set in codespaces.
   // In theory this should work automatically but it doesn't seem to - maybe an issue with codespaces?
   // https://code.visualstudio.com/updates/v1_88#_hatch-environment-discovery

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
         language: node
         types: [text]
         additional_dependencies: ["prettier@3.3.3"]
-        exclude_types: [markdown]
+        exclude_types: [markdown, css]
 
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
     rev: v2.14.0
@@ -83,6 +83,7 @@ repos:
           - stylelint-config-standard@36.0.0
           - stylelint-order@4.1.0
         args: ["--fix"]
+        exclude: ^vizro-core/src/vizro/static/css/.+\.min.*|^vizro-core/src/vizro/static/css/mantine_dates.css
 
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.21

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,0 @@
-**/docs/
-**/.devcontainer/devcontainer.json
-**/static/css/vizro-bootstrap.min.css
-**/static/css/vizro-bootstrap.min.css.map

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,2 +1,0 @@
-**/static/css/vizro-bootstrap.min.css
-**/static/css/vizro-bootstrap.min.css.map


### PR DESCRIPTION
## Description

Very minor tidy up to keep the top level of the repo clean: we can just specify these ignores in `pre-commit-config.yaml` rather than in their own top-level `ignore` files.

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
