### PR TITLE
[Bug] Fix discriminator error when adding duplicate type model

### DIFF
--- a/vizro-core/changelog.d/20250206_203003_maximilian_schulz_add_type_bug.md
+++ b/vizro-core/changelog.d/20250206_203003_maximilian_schulz_add_type_bug.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/changelog.d/20250206_203003_maximilian_schulz_add_type_bug.md
+++ b/vizro-core/changelog.d/20250206_203003_maximilian_schulz_add_type_bug.md
@@ -37,7 +37,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Fixed
 
-- Fixed a bug where adding a model of the same discriminated type as an existing type would raise an error. Now added types overwrite previous type. ([#999](https://github.com/mckinsey/vizro/pull/999))
+- Fix a bug where `add_type` would raise an error if the `type` had already been added. ([#999](https://github.com/mckinsey/vizro/pull/999))
 
 
 <!--

--- a/vizro-core/changelog.d/20250206_203003_maximilian_schulz_add_type_bug.md
+++ b/vizro-core/changelog.d/20250206_203003_maximilian_schulz_add_type_bug.md
@@ -34,12 +34,12 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 - A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
 
 -->
-<!--
+
 ### Fixed
 
-- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+- Fixed a bug where adding a model of the same discriminated type as an existing type would raise an error. Now added types overwrite previous type. ([#999](https://github.com/mckinsey/vizro/pull/999))
 
--->
+
 <!--
 ### Security
 

--- a/vizro-core/src/vizro/models/_base.py
+++ b/vizro-core/src/vizro/models/_base.py
@@ -137,8 +137,14 @@ def _extract_captured_callable_data_info() -> set[str]:
 def _add_type_to_union(union: type[Any], new_type: type[Any]):  # TODO[mypy]: not sure how to type the return type
     args = get_args(union)
     all_types = args + (new_type,)  # noqa: RUF005 #as long as we support Python 3.9, we can't use the new syntax
-    # The below removes duplicates by type, which would trigger a pydantic error otherwise
-    # Last added type will be the one that is kept - this is replicating V1 behavior that would other raise an error in V2
+    # The below removes duplicates by type, which would trigger a pydantic error (TypeError: Value 'xxx'
+    # for discriminator 'type' mapped to multiple choices) otherwise.
+    # We get the type value by accessing the type objects model_fields attribute, which is a dict of the fields
+    # of the model. Since in Vizro we always define the type with a default value (and don't change it), the default
+    # value of the type field is the only possible `type`.
+    # Last added type will be the one that is kept - this is replicating V1 behavior that would other raise an error
+    # in V2, and thus we are defining NEW behavior here. This works by using .values(), which extract values by
+    # insertion order (since Python 3.7), thus the last added type will be the one that is kept.
     unique_types = tuple({t.model_fields["type"].default: t for t in all_types}.values())
     return Union[unique_types]
 

--- a/vizro-core/src/vizro/models/_base.py
+++ b/vizro-core/src/vizro/models/_base.py
@@ -138,6 +138,7 @@ def _add_type_to_union(union: type[Any], new_type: type[Any]):  # TODO[mypy]: no
     args = get_args(union)
     all_types = args + (new_type,)  # noqa: RUF005 #as long as we support Python 3.9, we can't use the new syntax
     # The below removes duplicates by type, which would trigger a pydantic error otherwise
+    # Last added type will be the one that is kept - this is replicating V1 behavior that would other raise an error in V2
     unique_types = tuple({t.model_fields["type"].default: t for t in all_types}.values())
     return Union[unique_types]
 

--- a/vizro-core/tests/unit/vizro/models/test_base.py
+++ b/vizro-core/tests/unit/vizro/models/test_base.py
@@ -600,3 +600,26 @@ class TestPydanticPython:
         # Test more complete and nested model
         result = complete_dashboard._to_python(extra_imports={"from typing import Optional"})
         assert result == expected_complete_dashboard
+
+
+class TestAddingDuplicateDiscriminator:
+    def test_add_same_model(self, Parent):
+        """Test whether adding same model re-defined avoids pydantic discriminator error."""
+
+        class MultipleChild(vm.VizroBaseModel):
+            type: Literal["derived"] = "derived"
+
+        Parent.add_type("child", MultipleChild)
+
+        class MultipleChild(vm.VizroBaseModel):
+            type: Literal["derived"] = "derived"
+
+        Parent.add_type("child", MultipleChild)
+
+    def test_add_duplicate_type(self, Parent):
+        """Test whether adding model of same type avoids pydantic discriminator error."""
+
+        class MultipleChild(ChildX):
+            pass
+
+        Parent.add_type("child", MultipleChild)


### PR DESCRIPTION
## Description
There was a discrepancy between pydantic V1 and V2:

V1: you could have a discriminated union where the discriminator would have multiple options for choosing which model to coerce into: e.g. you could have `type = "card"` twice, and it would coerce into the last type added.

V2: In V2 the same situation would lead to an error that would say: `TypeError: Value 'card' for discriminator 'type' mapped to multiple choices`.

This situation does not arise that often, mostly in re-runs, or tests. We test for this now, and it is fixed.

Note: We are thus defining a DEFAULT behaviour, which is that the last added model takes precedence in discriminated unions.


## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
