### PR TITLE
[Docs] Hide side navigation on index page

### DIFF
--- a/vizro-core/docs/javascripts/extra.js
+++ b/vizro-core/docs/javascripts/extra.js
@@ -1,0 +1,10 @@
+document.addEventListener("DOMContentLoaded", function () {
+  const isHomepage = document.title.trim() === "Vizro";
+
+  if (isHomepage) {
+    const sidebar = document.querySelector(".md-sidebar--primary");
+    if (sidebar) {
+      sidebar.style.display = "none";
+    }
+  }
+});

--- a/vizro-core/docs/stylesheets/extra.css
+++ b/vizro-core/docs/stylesheets/extra.css
@@ -64,6 +64,6 @@ td:not([class]):not(:last-child) {
 }
 
 
-.md-sidebar .md-sidebar--primary {
-  width: 20%;
+.md-sidebar--primary {
+  width: 13rem;
 }

--- a/vizro-core/docs/stylesheets/extra.css
+++ b/vizro-core/docs/stylesheets/extra.css
@@ -62,3 +62,8 @@ td:not([class]):not(:last-child) {
   background-color: rgb(3, 3, 3);
   mask-image: var(--md-admonition-icon--details);
 }
+
+
+.md-sidebar .md-sidebar--primary {
+  width: 20%;
+}

--- a/vizro-core/docs/stylesheets/extra.css
+++ b/vizro-core/docs/stylesheets/extra.css
@@ -62,8 +62,3 @@ td:not([class]):not(:last-child) {
   background-color: rgb(3, 3, 3);
   mask-image: var(--md-admonition-icon--details);
 }
-
-
-.md-sidebar--primary {
-  width: 13rem;
-}

--- a/vizro-core/mkdocs.yml
+++ b/vizro-core/mkdocs.yml
@@ -158,6 +158,8 @@ extra:
       content: "CYb3cxosCgsN2QDQVaSGQpMQCesqpsGQ3oTM02NtvkY"
 extra_css:
   - stylesheets/extra.css
+extra_javascript:
+  - javascripts/extra.js
 
 # Strictest settings possible, and will be elevated to ERROR when run with --strict.
 # See https://www.mkdocs.org/user-guide/configuration/#validation.


### PR DESCRIPTION
## Description

- Hide side navigation on index page (we don't need it as there is only one item) to save space

**After**

![Screenshot 2025-05-20 at 15 34 21](https://github.com/user-attachments/assets/591ef108-884a-4ca8-9f69-791c1a14accd)

**Before**
![Screenshot 2025-05-20 at 15 34 36](https://github.com/user-attachments/assets/6d71965a-d4e5-4df2-9370-c750375e8a8d)




## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
