### PR TITLE
[Tidy] Make `Container.title` optional

### DIFF
--- a/vizro-core/changelog.d/20250409_100011_huong_li_nguyen_make_container_title_optional.md
+++ b/vizro-core/changelog.d/20250409_100011_huong_li_nguyen_make_container_title_optional.md
@@ -25,7 +25,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Changed
 
-- Make `Container.title` mandatory only when used within Tabs.([#1](https://github.com/mckinsey/vizro/pull/1))
+- Make `Container.title` mandatory only when used within Tabs.([#1103](https://github.com/mckinsey/vizro/pull/1103))
 
 
 <!--

--- a/vizro-core/changelog.d/20250409_100011_huong_li_nguyen_make_container_title_optional.md
+++ b/vizro-core/changelog.d/20250409_100011_huong_li_nguyen_make_container_title_optional.md
@@ -25,7 +25,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Changed
 
-- Make `Container.title` mandatory only when used within Tabs.([#1103](https://github.com/mckinsey/vizro/pull/1103))
+- Make `Container.title` mandatory only when used within `Tabs`. ([#1103](https://github.com/mckinsey/vizro/pull/1103))
 
 
 <!--

--- a/vizro-core/changelog.d/20250409_100011_huong_li_nguyen_make_container_title_optional.md
+++ b/vizro-core/changelog.d/20250409_100011_huong_li_nguyen_make_container_title_optional.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+
+### Changed
+
+- Make `Container.title` mandatory only when used within Tabs.([#1](https://github.com/mckinsey/vizro/pull/1))
+
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/docs/pages/user-guides/container.md
+++ b/vizro-core/docs/pages/user-guides/container.md
@@ -32,8 +32,8 @@ Here are a few cases where you might want to use a `Container` instead of `Page.
 To add a [`Container`][vizro.models.Container] to your page, do the following:
 
 1. Insert the `Container` into the `components` argument of the [`Page`][vizro.models.Page]
-1. Set a `title` for your `Container`
 1. Configure your `components`, [read the overview page for various options](components.md)
+1. (optional) Set a `title` for your `Container`
 1. (optional) Configure your `layout`, see [the guide on layouts](layouts.md)
 
 !!! example "Container"

--- a/vizro-core/docs/pages/user-guides/tabs.md
+++ b/vizro-core/docs/pages/user-guides/tabs.md
@@ -22,6 +22,7 @@ To add [`Tabs`][vizro.models.Tabs] to your page, do the following:
 
 1. Insert the [`Tabs`][vizro.models.Tabs] into the `components` argument of the [`Page`][vizro.models.Page]
 1. Insert your [`Containers`][vizro.models.Container] into the `tabs` argument of the [`Tabs`][vizro.models.Tabs]
+1. Add a `title` to the `Container`, which will be used as the `label` for the corresponding `Tab`.
 
 !!! example "Tabs"
     === "app.py"

--- a/vizro-core/schemas/0.1.37.dev0.json
+++ b/vizro-core/schemas/0.1.37.dev0.json
@@ -316,7 +316,7 @@
     },
     "Container": {
       "additionalProperties": false,
-      "description": "Container to group together a set of components on a page.\n\nArgs:\n    type (Literal[\"container\"]): Defaults to `\"container\"`.\n    components (list[ComponentType]): See [ComponentType][vizro.models.types.ComponentType]. At least one component\n        has to be provided.\n    title (str): Title to be displayed.\n    layout (Optional[LayoutType]): Layout to place components in. Defaults to `None`.\n    variant (Literal[\"plain\", \"filled\", \"outlined\"]): Predefined styles to choose from. Options are `plain`,\n        `filled` or `outlined`. Defaults to `plain`.\n    extra (Optional[dict[str, Any]]): Extra keyword arguments that are passed to `dbc.Container` and overwrite any\n        defaults chosen by the Vizro team. This may have unexpected behavior.\n        Visit the [dbc documentation](https://dash-bootstrap-components.opensource.faculty.ai/docs/components/layout/)\n        to see all available arguments. [Not part of the official Vizro schema](../explanation/schema.md) and the\n        underlying component may change in the future. Defaults to `{}`.",
+      "description": "Container to group together a set of components on a page.\n\nArgs:\n    type (Literal[\"container\"]): Defaults to `\"container\"`.\n    components (list[ComponentType]): See [ComponentType][vizro.models.types.ComponentType]. At least one component\n        has to be provided.\n    title (str): Title of the `Container`. Defaults to `\"\"`.\n    layout (Optional[LayoutType]): Layout to place components in. Defaults to `None`.\n    variant (Literal[\"plain\", \"filled\", \"outlined\"]): Predefined styles to choose from. Options are `plain`,\n        `filled` or `outlined`. Defaults to `plain`.\n    extra (Optional[dict[str, Any]]): Extra keyword arguments that are passed to `dbc.Container` and overwrite any\n        defaults chosen by the Vizro team. This may have unexpected behavior.\n        Visit the [dbc documentation](https://dash-bootstrap-components.opensource.faculty.ai/docs/components/layout/)\n        to see all available arguments. [Not part of the official Vizro schema](../explanation/schema.md) and the\n        underlying component may change in the future. Defaults to `{}`.",
       "properties": {
         "id": {
           "default": "",
@@ -382,7 +382,8 @@
           "type": "array"
         },
         "title": {
-          "description": "Title to be displayed.",
+          "default": "",
+          "description": "Title of the `Container`",
           "title": "Title",
           "type": "string"
         },
@@ -417,7 +418,7 @@
           "type": "string"
         }
       },
-      "required": ["components", "title"],
+      "required": ["components"],
       "title": "Container",
       "type": "object"
     },
@@ -1120,7 +1121,7 @@
     },
     "Page": {
       "additionalProperties": false,
-      "description": "A page in [`Dashboard`][vizro.models.Dashboard] with its own URL path and place in the `Navigation`.\n\nArgs:\n    components (list[ComponentType]): See [ComponentType][vizro.models.types.ComponentType]. At least one component\n        has to be provided.\n    title (str): Title to be displayed.\n    description (str): Description for meta tags.\n    layout (Optional[LayoutType]): Layout to place components in. Defaults to `None`.\n    controls (list[ControlType]): See [ControlType][vizro.models.types.ControlType]. Defaults to `[]`.\n    path (str): Path to navigate to page. Defaults to `\"\"`.",
+      "description": "A page in [`Dashboard`][vizro.models.Dashboard] with its own URL path and place in the `Navigation`.\n\nArgs:\n    components (list[ComponentType]): See [ComponentType][vizro.models.types.ComponentType]. At least one component\n        has to be provided.\n    title (str): Title of the `Page`.\n    description (str): Description for meta tags.\n    layout (Optional[LayoutType]): Layout to place components in. Defaults to `None`.\n    controls (list[ControlType]): See [ControlType][vizro.models.types.ControlType]. Defaults to `[]`.\n    path (str): Path to navigate to page. Defaults to `\"\"`.",
       "properties": {
         "id": {
           "default": "",
@@ -1180,7 +1181,7 @@
           "type": "array"
         },
         "title": {
-          "description": "Title to be displayed.",
+          "description": "Title of the `Page`",
           "title": "Title",
           "type": "string"
         },

--- a/vizro-core/src/vizro/models/_components/container.py
+++ b/vizro-core/src/vizro/models/_components/container.py
@@ -20,7 +20,7 @@ class Container(VizroBaseModel):
         type (Literal["container"]): Defaults to `"container"`.
         components (list[ComponentType]): See [ComponentType][vizro.models.types.ComponentType]. At least one component
             has to be provided.
-        title (str): Title to be displayed.
+        title (str): Title of the `Container`. Defaults to `""`.
         layout (Optional[LayoutType]): Layout to place components in. Defaults to `None`.
         variant (Literal["plain", "filled", "outlined"]): Predefined styles to choose from. Options are `plain`,
             `filled` or `outlined`. Defaults to `plain`.
@@ -39,7 +39,7 @@ class Container(VizroBaseModel):
         Annotated[ComponentType, BeforeValidator(check_captured_callable_model)],
         min_length=1,
     )
-    title: str = Field(description="Title to be displayed.")
+    title: str = Field(default="", description="Title of the `Container`")
     layout: Annotated[Optional[LayoutType], AfterValidator(set_layout), Field(default=None, validate_default=True)]
     variant: Literal["plain", "filled", "outlined"] = Field(
         default="plain",
@@ -78,7 +78,9 @@ class Container(VizroBaseModel):
         defaults = {
             "id": self.id,
             "children": [
-                html.H3(children=self.title, className="container-title", id=f"{self.id}_title"),
+                html.H3(children=self.title, className="container-title", id=f"{self.id}_title")
+                if self.title
+                else None,
                 _build_inner_layout(self.layout, self.components),
             ],
             "fluid": True,

--- a/vizro-core/src/vizro/models/_components/tabs.py
+++ b/vizro-core/src/vizro/models/_components/tabs.py
@@ -1,15 +1,21 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Annotated, Literal
 
 import dash_bootstrap_components as dbc
-from pydantic import conlist, field_validator
+from pydantic import AfterValidator, conlist
 
 from vizro.models import VizroBaseModel
 from vizro.models._models_utils import _log_call
 
 if TYPE_CHECKING:
     from vizro.models._components import Container
+
+
+def validate_tab_has_title(tab: Container) -> Container:
+    if not tab.title:
+        raise ValueError("`Container` must have a `title` explicitly set when used inside `Tabs`.")
+    return tab
 
 
 class Tabs(VizroBaseModel):
@@ -23,13 +29,7 @@ class Tabs(VizroBaseModel):
 
     type: Literal["tabs"] = "tabs"
     # TODO[mypy], see: https://github.com/pydantic/pydantic/issues/156 for tabs field
-    tabs: conlist(Container, min_length=1)  # type: ignore[valid-type]
-
-    @field_validator("tabs")
-    def validate_tabs_have_titles(cls, tabs: list[Container]) -> list[Container]:
-        if any(tab.title == "" for tab in tabs):
-            raise ValueError("Each `Container` in `tabs` requires a `title` provided.")
-        return tabs
+    tabs: conlist(Annotated[Container, AfterValidator(validate_tab_has_title)], min_length=1)  # type: ignore[valid-type]
 
     @_log_call
     def build(self):

--- a/vizro-core/src/vizro/models/_components/tabs.py
+++ b/vizro-core/src/vizro/models/_components/tabs.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Literal
 
 import dash_bootstrap_components as dbc
-from pydantic import conlist
+from pydantic import conlist, field_validator
 
 from vizro.models import VizroBaseModel
 from vizro.models._models_utils import _log_call
@@ -24,6 +24,12 @@ class Tabs(VizroBaseModel):
     type: Literal["tabs"] = "tabs"
     # TODO[mypy], see: https://github.com/pydantic/pydantic/issues/156 for tabs field
     tabs: conlist(Container, min_length=1)  # type: ignore[valid-type]
+
+    @field_validator("tabs")
+    def validate_tabs_have_titles(cls, tabs: list[Container]) -> list[Container]:
+        if any(tab.title == "" for tab in tabs):
+            raise ValueError("Each `Container` in `tabs` requires a `title` provided.")
+        return tabs
 
     @_log_call
     def build(self):

--- a/vizro-core/src/vizro/models/_page.py
+++ b/vizro-core/src/vizro/models/_page.py
@@ -54,7 +54,7 @@ class Page(VizroBaseModel):
     Args:
         components (list[ComponentType]): See [ComponentType][vizro.models.types.ComponentType]. At least one component
             has to be provided.
-        title (str): Title to be displayed.
+        title (str): Title of the `Page`.
         description (str): Description for meta tags.
         layout (Optional[LayoutType]): Layout to place components in. Defaults to `None`.
         controls (list[ControlType]): See [ControlType][vizro.models.types.ControlType]. Defaults to `[]`.
@@ -64,7 +64,7 @@ class Page(VizroBaseModel):
 
     # TODO[mypy], see: https://github.com/pydantic/pydantic/issues/156 for components field
     components: conlist(Annotated[ComponentType, BeforeValidator(check_captured_callable_model)], min_length=1)  # type: ignore[valid-type]
-    title: str = Field(description="Title to be displayed.")
+    title: str = Field(description="Title of the `Page`")
     description: str = Field(default="", description="Description for meta tags.")
     layout: Annotated[Optional[LayoutType], AfterValidator(set_layout), Field(default=None, validate_default=True)]
     controls: list[ControlType] = []

--- a/vizro-core/tests/unit/vizro/models/_components/test_container.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_container.py
@@ -13,10 +13,10 @@ class TestContainerInstantiation:
     """Tests model instantiation and the validators run at that time."""
 
     def test_create_container_mandatory_only(self):
-        container = vm.Container(title="Title", components=[vm.Button(), vm.Button()])
+        container = vm.Container(components=[vm.Button(), vm.Button()])
         assert isinstance(container.components[0], vm.Button) and isinstance(container.components[1], vm.Button)
         assert container.layout.grid == [[0], [1]]
-        assert container.title == "Title"
+        assert container.title == ""
         assert container.variant == "plain"
 
     @pytest.mark.parametrize("variant", ["plain", "filled", "outlined"])
@@ -61,7 +61,16 @@ class TestContainerInstantiation:
 
 
 class TestContainerBuildMethod:
-    def test_container_build(self):
+    def test_container_build_without_title(self):
+        result = vm.Container(
+            id="container", components=[vm.Button()], layout=vm.Grid(id="layout_id", grid=[[0]])
+        ).build()
+        assert_component_equal(
+            result, dbc.Container(id="container", class_name="", fluid=True), keys_to_strip={"children"}
+        )
+        assert_component_equal(result.children, [None, html.Div()], keys_to_strip=STRIP_ALL)
+
+    def test_container_build_with_title(self):
         result = vm.Container(
             id="container", title="Title", components=[vm.Button()], layout=vm.Grid(id="layout_id", grid=[[0]])
         ).build()
@@ -71,8 +80,6 @@ class TestContainerBuildMethod:
         assert_component_equal(result.children, [html.H3(), html.Div()], keys_to_strip=STRIP_ALL)
         # We still want to test the exact H3 produced in Container.build:
         assert_component_equal(result.children[0], html.H3("Title", className="container-title", id="container_title"))
-        # And also that a button has been inserted in the right place:
-        assert_component_equal(result["layout_id_0"].children, dbc.Button(), keys_to_strip=STRIP_ALL)
 
     def test_container_build_legacy_layout(self):
         with pytest.warns(FutureWarning, match="The `Layout` model has been renamed `Grid`"):

--- a/vizro-core/tests/unit/vizro/models/_components/test_container.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_container.py
@@ -47,10 +47,6 @@ class TestContainerInstantiation:
         assert container.layout.grid == [[0, 1]]
         assert container.title == "Title"
 
-    def test_mandatory_title_missing(self):
-        with pytest.raises(ValidationError, match="Field required"):
-            vm.Container(components=[vm.Button()])
-
     def test_mandatory_components_missing(self):
         with pytest.raises(ValidationError, match="Field required"):
             vm.Container(title="Title")

--- a/vizro-core/tests/unit/vizro/models/_components/test_tabs.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_tabs.py
@@ -27,7 +27,19 @@ class TestTabsInstantiation:
 
     def test_mandatory_tabs_missing(self):
         with pytest.raises(ValidationError, match="Field required"):
-            vm.Tabs(id="tabs-id")
+            vm.Tabs()
+
+    def test_minimum_tabs_length(self):
+        with pytest.raises(ValidationError, match="List should have at least 1 item after validation."):
+            vm.Tabs(tabs=[])
+
+    def test_incorrect_tabs_type(self):
+        with pytest.raises(ValidationError, match="Input should be a valid dictionary or instance of Container."):
+            vm.Tabs(tabs=[vm.Button()])
+
+    def test_missing_container_title(self):
+        with pytest.raises(ValidationError, match="Each `Container` in `tabs` requires a `title` provided."):
+            vm.Tabs(tabs=[vm.Container(components=[vm.Button()])])
 
 
 class TestTabsBuildMethod:

--- a/vizro-core/tests/unit/vizro/models/_components/test_tabs.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_tabs.py
@@ -37,8 +37,10 @@ class TestTabsInstantiation:
         with pytest.raises(ValidationError, match="Input should be a valid dictionary or instance of Container."):
             vm.Tabs(tabs=[vm.Button()])
 
-    def test_missing_container_title(self):
-        with pytest.raises(ValidationError, match="Each `Container` in `tabs` requires a `title` provided."):
+    def test_tab_has_title(self):
+        with pytest.raises(
+            ValidationError, match="`Container` must have a `title` explicitly set when used inside `Tabs`."
+        ):
             vm.Tabs(tabs=[vm.Container(components=[vm.Button()])])
 
 


### PR DESCRIPTION
## Description

- Make `Container.title `optional by default.  
- Enforce` Container.title` as mandatory via a validator only when the `Container` is used within `Tabs`.

**Context:**
Previously, `Container.title` was required in all cases, similar to `Page.title.` However, unlike Page, `Container.title` is not necessary for the `path` generation. Instead, it should be optional, aligning with components like `Graph`, `Table`, and `AgGrid`, where a title is not displayed unless provided.  

With the introduction of the `Flex` layout, having to always provide a `Container.title` has become a bit of a hassle, especially since it often needs to be hidden with CSS when creating sections without titles. By making `Container.title` optional, we make things more flexible while still ensuring it's required when used in Tabs, where a title is actually needed.


## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
