### PR TITLE
[Bugfix] Fixed dropdown height calculation in containers dropdown

### DIFF
--- a/vizro-core/changelog.d/20250612_095418_nadija_ratkusic_graca_dropdown_height_in_containers.md
+++ b/vizro-core/changelog.d/20250612_095418_nadija_ratkusic_graca_dropdown_height_in_containers.md
@@ -37,7 +37,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Fixed
 
-- Fixed dropdown height calculation in container controls. ([#1238](https://github.com/mckinsey/vizro/pull/1238))
+- Fix dynamically calculated row height for `Dropdown` when it's used within a container. ([#1238](https://github.com/mckinsey/vizro/pull/1238))
 
 
 <!--

--- a/vizro-core/changelog.d/20250612_095418_nadija_ratkusic_graca_dropdown_height_in_containers.md
+++ b/vizro-core/changelog.d/20250612_095418_nadija_ratkusic_graca_dropdown_height_in_containers.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+
+### Fixed
+
+- Fixed dropdown height calculation in container controls. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/changelog.d/20250612_095418_nadija_ratkusic_graca_dropdown_height_in_containers.md
+++ b/vizro-core/changelog.d/20250612_095418_nadija_ratkusic_graca_dropdown_height_in_containers.md
@@ -37,7 +37,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Fixed
 
-- Fixed dropdown height calculation in container controls. ([#1](https://github.com/mckinsey/vizro/pull/1))
+- Fixed dropdown height calculation in container controls. ([#1238](https://github.com/mckinsey/vizro/pull/1238))
 
 
 <!--

--- a/vizro-core/changelog.d/20250612_095418_nadija_ratkusic_graca_dropdown_height_in_containers.md
+++ b/vizro-core/changelog.d/20250612_095418_nadija_ratkusic_graca_dropdown_height_in_containers.md
@@ -37,7 +37,7 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 
 ### Fixed
 
-- Fix dynamically calculated row height for `Dropdown` when it's used within a container. ([#1238](https://github.com/mckinsey/vizro/pull/1238))
+- Fix dynamically calculated row height for `Dropdown` when it's used within `Container.controls`. ([#1238](https://github.com/mckinsey/vizro/pull/1238))
 
 
 <!--

--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -1,70 +1,48 @@
 from vizro import Vizro
 import vizro.plotly.express as px
 import vizro.models as vm
+import pandas as pd
+from vizro.tables import dash_ag_grid
 
 gapminder_2007 = px.data.gapminder().query("year == 2007")
 
+# Create a list of fake long words
+long_words = [
+    "Client Discussion",
+    "Client Discussion Engagement",
+    "Completed Engagement",
+    "Confirmed Engagement in Progress",
+    "Inactive/on hold",
+]
+
+# Create the DataFrame
+df = pd.DataFrame({"id": range(1, 6), "category": ["A", "B", "A", "C", "B"], "long_words": long_words})
+
+
 page_1 = vm.Page(
-    title="Page with button",
-    layout=vm.Grid(grid=[[0, 1, 2, 3, 4], [5, 5, 5, 5, 5], [5, 5, 5, 5, 5]]),
+    title="Test page",
     components=[
         vm.Container(
-            title="Plain button",
-            components=[
-                vm.Button(text="Click me!", description=vm.Tooltip(text="Button tooltip", icon="info"), variant="plain")
-            ],
+            components=[vm.AgGrid(figure=dash_ag_grid(df))],
             variant="outlined",
-        ),
-        vm.Container(
-            title="Filled button",
-            components=[vm.Button(text="Click me!", description=vm.Tooltip(text="Button tooltip", icon="info"))],
-            variant="outlined",
-        ),
-        vm.Container(
-            title="Outlined button",
-            components=[
-                vm.Button(
-                    text="Click me!", description=vm.Tooltip(text="Button tooltip", icon="info"), variant="outlined"
-                )
-            ],
-            variant="outlined",
-        ),
-        vm.Container(
-            title="Button with extra success",
-            components=[
-                vm.Button(
-                    text="Click me!",
-                    description=vm.Tooltip(text="Button tooltip", icon="info"),
-                    extra={"color": "success", "outline": True},
-                )
-            ],
-            variant="outlined",
-        ),
-        vm.Container(
-            title="Button with extra danger",
-            components=[
-                vm.Button(
-                    text="Click me!",
-                    description=vm.Tooltip(text="Button tooltip", icon="info"),
-                    extra={"color": "danger", "outline": True},
-                )
-            ],
-            variant="outlined",
-        ),
-        vm.Container(
-            title="Graph",
-            components=[
-                vm.Graph(
-                    title="Graph 1",
-                    figure=px.bar(
-                        gapminder_2007,
-                        x="continent",
-                        y="lifeExp",
-                        color="continent",
+            controls=[
+                vm.Filter(column="long_words"),
+                vm.Filter(
+                    column="category",
+                    selector=vm.Dropdown(
+                        options=[
+                            {"label": "a", "value": "A"},
+                            {"label": "b", "value": "B"},
+                            {"label": "c", "value": "C"},
+                        ]
                     ),
                 ),
+                vm.Filter(column="id"),
             ],
         ),
+    ],
+    controls=[
+        vm.Filter(column="long_words"),
     ],
 )
 

--- a/vizro-core/src/vizro/models/_components/form/dropdown.py
+++ b/vizro-core/src/vizro/models/_components/form/dropdown.py
@@ -1,40 +1,17 @@
-import math
-from datetime import date
 from typing import Annotated, Any, Literal, Optional, Union, cast
 
 import dash_bootstrap_components as dbc
 from dash import dcc, html
-from pydantic import AfterValidator, BeforeValidator, Field, PrivateAttr, StrictBool, ValidationInfo, model_validator
+from pydantic import AfterValidator, BeforeValidator, Field, PrivateAttr, ValidationInfo, model_validator
 from pydantic.functional_serializers import PlainSerializer
 from pydantic.json_schema import SkipJsonSchema
 
 from vizro.models import Tooltip, VizroBaseModel
 from vizro.models._action._actions_chain import _action_validator_factory
 from vizro.models._components.form._form_utils import get_options_and_default, validate_options_dict, validate_value
-from vizro.models._models_utils import _log_call
+from vizro.models._models_utils import _calculate_option_height, _log_call
 from vizro.models._tooltip import coerce_str_to_tooltip
 from vizro.models.types import ActionType, MultiValueType, OptionsDictType, OptionsType, SingleValueType, _IdProperty
-
-
-def _get_list_of_labels(full_options: OptionsType) -> Union[list[StrictBool], list[float], list[str], list[date]]:
-    """Returns a list of labels from the selector options provided."""
-    if all(isinstance(option, dict) for option in full_options):
-        return [option["label"] for option in full_options]  # type: ignore[index]
-    else:
-        return cast(Union[list[StrictBool], list[float], list[str], list[date]], full_options)
-
-
-def _calculate_option_height(full_options: OptionsType) -> int:
-    """Calculates the height of the dropdown options based on the longest option."""
-    # 30 characters is roughly the number of "A" characters you can fit comfortably on a line in the dropdown.
-    # "A" is representative of a slightly wider than average character:
-    # https://stackoverflow.com/questions/3949422/which-letter-of-the-english-alphabet-takes-up-most-pixels
-    # We look at the longest option to find number_of_lines it requires. Option height is the same for all options
-    # and needs 24px for each line + 8px padding.
-    list_of_labels = _get_list_of_labels(full_options)
-    max_length = max(len(str(option)) for option in list_of_labels)
-    number_of_lines = math.ceil(max_length / 30)
-    return 8 + 24 * number_of_lines
 
 
 def validate_multi(multi, info: ValidationInfo):

--- a/vizro-core/src/vizro/models/_controls/_controls_utils.py
+++ b/vizro-core/src/vizro/models/_controls/_controls_utils.py
@@ -47,9 +47,10 @@ def set_container_control_default(control: ControlType) -> None:
     page = model_manager._get_model_page(control)
     if control in page.controls:
         return None
+
     if isinstance(control.selector, (Checklist, RadioItems)):
         control.selector.extra.setdefault("inline", True)
 
-    elif isinstance(control.selector, Dropdown):
+    if isinstance(control.selector, Dropdown):
         option_height = _calculate_option_height(full_options=control.selector.options, char_count=15)
         control.selector.extra.setdefault("optionHeight", option_height)

--- a/vizro-core/src/vizro/models/_controls/_controls_utils.py
+++ b/vizro-core/src/vizro/models/_controls/_controls_utils.py
@@ -3,7 +3,8 @@ from typing import Optional
 
 from vizro.managers import model_manager
 from vizro.managers._model_manager import FIGURE_MODELS
-from vizro.models import Checklist, Container, RadioItems, VizroBaseModel
+from vizro.models import Checklist, Container, Dropdown, RadioItems, VizroBaseModel
+from vizro.models._models_utils import _calculate_option_height
 from vizro.models.types import ControlType
 
 
@@ -46,3 +47,8 @@ def set_container_control_default(control: ControlType) -> None:
     page = model_manager._get_model_page(control)
     if control not in page.controls and isinstance(control.selector, (Checklist, RadioItems)):
         control.selector.extra.setdefault("inline", True)
+
+    if control not in page.controls and isinstance(control.selector, Dropdown):
+        # 15 characters is roughly the number of "A" characters you can fit comfortably in the container dropdown line.
+        option_height = _calculate_option_height(full_options=control.selector.options, no_characters=15)
+        control.selector.extra.setdefault("optionHeight", option_height)

--- a/vizro-core/src/vizro/models/_controls/_controls_utils.py
+++ b/vizro-core/src/vizro/models/_controls/_controls_utils.py
@@ -45,10 +45,11 @@ def check_control_targets(control: ControlType) -> None:
 
 def set_container_control_default(control: ControlType) -> None:
     page = model_manager._get_model_page(control)
-    if control not in page.controls and isinstance(control.selector, (Checklist, RadioItems)):
+    if control in page.controls:
+        return None
+    if isinstance(control.selector, (Checklist, RadioItems)):
         control.selector.extra.setdefault("inline", True)
 
-    if control not in page.controls and isinstance(control.selector, Dropdown):
-        # 15 characters is roughly the number of "A" characters you can fit comfortably in the container dropdown line.
-        option_height = _calculate_option_height(full_options=control.selector.options, no_characters=15)
+    elif isinstance(control.selector, Dropdown):
+        option_height = _calculate_option_height(full_options=control.selector.options, char_count=15)
         control.selector.extra.setdefault("optionHeight", option_height)

--- a/vizro-core/src/vizro/models/_controls/filter.py
+++ b/vizro-core/src/vizro/models/_controls/filter.py
@@ -163,9 +163,6 @@ class Filter(VizroBaseModel):
         self.selector = self.selector or SELECTORS[self._column_type][0]()
         self.selector.title = self.selector.title or self.column.title()
 
-        # set default inline=True for container selectors
-        set_container_control_default(control=self)
-
         if isinstance(self.selector, DISALLOWED_SELECTORS.get(self._column_type, ())):
             raise ValueError(
                 f"Chosen selector {type(self.selector).__name__} is not compatible with {self._column_type} column "
@@ -219,6 +216,9 @@ class Filter(VizroBaseModel):
                     targets=self.targets,
                 ),
             ]
+
+        # set default inline=True for container selectors
+        set_container_control_default(control=self)
 
     @_log_call
     def build(self):

--- a/vizro-core/src/vizro/models/_controls/filter.py
+++ b/vizro-core/src/vizro/models/_controls/filter.py
@@ -200,6 +200,9 @@ class Filter(VizroBaseModel):
             self.selector = cast(CategoricalSelectorType, self.selector)
             self.selector.options = self.selector.options or self._get_options(targeted_data)
 
+        # set defaults for container selectors
+        set_container_control_default(control=self)
+
         if not self.selector.actions:
             if isinstance(self.selector, RangeSlider) or (
                 isinstance(self.selector, DatePicker) and self.selector.range
@@ -216,9 +219,6 @@ class Filter(VizroBaseModel):
                     targets=self.targets,
                 ),
             ]
-
-        # set default inline=True for container selectors
-        set_container_control_default(control=self)
 
     @_log_call
     def build(self):

--- a/vizro-core/src/vizro/models/_controls/filter.py
+++ b/vizro-core/src/vizro/models/_controls/filter.py
@@ -200,7 +200,6 @@ class Filter(VizroBaseModel):
             self.selector = cast(CategoricalSelectorType, self.selector)
             self.selector.options = self.selector.options or self._get_options(targeted_data)
 
-        # set defaults for container selectors
         set_container_control_default(control=self)
 
         if not self.selector.actions:

--- a/vizro-core/src/vizro/models/_models_utils.py
+++ b/vizro-core/src/vizro/models/_models_utils.py
@@ -76,14 +76,14 @@ def _get_list_of_labels(full_options: OptionsType) -> Union[list[StrictBool], li
         return cast(Union[list[StrictBool], list[float], list[str], list[date]], full_options)
 
 
-def _calculate_option_height(full_options: OptionsType, no_characters: int = 30) -> int:
+def _calculate_option_height(full_options: OptionsType, char_count: int = 30) -> int:
     """Calculates the height of the dropdown options based on the longest option."""
-    # 30 characters is roughly the number of "A" characters you can fit comfortably on a line in the page dropdown.
-    # "A" is representative of a slightly wider than average character:
+    # 30 characters is roughly the number of "A" characters you can fit comfortably on a line in the page dropdown
+    # (placed on the left-side). "A" is representative of a slightly wider than average character:
     # https://stackoverflow.com/questions/3949422/which-letter-of-the-english-alphabet-takes-up-most-pixels
     # We look at the longest option to find number_of_lines it requires. Option height is the same for all options
     # and needs 24px for each line + 8px padding.
     list_of_labels = _get_list_of_labels(full_options)
     max_length = max(len(str(option)) for option in list_of_labels)
-    number_of_lines = math.ceil(max_length / no_characters)
+    number_of_lines = math.ceil(max_length / char_count)
     return 8 + 24 * number_of_lines

--- a/vizro-core/src/vizro/models/_models_utils.py
+++ b/vizro-core/src/vizro/models/_models_utils.py
@@ -1,9 +1,13 @@
 import logging
+import math
+from datetime import date
 from functools import wraps
+from typing import Union, cast
 
 from dash import html
+from pydantic import StrictBool
 
-from vizro.models.types import CapturedCallable, _SupportsCapturedCallable
+from vizro.models.types import CapturedCallable, OptionsType, _SupportsCapturedCallable
 
 logger = logging.getLogger(__name__)
 
@@ -62,3 +66,24 @@ def _build_inner_layout(layout, components):
 
 def validate_icon(icon) -> str:
     return icon.strip().lower().replace(" ", "_")
+
+
+def _get_list_of_labels(full_options: OptionsType) -> Union[list[StrictBool], list[float], list[str], list[date]]:
+    """Returns a list of labels from the selector options provided."""
+    if all(isinstance(option, dict) for option in full_options):
+        return [option["label"] for option in full_options]  # type: ignore[index]
+    else:
+        return cast(Union[list[StrictBool], list[float], list[str], list[date]], full_options)
+
+
+def _calculate_option_height(full_options: OptionsType, no_characters: int = 30) -> int:
+    """Calculates the height of the dropdown options based on the longest option."""
+    # 30 characters is roughly the number of "A" characters you can fit comfortably on a line in the dropdown.
+    # "A" is representative of a slightly wider than average character:
+    # https://stackoverflow.com/questions/3949422/which-letter-of-the-english-alphabet-takes-up-most-pixels
+    # We look at the longest option to find number_of_lines it requires. Option height is the same for all options
+    # and needs 24px for each line + 8px padding.
+    list_of_labels = _get_list_of_labels(full_options)
+    max_length = max(len(str(option)) for option in list_of_labels)
+    number_of_lines = math.ceil(max_length / no_characters)
+    return 8 + 24 * number_of_lines

--- a/vizro-core/src/vizro/models/_models_utils.py
+++ b/vizro-core/src/vizro/models/_models_utils.py
@@ -78,7 +78,7 @@ def _get_list_of_labels(full_options: OptionsType) -> Union[list[StrictBool], li
 
 def _calculate_option_height(full_options: OptionsType, no_characters: int = 30) -> int:
     """Calculates the height of the dropdown options based on the longest option."""
-    # 30 characters is roughly the number of "A" characters you can fit comfortably on a line in the dropdown.
+    # 30 characters is roughly the number of "A" characters you can fit comfortably on a line in the page dropdown.
     # "A" is representative of a slightly wider than average character:
     # https://stackoverflow.com/questions/3949422/which-letter-of-the-english-alphabet-takes-up-most-pixels
     # We look at the longest option to find number_of_lines it requires. Option height is the same for all options

--- a/vizro-core/tests/unit/vizro/models/_components/conftest.py
+++ b/vizro-core/tests/unit/vizro/models/_components/conftest.py
@@ -3,9 +3,41 @@
 import pytest
 
 import vizro.models as vm
+import vizro.plotly.express as px
 from vizro.actions import filter_interaction
 
 
 @pytest.fixture
 def filter_interaction_action():
     return vm.Action(function=filter_interaction())
+
+
+@pytest.fixture
+def managers_page_container_controls(gapminder):
+    """Instantiates a simple model_manager and data_manager with a page, and two graph models and gapminder data."""
+    vm.Page(
+        id="test_container_page",
+        title="My first dashboard",
+        components=[
+            vm.Container(
+                id="test_container",
+                title="",
+                components=[
+                    vm.Graph(id="scatter_chart", figure=px.scatter(gapminder, x="lifeExp", y="gdpPercap")),
+                ],
+                controls=[
+                    vm.Filter(
+                        id="container_filter_dropdown",
+                        column="country",
+                    ),
+                ],
+            ),
+            vm.Graph(id="bar_chart", figure=px.bar(gapminder, x="country", y="gdpPercap")),
+        ],
+        controls=[
+            vm.Filter(
+                id="page_dropdown",
+                column="country",
+            ),
+        ],
+    )

--- a/vizro-core/tests/unit/vizro/models/_components/conftest.py
+++ b/vizro-core/tests/unit/vizro/models/_components/conftest.py
@@ -32,12 +32,5 @@ def managers_page_container_controls(gapminder):
                     ),
                 ],
             ),
-            vm.Graph(id="bar_chart", figure=px.bar(gapminder, x="country", y="gdpPercap")),
-        ],
-        controls=[
-            vm.Filter(
-                id="page_dropdown",
-                column="country",
-            ),
         ],
     )

--- a/vizro-core/tests/unit/vizro/models/_components/form/test_dropdown.py
+++ b/vizro-core/tests/unit/vizro/models/_components/form/test_dropdown.py
@@ -6,6 +6,7 @@ from asserts import assert_component_equal
 from dash import dcc, html
 from pydantic import ValidationError
 
+from vizro.managers import model_manager
 from vizro.models import Tooltip
 from vizro.models._action._action import Action
 from vizro.models._components.form import Dropdown
@@ -202,42 +203,6 @@ class TestDropdownBuild:
 
         assert_component_equal(dropdown, expected_dropdown)
 
-    @pytest.mark.parametrize(
-        "options, option_height",
-        [
-            (["A", "B", "C"], 32),
-            ([10, 20, 30], 32),
-            (["A" * 30, "B", "C"], 32),
-            (["A" * 31, "B", "C"], 56),
-            (["A" * 60, "B", "C"], 56),
-            (["A" * 61, "B", "C"], 80),
-            ([{"label": "A" * 30, "value": "A"}, {"label": "B", "value": "B"}, {"label": "C", "value": "C"}], 32),
-            ([{"label": "A" * 31, "value": "A"}, {"label": "B", "value": "B"}, {"label": "C", "value": "C"}], 56),
-            ([{"label": "A" * 60, "value": "A"}, {"label": "B", "value": "B"}, {"label": "C", "value": "C"}], 56),
-            ([{"label": "A" * 61, "value": "A"}, {"label": "B", "value": "B"}, {"label": "C", "value": "C"}], 80),
-        ],
-    )
-    def test_dropdown_dynamic_option_height(self, options, option_height):
-        default_value = options[0]["value"] if all(isinstance(option, dict) for option in options) else options[0]  # type: ignore[index]
-        dropdown = Dropdown(id="dropdown_id", multi=False, options=options).build()
-        expected_dropdown = html.Div(
-            [
-                None,
-                dcc.Dropdown(
-                    id="dropdown_id",
-                    options=options,
-                    optionHeight=option_height,
-                    multi=False,
-                    value=default_value,
-                    persistence=True,
-                    persistence_type="session",
-                    className="dropdown",
-                ),
-            ]
-        )
-
-        assert_component_equal(dropdown, expected_dropdown)
-
     def test_dropdown_build_with_extra(self):
         """Test that extra arguments correctly override defaults."""
         dropdown = Dropdown(
@@ -317,3 +282,73 @@ class TestDropdownBuild:
         )
 
         assert_component_equal(dropdown, expected_dropdown)
+
+    @pytest.mark.usefixtures("managers_page_container_controls")
+    @pytest.mark.parametrize(
+        "options, page_dropdown_height, container_dropdown_height",
+        [
+            (["A", "B", "C"], 32, 32),
+            ([10, 20, 30], 32, 32),
+            (["A" * 15, "B", "C"], 32, 32),
+            (["A" * 30, "B", "C"], 32, 56),
+            (["A" * 31, "B", "C"], 56, 80),
+            (["A" * 60, "B", "C"], 56, 104),
+            (["A" * 61, "B", "C"], 80, 128),
+            ([{"label": "A" * 30, "value": "A"}, {"label": "B", "value": "B"}, {"label": "C", "value": "C"}], 32, 56),
+            ([{"label": "A" * 31, "value": "A"}, {"label": "B", "value": "B"}, {"label": "C", "value": "C"}], 56, 80),
+            ([{"label": "A" * 60, "value": "A"}, {"label": "B", "value": "B"}, {"label": "C", "value": "C"}], 56, 104),
+            ([{"label": "A" * 61, "value": "A"}, {"label": "B", "value": "B"}, {"label": "C", "value": "C"}], 80, 128),
+        ],
+    )
+    def test_dropdown_dynamic_option_height(self, options, page_dropdown_height, container_dropdown_height):
+        """Test dropdown dynamic option height calculation for page and container dropdowns."""
+        # Common dropdown configuration
+        default_value = options[0]["value"] if all(isinstance(option, dict) for option in options) else options[0]  # type: ignore[index]
+        common_dropdown_config = {
+            "options": options,
+            "multi": False,
+            "value": default_value,
+            "persistence": True,
+            "persistence_type": "session",
+            "className": "dropdown",
+        }
+
+        # Build actual dropdowns
+        model_manager["page_dropdown"].selector = Dropdown(options=options, multi=False)
+        page_dropdown = model_manager["page_dropdown"].selector.build()
+
+        model_manager["container_filter_dropdown"].selector = Dropdown(
+            options=options, multi=False, id="container_dropdown_id"
+        )
+        container_dropdown_manager = model_manager["container_filter_dropdown"]
+        container_dropdown_manager.pre_build()
+        container_dropdown = container_dropdown_manager.selector.build()
+
+        # Expected components
+        expected_page_dropdown = html.Div(
+            [
+                None,
+                dcc.Dropdown(
+                    id="page_dropdown_id",
+                    optionHeight=page_dropdown_height,
+                    **common_dropdown_config,
+                ),
+            ]
+        )
+
+        expected_container_dropdown = html.Div(
+            [
+                dbc.Label(
+                    children=[html.Span(id="container_dropdown_id_title", children="Country"), None],
+                    html_for="container_dropdown_id",
+                ),
+                dcc.Dropdown(
+                    id="container_dropdown_id",
+                    optionHeight=container_dropdown_height,
+                    **common_dropdown_config,
+                ),
+            ]
+        )
+
+        assert_component_equal(page_dropdown, expected_page_dropdown, keys_to_strip={"id"})
+        assert_component_equal(container_dropdown, expected_container_dropdown, keys_to_strip={"id"})

--- a/vizro-core/tests/unit/vizro/models/_controls/conftest.py
+++ b/vizro-core/tests/unit/vizro/models/_controls/conftest.py
@@ -23,16 +23,22 @@ def managers_one_page_two_graphs(gapminder):
 def managers_one_page_container_controls(gapminder):
     """Instantiates a simple model_manager and data_manager with a page, and two graph models and gapminder data."""
     vm.Page(
-        id="test_container",
+        id="test_container_page",
         title="My first dashboard",
         components=[
             vm.Container(
+                id="test_container",
                 title="",
                 components=[
                     vm.Graph(id="scatter_chart", figure=px.scatter(gapminder, x="lifeExp", y="gdpPercap")),
                 ],
                 controls=[
                     vm.Filter(id="container_filter", column="continent", selector=vm.Checklist(value=["Europe"])),
+                    vm.Filter(
+                        id="container_dropdown",
+                        column="country",
+                        selector=vm.Dropdown(options=["Bosnia and Herzegovina", "Ireland", "Slovenia", "Spain"]),
+                    ),
                     vm.Parameter(
                         id="container_parameter",
                         targets=["scatter_chart.x"],

--- a/vizro-core/tests/unit/vizro/models/_controls/test_filter.py
+++ b/vizro-core/tests/unit/vizro/models/_controls/test_filter.py
@@ -874,6 +874,13 @@ class TestPreBuildMethod:
         assert filter.selector.extra == {"inline": True}
 
     @pytest.mark.usefixtures("managers_one_page_container_controls")
+    def test_filter_dropdown_height(self):
+        filter = model_manager["container_dropdown"]
+        filter.pre_build()
+
+        assert filter.selector.extra == {"optionHeight": 56}
+
+    @pytest.mark.usefixtures("managers_one_page_container_controls")
     def test_container_filter_default_targets(self):
         filter = model_manager["container_filter"]
         filter.pre_build()


### PR DESCRIPTION
## Description
closes https://github.com/McK-Internal/vizro-internal/issues/1846

Antony FYI: https://github.com/McK-Internal/vizro-internal/issues/1829
- we might want to reconsider moving this part of code to the selector, as part of your refactoring. 

Fixed dropdown height calculation when dropdown selector is used in containers 
## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
