### PR TITLE
[Bug] Fix text alignment in figure header and footer

### DIFF
--- a/vizro-core/changelog.d/20250625_093858_90609403+huong-li-nguyen_fix_header_alignment.md
+++ b/vizro-core/changelog.d/20250625_093858_90609403+huong-li-nguyen_fix_header_alignment.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -3,57 +3,30 @@ import numpy as np
 from vizro import Vizro
 import vizro.models as vm
 import pandas as pd
-from vizro.tables import dash_ag_grid
-import string
+import vizro.plotly.express as px
+
+iris = px.data.iris()
 
 
-N = len(string.ascii_letters)
-df = pd.DataFrame(
-    {
-        "category 1": np.random.choice(list("abc"), N),
-        "category 2": np.random.choice(list("ABC"), N),
-        "long_words": [" ".join(list(string.ascii_letters[: n + 1])) for n in range(N)],
-        "numbers": np.random.randint(N, size=N),
-    }
-)
-
-
-def dynamic_data(n=10):
-    return df.loc[:n]
-
-
-def make_controls():
-    return [
-        vm.Filter(column="long_words"),
-        vm.Filter(
-            column="category 1",
-            selector=vm.Checklist(),
-        ),
-        vm.Filter(column="category 2", selector=vm.RadioItems()),
-        vm.Filter(column="numbers"),
-    ]
-
-
-page_1 = vm.Page(
-    title="Test page",
+graphs = vm.Page(
+    title="Graphs",
     components=[
-        vm.Container(
-            components=[vm.AgGrid(id="grid", figure=dash_ag_grid(dynamic_data))],
-            controls=make_controls(),
+        vm.Graph(
+            figure=px.scatter(iris, x="sepal_width", y="sepal_length", color="species"),
+            title="Relationships between Sepal Width and Sepal Length",
+            header="""
+                Each point in the scatter plot represents one of the 150 iris flowers, with colors indicating their
+                types. The Setosa type is easily identifiable by its short and wide sepals.
+
+                However, there is still overlap between the Versicolor and Virginica types when considering only sepal
+                width and length.
+                """,
+            footer="""SOURCE: **Plotly iris data set, 2024**""",
         ),
-    ],
-    controls=[
-        vm.Parameter(
-            targets=["grid.data_frame.n"],
-            selector=vm.Slider(
-                title="Change me to see bug", min=0, max=N, step=1, marks={0: "0", N // 2: str(N // 2), N: str(N)}
-            ),
-        ),
-        *make_controls(),
     ],
 )
 
-dashboard = vm.Dashboard(title="Test dashboard", pages=[page_1])
+dashboard = vm.Dashboard(pages=[graphs])
 
 if __name__ == "__main__":
     app = Vizro().build(dashboard)

--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -26,7 +26,72 @@ graphs = vm.Page(
     ],
 )
 
-dashboard = vm.Dashboard(pages=[graphs])
+tooltip = vm.Page(
+    title="Tooltip",
+    layout=vm.Grid(grid=[[0], [0], [1], [1], [1], [1], [1], [1], [2]]),
+    components=[
+        vm.Card(
+            text="""
+                The `description` argument enables you to add helpful context to your components by displaying an
+                info icon next to its title. Hovering over the icon reveals a tooltip with the text you provide.
+
+                Tooltips can be added to any Vizro component that has a `title` argument.
+                You can provide a string to use the default info icon or `Tooltip` model to use any icon from the
+                [Google Material Icons library](https://fonts.google.com/icons).
+                Tooltips provide clean and lightweight way to add additional details to your dashboard.
+            """
+        ),
+        vm.Graph(
+            title="Relationships between Sepal Width and Sepal Length",
+            figure=px.scatter(
+                iris,
+                x="sepal_width",
+                y="sepal_length",
+                color="species",
+                size="petal_length",
+            ),
+            description="""
+                **The Iris dataset** includes measurements of 150 iris flowers across three types: Setosa, Versicolor,
+                and Virginica.
+                While all samples are labeled by type, they can appear similar when looking at just some features -
+                 making it a useful dataset for exploring patterns and challenges in classification.
+            """,
+        ),
+        vm.Button(
+            text="Export data",
+            description="""
+                Use this button to export the filtered data from the Iris dataset.
+            """,
+        ),
+    ],
+    controls=[
+        vm.Filter(
+            column="species",
+            selector=vm.Dropdown(
+                title="Species",
+                description="""
+                    Select one or more species to explore patterns
+                    specific to Setosa, Versicolor, or Virginica.
+                """,
+            ),
+        ),
+        vm.Filter(
+            column="sepal_width",
+            selector=vm.RangeSlider(
+                description="""
+                    Use the slider to filter flowers by sepal width.
+                    Only samples within the selected range will be shown.
+                """
+            ),
+        ),
+    ],
+    description="""
+        This page provides overview of Tooltip functionality.
+    """,
+)
+
+
+dashboard = vm.Dashboard(pages=[graphs, tooltip])
 
 if __name__ == "__main__":
     app = Vizro().build(dashboard)

--- a/vizro-core/src/vizro/static/css/tiles.css
+++ b/vizro-core/src/vizro/static/css/tiles.css
@@ -8,9 +8,9 @@
 .figure-title,
 .figure-header,
 .figure-footer {
-  align-items: center;
   display: flex;
   flex: 0 1 auto;
+  flex-direction: column;
   gap: 8px;
 }
 

--- a/vizro-core/src/vizro/static/css/tiles.css
+++ b/vizro-core/src/vizro/static/css/tiles.css
@@ -14,6 +14,12 @@
   gap: 8px;
 }
 
+/* Needs to deviate from the default as the info-icon could be placed inside*/
+.figure-title {
+  align-items: center;
+  flex-direction: row;
+}
+
 .figure-footer {
   padding-top: 0.75rem;
 }

--- a/vizro-core/src/vizro/static/css/tiles.css
+++ b/vizro-core/src/vizro/static/css/tiles.css
@@ -14,7 +14,7 @@
   gap: 8px;
 }
 
-/* Needs to deviate from the default as the info-icon could be placed inside*/
+/* Needs to deviate from the default as the info-icon could be placed inside */
 .figure-title {
   align-items: center;
   flex-direction: row;


### PR DESCRIPTION
## Description

* We previously adjusted the text alignment for `figure-title`, `header`, and `footer` to ensure the info icon aligns properly with the title.
* However, this change caused markdown text within the `header` and `footer` to appear misaligned.
* This PR applies targeted alignment fixes to all three selectors, so both the icons and markdown content are correctly aligned.


## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
