### PR TITLE
[Tidy] Remove default for `mapbox` inside template

### DIFF
--- a/vizro-ai/pyproject.toml
+++ b/vizro-ai/pyproject.toml
@@ -70,7 +70,10 @@ filterwarnings = [
   # Ignore deprecation warning until this is solved: https://github.com/plotly/dash/issues/2590:
   "ignore:HTTPResponse.getheader():DeprecationWarning",
   # Happens during dash_duo teardown in vizro_ai_ui tests. Not affecting functionality:
-  "ignore:Exception in thread"
+  "ignore:Exception in thread",
+    # Ignore deprecation warning as it comes from the plotly default template. In our templates `vizro_dark` and
+  # `vizro_light`, we do not use mapbox anymore, see: https://github.com/mckinsey/vizro/pull/974
+  "ignore:.*scattermapbox.*is deprecated.*Use.*scattermap.*instead:DeprecationWarning",
 ]
 pythonpath = ["../tools/tests"]
 

--- a/vizro-ai/pyproject.toml
+++ b/vizro-ai/pyproject.toml
@@ -71,9 +71,9 @@ filterwarnings = [
   "ignore:HTTPResponse.getheader():DeprecationWarning",
   # Happens during dash_duo teardown in vizro_ai_ui tests. Not affecting functionality:
   "ignore:Exception in thread",
-    # Ignore deprecation warning as it comes from the plotly default template. In our templates `vizro_dark` and
+  # Ignore deprecation warning as it comes from the plotly default template. In our templates `vizro_dark` and
   # `vizro_light`, we do not use mapbox anymore, see: https://github.com/mckinsey/vizro/pull/974
-  "ignore:.*scattermapbox.*is deprecated.*Use.*scattermap.*instead:DeprecationWarning",
+  "ignore:.*scattermapbox.*is deprecated.*Use.*scattermap.*instead:DeprecationWarning"
 ]
 pythonpath = ["../tools/tests"]
 

--- a/vizro-core/changelog.d/20250129_112526_huong_li_nguyen_check_plotly_update.md
+++ b/vizro-core/changelog.d/20250129_112526_huong_li_nguyen_check_plotly_update.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/pyproject.toml
+++ b/vizro-core/pyproject.toml
@@ -84,7 +84,7 @@ filterwarnings = [
   "ignore:HTTPResponse.getheader():DeprecationWarning",
   # Ignore deprecation warning as it comes from the plotly default template. In our templates `vizro_dark` and
   # `vizro_light`, we do not use mapbox anymore, see: https://github.com/mckinsey/vizro/pull/974
-  "ignore:.*scattermapbox.*is deprecated.*Use.*scattermap.*instead:DeprecationWarning",
+  "ignore:.*scattermapbox.*is deprecated.*Use.*scattermap.*instead:DeprecationWarning"
 ]
 norecursedirs = ["tests/tests_utils", "tests/js"]
 pythonpath = ["tests/tests_utils"]

--- a/vizro-core/pyproject.toml
+++ b/vizro-core/pyproject.toml
@@ -81,7 +81,10 @@ filterwarnings = [
   # Ignore warning for Pydantic v1 API and Python 3.13:
   "ignore:Failing to pass a value to the 'type_params' parameter of 'typing.ForwardRef._evaluate' is deprecated:DeprecationWarning",
   # Ignore deprecation warning until this is solved: https://github.com/plotly/dash/issues/2590:
-  "ignore:HTTPResponse.getheader():DeprecationWarning"
+  "ignore:HTTPResponse.getheader():DeprecationWarning",
+  # Ignore deprecation warning as it comes from the plotly default template. In our templates `vizro_dark` and
+  # `vizro_light`, we do not use mapbox anymore, see: https://github.com/mckinsey/vizro/pull/974
+  "ignore:.*scattermapbox.*is deprecated.*Use.*scattermap.*instead:DeprecationWarning",
 ]
 norecursedirs = ["tests/tests_utils", "tests/js"]
 pythonpath = ["tests/tests_utils"]

--- a/vizro-core/src/vizro/_themes/generate_plotly_templates.py
+++ b/vizro-core/src/vizro/_themes/generate_plotly_templates.py
@@ -80,7 +80,6 @@ def generate_json_template(extracted_values: dict[str, str]) -> go.layout.Templa
         ternary_baxis_linecolor=AXIS_COLOR,
         ternary_caxis_gridcolor=GRID_COLOR,
         ternary_caxis_linecolor=AXIS_COLOR,
-        mapbox_style="carto-darkmatter",
         coloraxis_colorbar_tickcolor=AXIS_COLOR,
         coloraxis_colorbar_tickfont_color=FONT_COLOR_SECONDARY,
         coloraxis_colorbar_title_font_color=FONT_COLOR_SECONDARY,

--- a/vizro-core/src/vizro/_themes/vizro_dark.json
+++ b/vizro-core/src/vizro/_themes/vizro_dark.json
@@ -225,9 +225,6 @@
         "gridcolor": "rgba(255, 255, 255, 0.1019607843)",
         "linecolor": "rgba(255, 255, 255, 0.3019607843)"
       }
-    },
-    "mapbox": {
-      "style": "carto-darkmatter"
     }
   },
   "data": {

--- a/vizro-core/src/vizro/_themes/vizro_light.json
+++ b/vizro-core/src/vizro/_themes/vizro_light.json
@@ -225,9 +225,6 @@
         "gridcolor": "rgba(20, 23, 33, 0.1019607843)",
         "linecolor": "rgba(20, 23, 33, 0.3019607843)"
       }
-    },
-    "mapbox": {
-      "style": "carto-darkmatter"
     }
   },
   "data": {


### PR DESCRIPTION
## Description

- Remove the default `mapbox` setting from our templates.
- Ignore deprecation warnings inside our tests since they originate from the `plotly` template and not from our own templates.

Since our templates are now static files instead of being dynamically generated (see: https://github.com/mckinsey/vizro/pull/967), we no longer set any defaults for `map` and now also `mapbox`. These static templates need to be compatible with all versions of `plotly`. 

If we decide to stop supporting older versions of plotly where `map` is not yet supported, we can add a default for `map` in our templates again. I'll discuss this with A. when he returns. For now, let's remove the defaults as they were just a nice-to-have anyway.

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
