### PR TITLE
[Tidy] Unset height and width for Card inside Flex

### DIFF
--- a/vizro-core/changelog.d/20250405_130546_huong_li_nguyen_unset_card_heigth_width.md
+++ b/vizro-core/changelog.d/20250405_130546_huong_li_nguyen_unset_card_heigth_width.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -1,33 +1,77 @@
 """Scratchpad for testing."""
 
 import vizro.models as vm
-import vizro.plotly.express as px
 from vizro import Vizro
+import random
 
-tips = px.data.tips()
 
-page1 = vm.Page(
-    title="Default",
-    components=[
-        vm.Card(text="""# Good morning!"""),
-        vm.Graph(
-            title="Where do we get more tips?",
-            figure=px.bar(tips, y="tip", x="day"),
-        ),
-        vm.Graph(
-            title="Is the average driven by a few outliers?",
-            figure=px.violin(tips, y="tip", x="day", color="day", box=True),
-        ),
-        vm.Graph(
-            title="Which group size is more profitable?",
-            figure=px.density_heatmap(tips, x="day", y="size", z="tip", histfunc="avg", text_auto="$.2f"),
-        ),
-    ],
-    controls=[vm.Filter(column="day")],
+def generate_lorem_ipsum(length=None):
+    lorem_ipsum = """
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam sed elementum ligula, in pharetra velit.
+            In ultricies est ac mauris vehicula fermentum. Curabitur faucibus elementum lectus, vitae luctus libero fermentum.
+            Name ut ipsum tortor. Praesent ut nulla risus. Praesent in dignissim nulla. In quis blandit ipsum.
+        """
+    words = lorem_ipsum.split()
+    length = random.randint(100, 500) if length is None else length
+    while len(" ".join(words)) < length:
+        words += words  # repeat the words to extend the length
+    return " ".join(words)[:length]
+
+
+page3 = vm.Page(
+    title="Flex - default",
+    layout=vm.Flex(),
+    components=[vm.Card(text=generate_lorem_ipsum()) for i in range(6)],
 )
 
 
-dashboard = vm.Dashboard(pages=[page1])
+page4 = vm.Page(
+    title="Flex - gap",
+    layout=vm.Flex(gap="40px"),
+    components=[vm.Card(text=generate_lorem_ipsum()) for i in range(6)],
+)
+
+page5 = vm.Page(
+    title="Flex - row - unequal content",
+    layout=vm.Flex(direction="row"),
+    components=[vm.Card(text=generate_lorem_ipsum()) for i in range(6)],
+)
+
+page6 = vm.Page(
+    title="Flex - row/wrap - unequal content",
+    layout=vm.Flex(direction="row", wrap=True),
+    components=[vm.Card(text=generate_lorem_ipsum()) for i in range(6)],
+)
+
+page7 = vm.Page(
+    title="Flex - row - unequal content - same width",
+    layout=vm.Flex(direction="row"),
+    components=[vm.Card(text=generate_lorem_ipsum(), extra={"style": {"width": "200px"}}) for i in range(6)],
+)
+
+page8 = vm.Page(
+    title="Flex - row/wrap - unequal content - same width",
+    layout=vm.Flex(direction="row", wrap=True),
+    components=[vm.Card(text=generate_lorem_ipsum(), extra={"style": {"width": "200px"}}) for i in range(6)],
+)
+
+page9 = vm.Page(
+    title="Flex - row - equal content - no width",
+    layout=vm.Flex(direction="row"),
+    components=[vm.Card(text=generate_lorem_ipsum(300)) for i in range(6)],
+)
+
+page10 = vm.Page(
+    title="Flex - row/wrap - equal content - same width",
+    layout=vm.Flex(direction="row", wrap=True),
+    components=[vm.Card(text=generate_lorem_ipsum(300), extra={"style": {"width": "200px"}}) for i in range(6)],
+)
+
+
+dashboard = vm.Dashboard(
+    pages=[page3, page4, page5, page6, page7, page8, page9, page10],
+    title="Test out Card inside Flex",
+)
 
 if __name__ == "__main__":
     Vizro().build(dashboard).run()

--- a/vizro-core/src/vizro/static/css/flex.css
+++ b/vizro-core/src/vizro/static/css/flex.css
@@ -1,5 +1,5 @@
 /* To reset all heights coming from our parent containers otherwise there will be sizing issues */
-.flex-item, .flex-item .figure-container {
+.flex-item, .flex-item .figure-container, .flex-item .card {
   height: unset;
   width: unset;
 }
@@ -9,9 +9,4 @@ Specifications are taken from default height/width of Plotly charts. */
 .flex-item .table-container {
   height: 450px;
   width: 700px;
-}
-
-.flex-item .card {
-  height: unset;
-  width: unset;
 }

--- a/vizro-core/src/vizro/static/css/flex.css
+++ b/vizro-core/src/vizro/static/css/flex.css
@@ -10,3 +10,8 @@ Specifications are taken from default height/width of Plotly charts. */
   height: 450px;
   width: 700px;
 }
+
+.flex-item .card {
+  height: unset;
+  width: unset;
+}


### PR DESCRIPTION
## Description
- Follow up PR to Flex
- We also need to unset the height / width of `Card` inside the Flexbox. The Card previously had a height/width of 100% set to fill out any grid-space. Inside the Flex layout, it should just take on the size of its content.

@l0uden  - could you add another screenshot test that covers these cases (see scratch-dev):

```
page6 = vm.Page(
    title="Flex - row/wrap - unequal content - no width",
    layout=vm.Flex(direction="row", wrap=True),
    components=[vm.Card(text=generate_lorem_ipsum()) for i in range(6)],
)

page8 = vm.Page(
    title="Flex - row/wrap - unequal content - same width",
    layout=vm.Flex(direction="row", wrap=True),
    components=[vm.Card(text=generate_lorem_ipsum(), extra={"style": {"width": "200px"}}) for i in range(6)],
)
```


## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
