### PR TITLE
[Tidy] Remove old pytest ignores

### DIFF
--- a/vizro-ai/pyproject.toml
+++ b/vizro-ai/pyproject.toml
@@ -59,17 +59,12 @@ source_pkgs = ["vizro_ai"]
 [tool.pytest.ini_options]
 filterwarnings = [
   "error",
-  # Ignore until pandas is made compatible with Python 3.12:
-  "ignore:.*utcfromtimestamp:DeprecationWarning",
   # Ignore until pandas 3 is released:
   "ignore:(?s).*Pyarrow will become a required dependency of pandas:DeprecationWarning",
   # Ignore deprecation warning until this is solved: https://github.com/plotly/dash/issues/2590:
   "ignore:HTTPResponse.getheader():DeprecationWarning",
   # Happens during dash_duo teardown in vizro_ai_ui tests. Not affecting functionality:
   "ignore:Exception in thread",
-  # Ignore deprecation warning as it comes from the plotly default template. In our templates `vizro_dark` and
-  # `vizro_light`, we do not use mapbox anymore, see: https://github.com/mckinsey/vizro/pull/974
-  "ignore:.*scattermapbox.*is deprecated.*Use.*scattermap.*instead:DeprecationWarning",
   "ignore:CapturedCallable function is excluded from the schema"
 ]
 pythonpath = ["../tools/tests"]

--- a/vizro-core/pyproject.toml
+++ b/vizro-core/pyproject.toml
@@ -71,21 +71,12 @@ addopts = [
 ]
 filterwarnings = [
   "error",
-  # Ignore until pandas is made compatible with Python 3.12:
-  "ignore:.*utcfromtimestamp:DeprecationWarning",
   # Ignore until pandas 3 is released:
   "ignore:(?s).*Pyarrow will become a required dependency of pandas:DeprecationWarning",
-  # Ignore until plotly fixes so the warning is no longer raised:
-  "ignore:When grouping with a length-1 list-like, you will need to pass a length-1 tuple to get_group:FutureWarning",
   # Ignore warning when using the fig.layout.title inside examples:
   "ignore:Using the `title` argument in your Plotly chart function may cause misalignment:UserWarning",
-  # Ignore warning for Pydantic v1 API and Python 3.13:
-  "ignore:Failing to pass a value to the 'type_params' parameter of 'typing.ForwardRef._evaluate' is deprecated:DeprecationWarning",
   # Ignore deprecation warning until this is solved: https://github.com/plotly/dash/issues/2590:
   "ignore:HTTPResponse.getheader():DeprecationWarning",
-  # Ignore deprecation warning as it comes from the plotly default template. In our templates `vizro_dark` and
-  # `vizro_light`, we do not use mapbox anymore, see: https://github.com/mckinsey/vizro/pull/974
-  "ignore:.*scattermapbox.*is deprecated.*Use.*scattermap.*instead:DeprecationWarning",
   # ignore this warning for firefox screenshot tests
   "ignore:get_logs always return None with webdrivers other than Chrome"
 ]


### PR DESCRIPTION
## Description

Thanks to @emilykl for pointing out in #974 that we don't need to ignore some plotly warnings any more. I removed a few others that are no longer relevant too.

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
