### PR TITLE
[Bug] Fix coloring of NavLinks inside NavBar

### DIFF
--- a/vizro-ai/examples/dashboard_ui/assets/custom.css
+++ b/vizro-ai/examples/dashboard_ui/assets/custom.css
@@ -301,7 +301,7 @@
   background: var(--text-primary);
   border-top-left-radius: 8px;
   bottom: 0;
-  color: var(--text-primary-inverted);
+  color: var(--text-primary-inverted) !important;
   display: flex;
   font-size: 0.8rem;
   font-weight: 500;

--- a/vizro-core/changelog.d/20250123_183556_huong_li_nguyen_fix_css_nav_links.md
+++ b/vizro-core/changelog.d/20250123_183556_huong_li_nguyen_fix_css_nav_links.md
@@ -37,7 +37,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Fixed
 
-- Fix coloring of `NavLink` inside `NavBar`. ([#1](https://github.com/mckinsey/vizro/pull/1))
+- Fix coloring of `NavLink` inside `NavBar`. ([#968](https://github.com/mckinsey/vizro/pull/968))
 
 
 <!--

--- a/vizro-core/changelog.d/20250123_183556_huong_li_nguyen_fix_css_nav_links.md
+++ b/vizro-core/changelog.d/20250123_183556_huong_li_nguyen_fix_css_nav_links.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+
+### Fixed
+
+- Fix coloring of `NavLink` inside `NavBar`. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/examples/dev/assets/css/custom.css
+++ b/vizro-core/examples/dev/assets/css/custom.css
@@ -23,7 +23,7 @@
   background: var(--text-primary);
   border-top-left-radius: 8px;
   bottom: 0;
-  color: var(--text-primary-inverted);
+  color: var(--text-primary-inverted) !important;
   display: flex;
   font-size: 0.8rem;
   font-weight: 500;

--- a/vizro-core/examples/visual-vocabulary/assets/css/custom.css
+++ b/vizro-core/examples/visual-vocabulary/assets/css/custom.css
@@ -94,7 +94,7 @@ img[src*="#chart-icon"] {
   background: var(--text-primary);
   border-top-left-radius: 8px;
   bottom: 0;
-  color: var(--text-primary-inverted);
+  color: var(--text-primary-inverted) !important;
   display: flex;
   font-size: 0.8rem;
   font-weight: 500;

--- a/vizro-core/src/vizro/static/css/bootstrap_overwrites.css
+++ b/vizro-core/src/vizro/static/css/bootstrap_overwrites.css
@@ -28,6 +28,16 @@ All the HEX values starting with --text-code are taken from the Github code high
   --collapse-icon-bg: var(--primary-300);
 }
 
+/* This is currently as the NavBar comes with `navbar-light` even on dark theme */
+.nav-link {
+   color: var(--text-secondary) !important;
+}
+
+.nav-link:active, .nav-link.active {
+    color: var(--text-primary) !important;
+}
+
+
 /* CARDS */
 .card {
   height: 100%;

--- a/vizro-core/src/vizro/static/css/bootstrap_overwrites.css
+++ b/vizro-core/src/vizro/static/css/bootstrap_overwrites.css
@@ -28,7 +28,7 @@ All the HEX values starting with --text-code are taken from the Github code high
   --collapse-icon-bg: var(--primary-300);
 }
 
-/* This is currently as the NavBar comes with `navbar-light` even on dark theme */
+/* This is currently required as dbc.NavBar comes with the `navbar-light` class even on a dark theme */
 .nav-link {
    color: var(--text-secondary) !important;
 }


### PR DESCRIPTION
## Description
With the latest Bootstrap theme, the NavLinks inside our NavBars were incorrectly colored. However, this is actually not an issue of the Bootstrap theme, as the CSS itself is correct.

The issue appears as with the usage of `dbc.NavBar`, the className ="navbar-light" is automatically attached to that component in both dark and light theme. We could probably fix this via callbacks, but I think the CSS fix is fine.

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
