### PR TITLE
[Bug] Fix unintended value clearing for dropdown filter that targets dynamic data_frame

### DIFF
--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -12,31 +12,77 @@ def dynamic_data_load(number_of_rows: int = 10):
 
 data_manager["static_df"] = dynamic_data_load(number_of_rows=150)
 data_manager["dynamic_df"] = dynamic_data_load
+#
+# static_sliders = vm.Page(
+#     title="Static sliders",
+#     components=[
+#         vm.Graph(figure=px.scatter("static_df", x="sepal_length", y="petal_length", color="species")),
+#     ],
+#     controls=[
+#         vm.Filter(column="sepal_length"),
+#         vm.Filter(column="petal_length", selector=vm.Slider()),
+#     ],
+# )
+#
+#
+# dynamic_sliders = vm.Page(
+#     title="Dynamic sliders",
+#     components=[
+#         vm.Graph(
+#             id="page_2_graph_1", figure=px.scatter("dynamic_df", x="sepal_length", y="petal_length", color="species")
+#         ),
+#     ],
+#     controls=[
+#         vm.Filter(column="sepal_length"),
+#         vm.Filter(column="petal_length", selector=vm.Slider()),
+#         vm.Parameter(
+#             targets=["page_2_graph_1.data_frame.number_of_rows"],
+#             selector=vm.Slider(
+#                 title="Number of Rows",
+#                 min=10,
+#                 max=150,
+#             ),
+#         ),
+#     ],
+# )
+#
+#
+# url_dynamic_sliders = vm.Page(
+#     title="Dynamic data from URL",
+#     components=[
+#         vm.Graph(
+#             id="page_3_graph_1",
+#             figure=px.scatter("dynamic_df", x="sepal_length", y="petal_length", color="species"),
+#         )
+#     ],
+#     controls=[
+#         vm.Filter(id="filter-1", column="sepal_length", show_in_url=True),
+#         vm.Filter(id="filter-2", column="petal_length", selector=vm.Slider(), show_in_url=True),
+#         vm.Parameter(
+#             id="dfp-parameter",
+#             targets=["page_3_graph_1.data_frame.number_of_rows"],
+#             selector=vm.Slider(
+#                 title="Number of Rows",
+#                 min=10,
+#                 max=150,
+#             ),
+#             show_in_url=True,
+#         ),
+#     ],
+# )
 
-static_sliders = vm.Page(
-    title="Static sliders",
-    components=[
-        vm.Graph(figure=px.scatter("static_df", x="sepal_length", y="petal_length", color="species")),
-    ],
-    controls=[
-        vm.Filter(column="sepal_length"),
-        vm.Filter(column="petal_length", selector=vm.Slider()),
-    ],
-)
-
-
-dynamic_sliders = vm.Page(
-    title="Dynamic sliders",
+dropdown_dynamic_data_bug = vm.Page(
+    title="Dropdown dynamic data bug",
     components=[
         vm.Graph(
-            id="page_2_graph_1", figure=px.scatter("dynamic_df", x="sepal_length", y="petal_length", color="species")
+            id="page_4_graph_1", figure=px.scatter("dynamic_df", x="sepal_length", y="petal_length", color="species")
         ),
     ],
     controls=[
-        vm.Filter(column="sepal_length"),
-        vm.Filter(column="petal_length", selector=vm.Slider()),
+        vm.Filter(column="species"),
+        vm.Filter(column="species", selector=vm.Dropdown(multi=False)),
         vm.Parameter(
-            targets=["page_2_graph_1.data_frame.number_of_rows"],
+            targets=["page_4_graph_1.data_frame.number_of_rows"],
             selector=vm.Slider(
                 title="Number of Rows",
                 min=10,
@@ -46,32 +92,12 @@ dynamic_sliders = vm.Page(
     ],
 )
 
-
-url_dynamic_sliders = vm.Page(
-    title="Dynamic data from URL",
-    components=[
-        vm.Graph(
-            id="page_3_graph_1",
-            figure=px.scatter("dynamic_df", x="sepal_length", y="petal_length", color="species"),
-        )
-    ],
-    controls=[
-        vm.Filter(id="filter-1", column="sepal_length", show_in_url=True),
-        vm.Filter(id="filter-2", column="petal_length", selector=vm.Slider(), show_in_url=True),
-        vm.Parameter(
-            id="dfp-parameter",
-            targets=["page_3_graph_1.data_frame.number_of_rows"],
-            selector=vm.Slider(
-                title="Number of Rows",
-                min=10,
-                max=150,
-            ),
-            show_in_url=True,
-        ),
-    ],
-)
-
-dashboard = vm.Dashboard(pages=[static_sliders, dynamic_sliders, url_dynamic_sliders])
+dashboard = vm.Dashboard(pages=[
+    # static_sliders,
+    # dynamic_sliders,
+    # url_dynamic_sliders,
+    dropdown_dynamic_data_bug,
+])
 
 if __name__ == "__main__":
-    Vizro().build(dashboard).run()
+    Vizro().build(dashboard).run(debug=True)

--- a/vizro-core/src/vizro/actions/_on_page_load.py
+++ b/vizro-core/src/vizro/actions/_on_page_load.py
@@ -21,8 +21,6 @@ class _on_page_load(_AbstractAction):
             Dict mapping target chart ids to modified figures e.g. {"my_scatter": Figure(...)}.
 
         """
-        # import time
-        # time.sleep(2)
         # TODO-AV2 A 1: _controls is not currently used but instead taken out of the Dash context. This
         # will change in future once the structure of _controls has been worked out and we know how to pass ids through.
         # See https://github.com/mckinsey/vizro/pull/880

--- a/vizro-core/src/vizro/actions/_on_page_load.py
+++ b/vizro-core/src/vizro/actions/_on_page_load.py
@@ -21,6 +21,8 @@ class _on_page_load(_AbstractAction):
             Dict mapping target chart ids to modified figures e.g. {"my_scatter": Figure(...)}.
 
         """
+        # import time
+        # time.sleep(2)
         # TODO-AV2 A 1: _controls is not currently used but instead taken out of the Dash context. This
         # will change in future once the structure of _controls has been worked out and we know how to pass ids through.
         # See https://github.com/mckinsey/vizro/pull/880

--- a/vizro-core/src/vizro/models/_components/form/dropdown.py
+++ b/vizro-core/src/vizro/models/_components/form/dropdown.py
@@ -3,7 +3,6 @@ from datetime import date
 from typing import Annotated, Any, Literal, Optional, Union, cast
 
 import dash_bootstrap_components as dbc
-import dash_mantine_components as dmc
 from dash import ClientsideFunction, Input, Output, State, clientside_callback, dcc, html
 from pydantic import AfterValidator, BeforeValidator, Field, PrivateAttr, StrictBool, ValidationInfo, model_validator
 from pydantic.functional_serializers import PlainSerializer
@@ -147,6 +146,7 @@ class Dropdown(VizroBaseModel):
         value = self.value if self.value is not None else default_value
 
         if self.multi:
+            self._define_clientside_callback()
             value = value if isinstance(value, list) else [value]  # type: ignore[assignment]
             dict_options = [
                 {
@@ -165,21 +165,7 @@ class Dropdown(VizroBaseModel):
                 *dict_options,
             ]
 
-            clientside_callback(
-                ClientsideFunction(namespace="dropdown", function_name="update_dropdown_select_all"),
-                output=[
-                    Output(f"{self.id}_select_all", "value"),
-                    Output(self.id, "value", allow_duplicate=True),
-                ],
-                inputs=[
-                    Input(self.id, "value"),
-                    State(self.id, "options"),
-                ],
-                prevent_initial_call="initial_duplicate",
-            )
-
         description = self.description.build().children if self.description else [None]
-
         defaults = {
             "id": self.id,
             "options": dict_options,
@@ -213,28 +199,21 @@ class Dropdown(VizroBaseModel):
             _, default_value = get_dict_options_and_default(options=self.options, multi=self.multi)
             self.value = default_value
 
+        # The rest of the method is added instead of calling and returning the content from the __call__ method
+        # because placeholder for the Dropdown can't be the dropdown itself. The reason is that the Dropdown value can
+        # be unexpectedly changed when the new options are added. This is developed as the dash feature
+        # https://github.com/plotly/dash/pull/1970.
         if self.multi:
-            clientside_callback(
-                ClientsideFunction(namespace="dropdown", function_name="update_dropdown_select_all"),
-                output=[
-                    Output(f"{self.id}_select_all", "value"),
-                    Output(self.id, "value", allow_duplicate=True),
-                ],
-                inputs=[
-                    Input(self.id, "value"),
-                    State(self.id, "options"),
-                ],
-                prevent_initial_call="initial_duplicate",
-            )
-
-        placeholder_defaults = {
-            "id": self.id,
-            "options": self.value if self.multi else [self.value],
-            "value": self.value,
-            "persistence": True,
-            "persistence_type": "session",
-        }
-        placeholder_component = dcc.Checklist(**placeholder_defaults) if self.multi else dbc.RadioItems(**placeholder_defaults)
+            # Add the clientside callback as the callback has to be defined in the page.build process.
+            self._define_clientside_callback()
+            # hidden_select_all_dropdown is needed to ensure that clientside callback doesn't raise the no output error.
+            hidden_select_all_dropdown = [dcc.Dropdown(id=f"{self.id}_select_all", style={"display": "none"})]
+            placeholder_model = dcc.Checklist
+            placeholder_options = self.value
+        else:
+            hidden_select_all_dropdown = [None]
+            placeholder_model = dbc.RadioItems
+            placeholder_options = [self.value]  # type: ignore[assignment]
 
         description = self.description.build().children if self.description else [None]
         return html.Div(
@@ -242,15 +221,32 @@ class Dropdown(VizroBaseModel):
                 dbc.Label(
                     children=[html.Span(id=f"{self.id}_title", children=self.title), *description], html_for=self.id
                 ),
-                placeholder_component,
-                html.Div(id="fake_dropdown-placeholder", style={"display": "none"}, children=[
-                    dcc.Dropdown(id=f"{self.id}_select_all", value=False)
-                ]),
+                placeholder_model(
+                    id=self.id,
+                    options=placeholder_options,
+                    value=self.value,
+                    persistence=True,
+                    persistence_type="session",
+                ),
+                *hidden_select_all_dropdown,
             ]
         )
-
-        # return self.__call__(self.options)
 
     @_log_call
     def build(self):
         return self._build_dynamic_placeholder() if self._dynamic else self.__call__(self.options)
+
+    def _define_clientside_callback(self):
+        """Define the clientside callbacks in the page build phase responsible for handling the select_all."""
+        clientside_callback(
+            ClientsideFunction(namespace="dropdown", function_name="update_dropdown_select_all"),
+            output=[
+                Output(f"{self.id}_select_all", "value"),
+                Output(self.id, "value", allow_duplicate=True),
+            ],
+            inputs=[
+                Input(self.id, "value"),
+                State(self.id, "options"),
+            ],
+            prevent_initial_call="initial_duplicate",
+        )


### PR DESCRIPTION
Closes https://github.com/McK-Internal/vizro-internal/issues/1494
Closes https://github.com/McK-Internal/vizro-internal/issues/1637

## Description

As detailed in one of the linked tickets, the issue stems from how `dcc.Dropdown` handles selected `values` that aren't present in its current `options`. The component clears any value entries that are not part of the current options, leading to unintended behaviour in specific scenarios during page load.

Here’s a breakdown of the problem. When the page is opened:
1. PB must return the `original default value` to avoid overwriting any persisted state.
2. Persistence is applied next, replacing the value from PB with the stored (currently selected) one.
3. OPL then executes with the goal of returning `updated dynamic options` and the `currently selected value`.

Problem scenario:
1. Initial state: `options = ["A"]`, `value = ["A"]`
2. User later selects: `value = ["A", "B", "C"]` after dynamic options become `["A", "B", "C"]`
3. User refreshes the page:
   1. PB returns `options = ["A"]`, `value = ["A"]`
   2. Persistence restores from `value = ["A"]` -> `value = ["A", "B", "C"]`
   3. `Issue`: dcc.Dropdown internally removes any values not in current options, so it removes `"B"` and `"C"` because PB only returned `"A"` in options.
   4. OPL receives and returns `value = ["A"]` (incorrect), `options = ["A", "B", "C"]`

Outcome:
Even though the correct options and value are available, internal dropdown implementation mistakenly drops part of the selection, resulting in only `["A"]` being shown instead of the expected `["A", "B", "C"]`.

This behaviour is only specific to the `dcc.Dropdown` component and is caused by the component's internal validation logic. See the relevant Dash PR that introduced this mechanism -> https://github.com/plotly/dash/pull/1970.

## For reviewers:

As it's already added into the scratch dev example, here are the steps for recreating the bug on the main branch:
```md
To reproduce the bug on the main:
1. Open the first page
2. Set the number of rows to 150 (bottom slider)
3. Select ["setosa", "versicolor"] in the multi-select dropdown
4. Select "versicolor" in the single-select dropdown
5. Refresh the page -> The value is unexpectedly reset to "setosa" in the multi-select dropdown and clear
   in the single-select dropdown. The value should remain the same as it was before the refresh.
```
## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
