### PR TITLE
[Bug] Fix sending an empty list through parameter

### DIFF
--- a/vizro-core/changelog.d/20250218_142411_petar_pejovic_fix_sending_empty_list_through_parameter.md
+++ b/vizro-core/changelog.d/20250218_142411_petar_pejovic_fix_sending_empty_list_through_parameter.md
@@ -1,0 +1,46 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+### Fixed
+
+- Fix that empty list is sent its target when a multi-select parameter is cleared. ([#1026](https://github.com/mckinsey/vizro/pull/1026))
+
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/changelog.d/20250218_142411_petar_pejovic_fix_sending_empty_list_through_parameter.md
+++ b/vizro-core/changelog.d/20250218_142411_petar_pejovic_fix_sending_empty_list_through_parameter.md
@@ -36,7 +36,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 -->
 ### Fixed
 
-- Fix a bug where an empty parameter selection incorrectly sent the `[None]` value to its target. ([#1026](https://github.com/mckinsey/vizro/pull/1026))
+- Fix a bug where an empty parameter selection incorrectly sent `[None]` to its target. ([#1026](https://github.com/mckinsey/vizro/pull/1026))
 
 <!--
 ### Security

--- a/vizro-core/changelog.d/20250218_142411_petar_pejovic_fix_sending_empty_list_through_parameter.md
+++ b/vizro-core/changelog.d/20250218_142411_petar_pejovic_fix_sending_empty_list_through_parameter.md
@@ -36,7 +36,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 -->
 ### Fixed
 
-- Fix a bug where an empty parameter selection incorrectly sent the `[None]` value to its target. ([#1026](https://github.com/mckinsey/vizro/pull/1026)) 
+- Fix a bug where an empty parameter selection incorrectly sent the `[None]` value to its target. ([#1026](https://github.com/mckinsey/vizro/pull/1026))
 
 <!--
 ### Security

--- a/vizro-core/changelog.d/20250218_142411_petar_pejovic_fix_sending_empty_list_through_parameter.md
+++ b/vizro-core/changelog.d/20250218_142411_petar_pejovic_fix_sending_empty_list_through_parameter.md
@@ -36,7 +36,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 -->
 ### Fixed
 
-- Fix that empty list is sent its target when a multi-select parameter is cleared. ([#1026](https://github.com/mckinsey/vizro/pull/1026))
+- Fix a bug where an empty parameter selection incorrectly sent the `[None]` value to its target. ([#1026](https://github.com/mckinsey/vizro/pull/1026)) 
 
 <!--
 ### Security

--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -1,76 +1,44 @@
-"""Test app"""
+"""Dev app to try things out."""
+from os import chown
 
+import pandas as pd
 import vizro.models as vm
 import vizro.plotly.express as px
 from vizro import Vizro
+from vizro.tables import dash_ag_grid
+from vizro.models.types import capture
 
-iris = px.data.iris()
+
+df = px.data.iris()
+
+
+@capture('ag_grid')
+def my_custom_ag_grid(data_frame, chosen_columns, **kwargs):
+    print(f'\nChosen column: {chosen_columns}\n')
+    return dash_ag_grid(data_frame=data_frame[chosen_columns], **kwargs)()
+
 
 page = vm.Page(
-    title="New Line Height",
-    layout=vm.Layout(grid=[[0, 1]]),
+    title="Fix empty dropdown as parameter",
     components=[
-        vm.Card(
-            id="new-line-height",
-            text="""
-            # New
-
-            ## What is Vizro?
-
-            Vizro is an open-source dashboarding framework developed by McKinsey. Built with Plotly and Dash, Vizro
-            provides a high-level API for creating interactive, production-ready dashboards with minimal code.
-            It includes pre-configured layouts, themes, and components, making it easier to build data-driven
-            applications.
-
-            Even if you're not creating a Vizro app, you can still use its styling and design system in your Dash
-            applications.
-
-            ## Vizro Features Available for Dash Apps
-
-            * Vizro Bootstrap-themed figure templates are available in the dash-bootstrap-templates library starting
-            from version 2.1.0. Both dark and light-themed templates are included.
-
-            * Vizro Bootstrap theme provides styling for Bootstrap components, allowing them to match the Vizro light
-            or dark theme.
-
-            * Vizro theme for other Dash components extends styling beyond Bootstrap. Vizro includes custom CSS to
-            theme additional Dash components that are not part of Bootstrap. You can explore all the custom CSS files
-            in their GitHub repository.
-
-            * Vizro KPI cards like the ones shown in the image above can be added to a regular Dash app, bringing a
-            visually consistent way to display key performance indicators. For more details, see this Plotly forum post.""",
-        ),
-        vm.Card(
-            id="old-line-height",
-            text="""
-            # Old
-
-            ## What is Vizro?
-
-            Vizro is an open-source dashboarding framework developed by McKinsey. Built with Plotly and Dash, Vizro
-            provides a high-level API for creating interactive, production-ready dashboards with minimal code.
-            It includes pre-configured layouts, themes, and components, making it easier to build data-driven
-            applications.
-
-            Even if you're not creating a Vizro app, you can still use its styling and design system in your Dash
-            applications.
-
-            ## Vizro Features Available for Dash Apps
-
-            * Vizro Bootstrap-themed figure templates are available in the dash-bootstrap-templates library starting
-            from version 2.1.0. Both dark and light-themed templates are included.
-
-            * Vizro Bootstrap theme provides styling for Bootstrap components, allowing them to match the Vizro light
-            or dark theme.
-
-            * Vizro theme for other Dash components extends styling beyond Bootstrap. Vizro includes custom CSS to
-            theme additional Dash components that are not part of Bootstrap. You can explore all the custom CSS files
-            in their GitHub repository.
-
-            * Vizro KPI cards like the ones shown in the image above can be added to a regular Dash app, bringing a
-            visually consistent way to display key performance indicators. For more details, see this Plotly forum post.""",
-        ),
+        vm.AgGrid(
+            id="my_custom_ag_grid",
+            figure=my_custom_ag_grid(
+                data_frame=df,
+                chosen_columns=df.columns.to_list(),
+            )
+        )
     ],
+    controls=[
+        vm.Parameter(
+            targets=["my_custom_ag_grid.chosen_columns"],
+            selector=vm.Dropdown(
+                title="Choose columns",
+                options=df.columns.to_list(),
+                multi=True,
+            ),
+        ),
+    ]
 )
 
 dashboard = vm.Dashboard(pages=[page])

--- a/vizro-core/src/vizro/actions/_actions_utils.py
+++ b/vizro-core/src/vizro/actions/_actions_utils.py
@@ -126,7 +126,7 @@ def _apply_filter_interaction(
 def _validate_selector_value_none(value: Union[SingleValueType, MultiValueType]) -> ValidatedNoneValueType:
     if value == NONE_OPTION:
         return None
-    elif isinstance(value, list):
+    if isinstance(value, list) and len(value):
         return [i for i in value if i != NONE_OPTION] or [None]  # type: ignore[list-item]
     return value
 

--- a/vizro-core/tests/unit/vizro/actions/test_parameter_action.py
+++ b/vizro-core/tests/unit/vizro/actions/test_parameter_action.py
@@ -241,6 +241,7 @@ class TestParameter:
     @pytest.mark.parametrize(
         "ctx_parameter_hover_data, target_scatter_parameter_hover_data",
         [
+            ([], []),
             (["NONE"], [None]),
             (["NONE", "pop"], ["pop"]),
             (["NONE", "NONE"], [None]),


### PR DESCRIPTION
## Description
Fixes https://github.com/mckinsey/vizro/issues/1010

Currently on the main branch, if an empty value of the `vm.Dropdown(multi=True)` Parameter.selector is chosen, `[None]` value will be sent into its target. This behaviour is introduced in this PR https://github.com/mckinsey/vizro/pull/95.

P.S.
Mentioned PR (https://github.com/mckinsey/vizro/pull/95) actually handles a really great use-case. It enables `None` to be sent into Parameter target which is not possible in the plain dash app by using a `dcc.Dropdown` component. So, creating the following component in the plain dash app will raise and exception only because of the `{"label": "None", "value": None}` option. Options like `True`, `False` and others work correctly. :

```py
dcc.Dropdown(
    id="dropdown",
    options=[
        {"label": "None", "value": None},
        {"label": "True", "value": True},
        {"label": "False", "value": False},
        {"label": "Option A", "value": "A"},
    ],
    value="A"
),
```

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
