### PR TITLE
[POC] Enable targeting header and footer inside figures with action

### DIFF
--- a/vizro-core/changelog.d/20250327_152240_huong_li_nguyen_add_ids_to_non_primary_traces.md
+++ b/vizro-core/changelog.d/20250327_152240_huong_li_nguyen_add_ids_to_non_primary_traces.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -1,27 +1,42 @@
 import vizro.models as vm
+import vizro.plotly.express as px
 from vizro import Vizro
+from vizro.models.types import capture
+from typing import Optional
+
+df = px.data.iris()
+
+
+@capture("action")
+def custom_action_obtiene_seleccion(points_data: Optional[dict] = None):
+    """Custom action."""
+    clicked_point = points_data["points"][0]
+    x = clicked_point["x"]
+    text = f"Clicked point has sepal length {x}"
+    return text, text
 
 
 page = vm.Page(
-    title="Text with extra argument",
+    title="Action with clickData as input",
     components=[
-        vm.Text(
-            text="""
-              This example uses the block delimiter:
-              $$
-              \\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}
-              $$
-
-              This example uses the inline delimiter:
-              $x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$
-            """,
-            extra={"mathjax": True},
+        vm.Graph(
+            id="scatter_chart",
+            title="Title",
+            footer="Footer",
+            header="Header",
+            figure=px.scatter(df, x="sepal_length", y="petal_width", color="species", custom_data=["species"]),
+            actions=[
+                vm.Action(
+                    function=custom_action_obtiene_seleccion(),
+                    inputs=["scatter_chart.clickData"],
+                    outputs=["my_card.children", "scatter_chart_header.children"],
+                ),
+            ],
         ),
+        vm.Card(id="my_card", text="Click on a point on the above graph."),
     ],
 )
-
 dashboard = vm.Dashboard(pages=[page])
-
 
 if __name__ == "__main__":
     Vizro().build(dashboard).run()

--- a/vizro-core/src/vizro/models/_components/ag_grid.py
+++ b/vizro-core/src/vizro/models/_components/ag_grid.py
@@ -133,7 +133,9 @@ class AgGrid(VizroBaseModel):
             children=html.Div(
                 children=[
                     html.H3(self.title, className="figure-title", id=f"{self.id}_title") if self.title else None,
-                    dcc.Markdown(self.header, className="figure-header") if self.header else None,
+                    dcc.Markdown(self.header, className="figure-header", id=f"{self.id}_header")
+                    if self.header
+                    else None,
                     # The Div component with `id=self._input_component_id` is rendered during the build phase.
                     # This placeholder component is quickly replaced by the actual AgGrid object, which is generated
                     # using a filtered data_frame and parameterized arguments as part of the on_page_load mechanism.
@@ -146,7 +148,9 @@ class AgGrid(VizroBaseModel):
                         children=[html.Div(id=self._input_component_id)],
                         className="table-container",
                     ),
-                    dcc.Markdown(self.footer, className="figure-footer") if self.footer else None,
+                    dcc.Markdown(self.footer, className="figure-footer", id=f"{self.id}_footer")
+                    if self.footer
+                    else None,
                 ],
                 className="figure-container",
             ),

--- a/vizro-core/src/vizro/models/_components/graph.py
+++ b/vizro-core/src/vizro/models/_components/graph.py
@@ -200,7 +200,9 @@ class Graph(VizroBaseModel):
             children=html.Div(
                 children=[
                     html.H3(self.title, className="figure-title", id=f"{self.id}_title") if self.title else None,
-                    dcc.Markdown(self.header, className="figure-header") if self.header else None,
+                    dcc.Markdown(self.header, className="figure-header", id=f"{self.id}_header")
+                    if self.header
+                    else None,
                     dcc.Graph(
                         id=self.id,
                         figure=go.Figure(
@@ -218,7 +220,9 @@ class Graph(VizroBaseModel):
                             "modeBarButtonsToRemove": ["toImage"],
                         },
                     ),
-                    dcc.Markdown(self.footer, className="figure-footer") if self.footer else None,
+                    dcc.Markdown(self.footer, className="figure-footer", id=f"{self.id}_footer")
+                    if self.footer
+                    else None,
                 ],
                 className="figure-container",
             ),

--- a/vizro-core/src/vizro/models/_components/table.py
+++ b/vizro-core/src/vizro/models/_components/table.py
@@ -131,7 +131,9 @@ class Table(VizroBaseModel):
             children=html.Div(
                 children=[
                     html.H3(self.title, className="figure-title", id=f"{self.id}_title") if self.title else None,
-                    dcc.Markdown(self.header, className="figure-header") if self.header else None,
+                    dcc.Markdown(self.header, className="figure-header", id=f"{self.id}_header")
+                    if self.header
+                    else None,
                     # Refer to the vm.AgGrid build method for details on why we return the
                     # html.Div(id=self._input_component_id) instead of actual figure object
                     # with the original data_frame.
@@ -140,7 +142,9 @@ class Table(VizroBaseModel):
                         children=[html.Div(id=self._input_component_id)],
                         className="table-container",
                     ),
-                    dcc.Markdown(self.footer, className="figure-footer") if self.footer else None,
+                    dcc.Markdown(self.footer, className="figure-footer", id=f"{self.id}_footer")
+                    if self.footer
+                    else None,
                 ],
                 className="figure-container",
             ),


### PR DESCRIPTION
## Description

- Provide `id` to `header` and `footer` of `Graph`, `Table` and `AgGrid` to be able to target via actions

## Screenshot

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
