### PR TITLE
[CI] Fix PyCafe CI failure on release

### DIFF
--- a/tools/pycafe/create_pycafe_links_comments.py
+++ b/tools/pycafe/create_pycafe_links_comments.py
@@ -7,6 +7,7 @@ from pycafe_utils import (
     PyCafeConfig,
     create_github_client,
     create_status_check,
+    fetch_package_versions,
     generate_comparison_links,
     get_example_directories,
 )
@@ -73,8 +74,20 @@ if __name__ == "__main__":
         pr_number=args.pr_number,
     )
 
+    # Fetch package versions directly and update config
+    try:
+        config.vizro_version, config.vizro_ai_version = fetch_package_versions(config.repo_name, config.commit_sha)
+    except Exception as e:
+        print(f"Error fetching versions: {e}")  # noqa
+        # Keep the default values if an error occurs
+
     # Initialize GitHub connection
     repo, commit = create_github_client(config)
+
+    # Print package versions from the repository at the current commit
+    print("Fetching package versions from repository...")  # noqa
+    print(f"Vizro version from repo: {config.vizro_version}")  # noqa
+    print(f"Vizro-AI version from repo: {config.vizro_ai_version}")  # noqa
 
     # Get example directories
     directories_with_requirements = get_example_directories()

--- a/tools/pycafe/pycafe_utils.py
+++ b/tools/pycafe/pycafe_utils.py
@@ -10,7 +10,6 @@ from typing import Optional, Tuple
 from urllib.parse import quote, urlencode
 
 import requests
-import vizro
 from github import Auth, Github
 from github.Commit import Commit
 from github.Repository import Repository

--- a/tools/pycafe/pycafe_utils.py
+++ b/tools/pycafe/pycafe_utils.py
@@ -3,17 +3,65 @@
 import base64
 import gzip
 import json
+import re
 import textwrap
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Tuple
 from urllib.parse import quote, urlencode
 
 import requests
 import vizro
-import vizro_ai
 from github import Auth, Github
 from github.Commit import Commit
 from github.Repository import Repository
+
+
+# Function to extract version string from file content using regex
+def _extract_version(content: str) -> str:
+    version_match = re.search(r'__version__\s*=\s*["\']([^"\']+)["\']', content)
+    if version_match:
+        return version_match.group(1)
+    return "unknown"
+
+
+def fetch_package_versions(repo_name: str, commit_sha: str) -> Tuple[str, str]:
+    """Fetch package versions directly from the repository files.
+
+    This function retrieves the version strings from the __init__.py files of vizro and vizro-ai
+    packages for the specific commit being tested.
+
+    Args:
+        repo_name: Name of the GitHub repository
+        commit_sha: The commit SHA to fetch versions from
+
+    Returns:
+        A tuple with (vizro_version, vizro_ai_version)
+    """
+    vizro_version = "unknown"
+    vizro_ai_version = "unknown"
+
+    # Define paths to __init__.py files that contain version information
+    version_files = {"vizro": "vizro-core/src/vizro/__init__.py", "vizro-ai": "vizro-ai/src/vizro_ai/__init__.py"}
+
+    # Fetch each file and extract the version
+    for package, file_path in version_files.items():
+        url = f"https://raw.githubusercontent.com/{repo_name}/{commit_sha}/{file_path}"
+        try:
+            response = requests.get(url, timeout=10)
+            response.raise_for_status()
+            content = response.text
+
+            # Update the appropriate version
+            version = _extract_version(content)
+            if package == "vizro" and version != "unknown":
+                vizro_version = version
+            elif package == "vizro-ai" and version != "unknown":
+                vizro_ai_version = version
+
+        except Exception as e:
+            print(f"Failed to fetch version for {package}: {str(e)}")  # noqa
+
+    return vizro_version, vizro_ai_version
 
 
 @dataclass
@@ -27,8 +75,8 @@ class PyCafeConfig:
     pr_number: Optional[int] = None
     pycafe_url: str = "https://py.cafe"
     vizro_raw_url: str = "https://raw.githubusercontent.com/mckinsey/vizro"
-    package_version: str = vizro.__version__
-    vizro_ai_package_version: str = vizro_ai.__version__
+    package_version: str = "unknown"
+    vizro_ai_package_version: str = "unknown"
 
 
 def create_github_client(config: PyCafeConfig) -> tuple[Repository, Commit]:

--- a/tools/pycafe/pycafe_utils.py
+++ b/tools/pycafe/pycafe_utils.py
@@ -6,7 +6,7 @@ import json
 import re
 import textwrap
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Optional
 from urllib.parse import quote, urlencode
 
 import requests
@@ -23,7 +23,7 @@ def _extract_version(content: str) -> str:
     return "unknown"
 
 
-def fetch_package_versions(repo_name: str, commit_sha: str) -> Tuple[str, str]:
+def fetch_package_versions(repo_name: str, commit_sha: str) -> tuple[str, str]:
     """Fetch package versions directly from the repository files.
 
     This function retrieves the version strings from the __init__.py files of vizro and vizro-ai

--- a/tools/pycafe/test_pycafe_links.py
+++ b/tools/pycafe/test_pycafe_links.py
@@ -8,6 +8,7 @@ from pycafe_utils import (
     PyCafeConfig,
     create_github_client,
     create_status_check,
+    fetch_package_versions,
     generate_link,
 )
 
@@ -55,8 +56,20 @@ if __name__ == "__main__":
         commit_sha=args.commit_sha,
     )
 
+    # Fetch package versions directly and update config
+    try:
+        config.vizro_version, config.vizro_ai_version = fetch_package_versions(config.repo_name, config.commit_sha)
+    except Exception as e:
+        print(f"Error fetching versions: {e}")  # noqa
+        # Keep the default values if an error occurs
+
     # Initialize GitHub connection
     repo, commit = create_github_client(config)
+
+    # Print package versions from the repository at the current commit
+    print("Fetching package versions from repository...")  # noqa
+    print(f"Vizro version from repo: {config.vizro_version}")  # noqa
+    print(f"Vizro-AI version from repo: {config.vizro_ai_version}")  # noqa
 
     # Test dev example with latest version - we currently one test this for simplicity, but this could be changed
     # This would mean that we need to change also what the wait_for_text is

--- a/vizro-core/pyproject.toml
+++ b/vizro-core/pyproject.toml
@@ -37,7 +37,7 @@ requires-python = ">=3.9"
 
 [project.optional-dependencies]
 kedro = [
-  "kedro>=0.19.0,<1.0", # remove once we have tested the released Kedro 1.0
+  "kedro>=0.19.0,<1.0",  # remove once we have tested the released Kedro 1.0
   "kedro-datasets"  # no longer a dependency of kedro for kedro>=0.19.2
 ]
 

--- a/vizro-core/pyproject.toml
+++ b/vizro-core/pyproject.toml
@@ -37,7 +37,7 @@ requires-python = ">=3.9"
 
 [project.optional-dependencies]
 kedro = [
-  "kedro>=0.19.0",
+  "kedro>=0.19.0,<1.0", # remove once we have tested the released Kedro 1.0
   "kedro-datasets"  # no longer a dependency of kedro for kedro>=0.19.2
 ]
 

--- a/vizro-core/tests/unit/vizro/integrations/kedro/test_kedro_data_manager.py
+++ b/vizro-core/tests/unit/vizro/integrations/kedro/test_kedro_data_manager.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import kedro.pipeline as kp
 import pytest
 from kedro.config import OmegaConfigLoader
-from kedro.io import DataCatalog
 from packaging.version import parse
 
 from vizro.integrations.kedro import datasets_from_catalog
@@ -15,10 +14,15 @@ LEGACY_KEDRO = parse(version("kedro")) < parse("0.19.9")
 
 if not LEGACY_KEDRO:
     # KedroDataCatalog only exists and hence can only be tested against in kedro>=0.19.9.
+    # We could also still test against DataCatalog, but that would require filtering the deprecation warnings.
+    # Since there is no development expected on DataCatalog before deprecation, we might as well only test
+    # KedroDataCatalog
     from kedro.io import KedroDataCatalog
 
-    data_catalog_classes = [DataCatalog, KedroDataCatalog]
+    data_catalog_classes = [KedroDataCatalog]
 else:
+    from kedro.io import DataCatalog
+
     data_catalog_classes = [DataCatalog]
 
 


### PR DESCRIPTION
## Description
PyCafe CI testing would fail on release PRs due to a mismatch in versions. This should address this.

Sneaked in:
- remove test for `DataCatalog` in non-lower bound tests due to deprecation warnings. Still testing for it in lower bound. Since we don't expect developmnet on a deprecated feature this shoulld be ok

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
