### PR TITLE
[Docs] Add information note to Vizro-AI docs

### DIFF
--- a/vizro-ai/docs/index.md
+++ b/vizro-ai/docs/index.md
@@ -1,8 +1,14 @@
 # Vizro-AI
 
+!!! info "Vizro-AI has been replaced by Vizro-MCP"
+
+    Vizro-AI has mostly been superceded by [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md), which offers a unified experience within familiar LLM apps, such as Claude Desktop. 
+    
+    **We suggest you review [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md) before you try Vizro-AI as it is more straightforward and does not require an API key.**
+
 Vizro-AI uses generative AI to extend [Vizro](https://vizro.readthedocs.io) so you can use instructions in English, or other languages, to effortlessly create interactive charts and dashboards.
 
-By using Vizro's themes, you can incorporate design best practices by default. If you're new to coding, Vizro-AI simplifies both the creation of charts with [Plotly](https://plotly.com/python/) and their layout upon an interactive and easily-distributed dashboard.
+If you're new to coding, Vizro-AI simplifies both the creation of charts with [Plotly](https://plotly.com/python/) and their layout upon an interactive and easily-distributed dashboard.
 
 Even if you are an experienced data practitioner, Vizro-AI optimizes how you create visually appealing layouts to present detailed insights about your data.
 

--- a/vizro-ai/docs/index.md
+++ b/vizro-ai/docs/index.md
@@ -2,10 +2,9 @@
 
 !!! warning "Vizro-AI has been replaced by Vizro-MCP"
 
-    Vizro-AI has largely been replaced by [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md) and only supports chart generation from version 0.4.0. 
-    
-    **For chart and dashboard generation, we recommend using [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md). It doesn’t require an API key and works with familiar LLM applications like Claude Desktop, making it simpler to use.**   
-    
+    Vizro-AI has largely been replaced by [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md) and only supports chart generation from version 0.4.0.
+
+    **For chart and dashboard generation, we recommend using [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md). It doesn’t require an API key and works with familiar LLM applications like Claude Desktop, making it simpler to use.**
 
 Vizro-AI uses generative AI to extend [Vizro](https://vizro.readthedocs.io) so you can use instructions in English, or other languages, to effortlessly create interactive charts and dashboards.
 

--- a/vizro-ai/docs/index.md
+++ b/vizro-ai/docs/index.md
@@ -2,8 +2,8 @@
 
 !!! info "Vizro-AI has been replaced by Vizro-MCP"
 
-    Vizro-AI has mostly been superceded by [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md), which offers a unified experience within familiar LLM apps, such as Claude Desktop. 
-    
+    Vizro-AI has mostly been superceded by [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md), which offers a unified experience within familiar LLM apps, such as Claude Desktop.
+
     **We suggest you review [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md) before you try Vizro-AI as it is more straightforward and does not require an API key.**
 
 Vizro-AI uses generative AI to extend [Vizro](https://vizro.readthedocs.io) so you can use instructions in English, or other languages, to effortlessly create interactive charts and dashboards.

--- a/vizro-ai/docs/index.md
+++ b/vizro-ai/docs/index.md
@@ -1,10 +1,11 @@
 # Vizro-AI
 
-!!! info "Vizro-AI has been replaced by Vizro-MCP"
+!!! warning "Vizro-AI has been replaced by Vizro-MCP"
 
-    Vizro-AI has mostly been superceded by [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md), which offers a unified experience within familiar LLM apps, such as Claude Desktop.
-
-    **We suggest you review [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md) before you try Vizro-AI as it is more straightforward and does not require an API key.**
+    Vizro-AI has largely been replaced by [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md) and only supports chart generation from version 0.4.0. 
+    
+    **For chart and dashboard generation, we recommend using [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md). It doesn’t require an API key and works with familiar LLM applications like Claude Desktop, making it simpler to use.**   
+    
 
 Vizro-AI uses generative AI to extend [Vizro](https://vizro.readthedocs.io) so you can use instructions in English, or other languages, to effortlessly create interactive charts and dashboards.
 

--- a/vizro-ai/docs/pages/explanation/faq.md
+++ b/vizro-ai/docs/pages/explanation/faq.md
@@ -1,5 +1,11 @@
 # Frequently asked questions
 
+## Should I use Vizro-AI or Vizro-MCP?
+
+Vizro-AI has largely been replaced by [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md) and only supports chart generation from version 0.4.0. 
+    
+For chart and dashboard generation, we recommend using [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md). It doesn’t require an API key and works with familiar LLM applications like Claude Desktop, making it simpler to use.   
+
 ## Who works on Vizro-AI?
 
 ### Current team members

--- a/vizro-ai/docs/pages/explanation/faq.md
+++ b/vizro-ai/docs/pages/explanation/faq.md
@@ -2,9 +2,9 @@
 
 ## Should I use Vizro-AI or Vizro-MCP?
 
-Vizro-AI has largely been replaced by [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md) and only supports chart generation from version 0.4.0. 
-    
-For chart and dashboard generation, we recommend using [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md). It doesn’t require an API key and works with familiar LLM applications like Claude Desktop, making it simpler to use.   
+Vizro-AI has largely been replaced by [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md) and only supports chart generation from version 0.4.0.
+
+For chart and dashboard generation, we recommend using [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md). It doesn’t require an API key and works with familiar LLM applications like Claude Desktop, making it simpler to use.
 
 ## Who works on Vizro-AI?
 

--- a/vizro-ai/docs/pages/tutorials/quickstart-dashboard.md
+++ b/vizro-ai/docs/pages/tutorials/quickstart-dashboard.md
@@ -1,5 +1,9 @@
 # Dashboard generation
 
+!!! warning "Vizro-AI has been replaced by Vizro-MCP"
+
+    Vizro-AI has largely been replaced by [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md) and only supports chart generation from version 0.4.0. 
+
 In the previous tutorial, we explained how to use Vizro-AI to generate individual charts from text. Vizro-AI also supports text-to-dashboard functionality, enabling you to generate a complete [Vizro](https://vizro.readthedocs.io/en/stable/) dashboard containing multiple charts and pages.
 
 You may also want to review the [Vizro dashboard tutorial](https://vizro.readthedocs.io/en/stable/pages/tutorials/first-dashboard/), which creates a dashboard from scratch rather than by generation with Vizro-AI.

--- a/vizro-ai/docs/pages/tutorials/quickstart-dashboard.md
+++ b/vizro-ai/docs/pages/tutorials/quickstart-dashboard.md
@@ -2,7 +2,7 @@
 
 !!! warning "Vizro-AI has been replaced by Vizro-MCP"
 
-    Vizro-AI has largely been replaced by [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md) and only supports chart generation from version 0.4.0. 
+    Vizro-AI has largely been replaced by [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md) and only supports chart generation from version 0.4.0.
 
 In the previous tutorial, we explained how to use Vizro-AI to generate individual charts from text. Vizro-AI also supports text-to-dashboard functionality, enabling you to generate a complete [Vizro](https://vizro.readthedocs.io/en/stable/) dashboard containing multiple charts and pages.
 

--- a/vizro-ai/docs/pages/user-guides/create-complex-dashboard.md
+++ b/vizro-ai/docs/pages/user-guides/create-complex-dashboard.md
@@ -1,5 +1,9 @@
 # Generate a complex dashboard
 
+!!! warning "Vizro-AI has been replaced by Vizro-MCP"
+
+    Vizro-AI has largely been replaced by [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md) and only supports chart generation from version 0.4.0. 
+
 This guide shows you how to instruct Vizro-AI to create a complex dashboard.
 
 In general, Vizro-AI can follow user requirements well and generate high-quality dashboards, but the nature of LLMs means that the output generated at first is not always an exact match for your expectations. When the text length of user requirements increases, the LLMs can start to miss part of the user requirements or make mistakes. Apart from choosing more advanced models for harder tasks, improving the user prompt can help too.

--- a/vizro-ai/docs/pages/user-guides/create-complex-dashboard.md
+++ b/vizro-ai/docs/pages/user-guides/create-complex-dashboard.md
@@ -2,7 +2,7 @@
 
 !!! warning "Vizro-AI has been replaced by Vizro-MCP"
 
-    Vizro-AI has largely been replaced by [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md) and only supports chart generation from version 0.4.0. 
+    Vizro-AI has largely been replaced by [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md) and only supports chart generation from version 0.4.0.
 
 This guide shows you how to instruct Vizro-AI to create a complex dashboard.
 

--- a/vizro-ai/docs/pages/user-guides/run-vizro-ai-dashboard.md
+++ b/vizro-ai/docs/pages/user-guides/run-vizro-ai-dashboard.md
@@ -2,7 +2,7 @@
 
 !!! warning "Vizro-AI has been replaced by Vizro-MCP"
 
-    Vizro-AI has largely been replaced by [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md) and only supports chart generation from version 0.4.0. 
+    Vizro-AI has largely been replaced by [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md) and only supports chart generation from version 0.4.0.
 
 This guide offers insights into different ways of running `VizroAI.dashboard` to generate a Vizro dashboards from natural language prompts.
 

--- a/vizro-ai/docs/pages/user-guides/run-vizro-ai-dashboard.md
+++ b/vizro-ai/docs/pages/user-guides/run-vizro-ai-dashboard.md
@@ -1,5 +1,9 @@
 # How to run Vizro-AI dashboard
 
+!!! warning "Vizro-AI has been replaced by Vizro-MCP"
+
+    Vizro-AI has largely been replaced by [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md) and only supports chart generation from version 0.4.0. 
+
 This guide offers insights into different ways of running `VizroAI.dashboard` to generate a Vizro dashboards from natural language prompts.
 
 ??? note "Note: API key"

--- a/vizro-ai/mkdocs.yml
+++ b/vizro-ai/mkdocs.yml
@@ -16,10 +16,10 @@ nav:
           - Advanced options: pages/user-guides/advanced-options.md
           - Advanced charts: pages/user-guides/create-advanced-charts.md
           - Add Vizro-AI charts to a Vizro dashboard: pages/user-guides/add-generated-chart-usecase.md
+          - Use Vizro-AI methods as Langchain tools: pages/user-guides/vizro-ai-langchain-guide.md
       - DASHBOARDS:
           - Run vizro_ai.dashboard: pages/user-guides/run-vizro-ai-dashboard.md
           - Advanced dashboards: pages/user-guides/create-complex-dashboard.md
-          - Use Vizro-AI methods as Langchain tools: pages/user-guides/vizro-ai-langchain-guide.md
   - API Reference:
       - VizroAI: pages/API-reference/vizro-ai.md
   - Explanation:


### PR DESCRIPTION
## Description

I propose to add this to the front page of Vizro-AI. (Edited to change it slightly based on @lingyielia's advice)

<img width="737" alt="image" src="https://github.com/user-attachments/assets/4a54f12a-6d84-4e86-8fec-d78cf6856770" />

---

I have also added a slightly shorter note to every dashboard page of Vizro-AI docs, so readers hitting them see it, in case they don't enter via the front page. It says this:

> Vizro-AI has largely been replaced by [Vizro-MCP](https://github.com/mckinsey/vizro/blob/main/vizro-mcp/README.md) and only supports chart generation from version 0.4.0.



---

Thoughts? @lingyielia ? @maxschulz-COL ? @antonymilne ?



## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
