### PR TITLE
[Fix] Add temporary upper bound on pydantic

### DIFF
--- a/vizro-ai/pyproject.toml
+++ b/vizro-ai/pyproject.toml
@@ -21,6 +21,8 @@ dependencies = [
   "langgraph>=0.1.2",
   "python-dotenv>=1.0.0",  # TODO decide env var management to see if we need this
   "vizro>=0.1.32",
+  # Temporary fix due to deprecations, can be removed after upgrading to latest vizro version where it is fixed.
+  "pydantic<2.11.0",
   "langchain_openai",  # Base dependency, ie minimum model working
   "black",
   "autoflake"

--- a/vizro-core/pyproject.toml
+++ b/vizro-core/pyproject.toml
@@ -20,7 +20,10 @@ dependencies = [
   "dash-ag-grid>=31.0.0",
   "pandas>=2",
   "plotly>=5.24.0",
-  "pydantic>=2.7.0",  # must be <= the version in pre-commit mypy hook, sync manually
+  # must be <= the version in pre-commit mypy hook, sync manually
+  # Hotfix currently sets upper bound on pydantic due to deprecations introduced in
+  # https://github.com/pydantic/pydantic/releases/tag/v2.11.0
+  "pydantic>=2.7.0,<2.11.0",
   "dash_mantine_components~=0.15.1",
   "flask_caching>=2",
   "wrapt>=1",


### PR DESCRIPTION
## Description
- main currently fails due to the latest release of pydantic v2.11.0 as they have deprecated several methods: https://github.com/pydantic/pydantic/releases/tag/v2.11.0
- Add temporary upper bound on pydantic for now (as otherwise lots of files need to change due to deprecated methods and currently potentially interfere with the actions V2 PR)

@maxschulz-COL - could you double-check the changes required to remove the upper bound and align with @antonymilne when to implement these such that it doesn't interfere with his PR?

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
