### PR TITLE
[Fix] Fix location of the vizro_url and vizro_download components so they work

### DIFF
--- a/vizro-core/changelog.d/20250703_114236_petar_pejovic_fix_download_and_url_components_location.md
+++ b/vizro-core/changelog.d/20250703_114236_petar_pejovic_fix_download_and_url_components_location.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -157,8 +157,13 @@ def change_location_callback(_):
 
 # ------------------------- Dashboard Build Components -------------------------
 
+DESCRIPTION = """
+    Add 'dashboard_vizro_download' and 'dashboard_vizro_url' component to the dashboard layout to check if it works
+"""
+
 page_3 = vm.Page(
     title="Test dashboard - Vizro actions",
+    description="ADD 'download_vizro_download' component to the dashboard layout to check if it works",
     path="page-3",
     components=[
         vm.Container(
@@ -169,6 +174,7 @@ page_3 = vm.Page(
                 vm.Button(
                     id="page_3_button_download",
                     text="Export data!",
+                    description=DESCRIPTION,
                     actions=[
                         vm.Action(
                             function=my_custom_export(),
@@ -179,6 +185,7 @@ page_3 = vm.Page(
                 vm.Button(
                     id="copy_page_3_button_download",
                     text="Copy Export data!",
+                    description=DESCRIPTION,
                     actions=[
                         vm.Action(
                             function=my_custom_export(),
@@ -189,6 +196,7 @@ page_3 = vm.Page(
                 vm.Button(
                     id="page_3_button_location",
                     text="Go to page 4!",
+                    description=DESCRIPTION,
                     actions=[
                         vm.Action(
                             function=my_custom_location(x=4),
@@ -199,6 +207,7 @@ page_3 = vm.Page(
                 vm.Button(
                     id="copy_page_3_button_location",
                     text="Copy Go to page 4!",
+                    description=DESCRIPTION,
                     actions=[
                         vm.Action(
                             function=my_custom_location(x=4),
@@ -217,7 +226,8 @@ page_3 = vm.Page(
 )
 
 page_4 = vm.Page(
-    title="Test dashboard - pure Dash callbacks",
+    title="Test dashboard - pure Dash callbacks - DOES NOT WORK AS EXPECTED",
+    description=DESCRIPTION,
     path="page-4",
     components=[
         vm.Container(
@@ -228,18 +238,22 @@ page_4 = vm.Page(
                 vm.Button(
                     id="page_4_button_download",
                     text="Export data!",
+                    description=DESCRIPTION,
                 ),
                 vm.Button(
                     id="copy_page_4_button_download",
                     text="Copy Export data!",
+                    description=DESCRIPTION,
                 ),
                 vm.Button(
                     id="page_4_button_location",
                     text="Go to page 3!",
+                    description=DESCRIPTION,
                 ),
                 vm.Button(
                     id="copy_page_4_button_location",
                     text="Copy Go to page 3!",
+                    description=DESCRIPTION,
                 ),
             ],
         ),

--- a/vizro-core/src/vizro/models/_page.py
+++ b/vizro-core/src/vizro/models/_page.py
@@ -207,14 +207,14 @@ class Page(VizroBaseModel):
         # Build layout with components
         components_container = _build_inner_layout(self.layout, self.components)
         components_container.id = "page-components"
-        # Keep this store in components_container, moving it outside prevents on_page_load_action from triggering
-        components_container.children.append(dcc.Store(id=f"{ON_PAGE_LOAD_ACTION_PREFIX}_trigger_{self.id}"))
 
-        return html.Div(
+        # Keep these components in components_container, moving them outside make them not work properly.
+        components_container.children.extend(
             [
-                control_panel,
-                components_container,
+                dcc.Store(id=f"{ON_PAGE_LOAD_ACTION_PREFIX}_trigger_{self.id}"),
                 dcc.Download(id="vizro_download"),
                 dcc.Location(id="vizro_url", refresh="callback-nav"),
             ]
         )
+
+        return html.Div([control_panel, components_container])


### PR DESCRIPTION
Closes https://github.com/McK-Internal/vizro-internal/issues/1935

## Description

The scratch dev example did not work before these changes as predefined `vizro_url` and `vizro_download` were placed in the wrong place.  

Here's the PR that introduced components -> https://github.com/mckinsey/vizro/pull/1258

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
