### PR TITLE
Set dash>=3.1.1 in pyproject.toml

### DIFF
--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -141,7 +141,7 @@ VIZRO_LOG_LEVEL = "DEBUG"
 
 [envs.lower-bounds]
 extra-dependencies = [
-  "dash==3.0.0",
+  "dash==3.1.1",
   "dash-bootstrap-components==2.0.0",
   "dash-ag-grid==31.3.1",
   "dash-mantine-components==1.0.0",

--- a/vizro-core/pyproject.toml
+++ b/vizro-core/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13"
 ]
 dependencies = [
-  "dash>=3,<3.1.0",  # temporary upper limit to prevent/investigate https://github.com/plotly/dash/issues/3349
+  "dash>=3.1.1",  # must be >=3.1.1 to include bugfixes for persistence and suppress_callback_exception
   "dash_bootstrap_components>=2",  # 2.0.0 needed to support dash>=3.0.0
   "dash-ag-grid>=31.3.1",  # 31.3.1 needed to support dash>=3.0.0
   "dash_mantine_components>=1",  # 1.0.0 needed to support dash>=3.0.0


### PR DESCRIPTION
Closes https://github.com/McK-Internal/vizro-internal/issues/1544

## Description
Set `dash>=3.1.1` in `pyproject.toml` to include:
- https://github.com/plotly/dash/pull/3279
- https://github.com/plotly/dash/pull/3351

I tested all `vizro-core` example dashboards, along with various dynamic filters and data-frame parameters, to verify that everything functions correctly, and I haven't found any unexpected behaviours. 

This PR unblocks the following tickets:
- https://github.com/mckinsey/vizro/pull/1243
- https://github.com/McK-Internal/vizro-internal/issues/1342
- https://github.com/mckinsey/vizro/pull/1265 without the `show_in_url=True` restriction when it's done on the same page.
- https://github.com/McK-Internal/vizro-internal/issues/1356
- https://github.com/McK-Internal/vizro-internal/issues/1547
- https://github.com/McK-Internal/vizro-internal/issues/1554
- https://github.com/McK-Internal/vizro-internal/issues/1545
- https://github.com/McK-Internal/vizro-internal/issues/1546

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
