### PR TITLE
Ux/issue 541

### DIFF
--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -6,12 +6,13 @@ import vizro.plotly.express as px
 from vizro import Vizro
 import vizro.models as vm
 from vizro.actions import filter_interaction, export_data
-from vizro.tables import dash_ag_grid, dash_data_table
+from vizro.tables import dash_data_table
 
 tips = px.data.tips()
 gapminder = px.data.gapminder()
 iris = px.data.iris()
-iris["date_column"] = pd.date_range(
+iris2 = px.data.iris()
+iris2["date_column"] = pd.date_range(
     start=pd.to_datetime("2024-01-01"), periods=len(iris), freq="D"
 )
 
@@ -119,46 +120,46 @@ page1 = vm.Page(
 page2 = vm.Page(
     title="FILTERS_PAGE",
     components=[
-        # vm.Tabs(
-        #     tabs=[
-        vm.Container(
-            id="FILTERS_TAB_CONTAINER",
-            title="FILTERS_TAB_CONTAINER",
-            components=[
+        vm.Tabs(
+            tabs=[
                 vm.Container(
-                    id="FILTERS_COMPONENTS_CONTAINER",
-                    title="FILTERS_COMPONENTS_CONTAINER",
-                    layout=vm.Grid(grid=[[0, 1], [0, 1], [0, 2]]),
+                    id="FILTERS_TAB_CONTAINER",
+                    title="FILTERS_TAB_CONTAINER",
                     components=[
-                        vm.Graph(
-                            id="SCATTER_GRAPH_ID",
-                            figure=px.scatter(
-                                iris,
-                                x="sepal_length",
-                                y="petal_width",
-                                color="sepal_width",
-                                height=450,
-                            ),
-                        ),
-                        vm.Graph(
-                            title="Where do we get more tips?",
-                            figure=px.bar(tips, y="tip", x="day"),
-                        ),
-                        vm.Graph(
-                            id="BOX_GRAPH_ID_2",
-                            figure=px.box(
-                                iris,
-                                x="sepal_length",
-                                y="petal_width",
-                                color="sepal_width",
-                            ),
-                        ),
+                        vm.Container(
+                            id="FILTERS_COMPONENTS_CONTAINER",
+                            title="FILTERS_COMPONENTS_CONTAINER",
+                            layout=vm.Grid(grid=[[0, 1], [0, 1], [0, 2]]),
+                            components=[
+                                vm.Graph(
+                                    id="SCATTER_GRAPH_ID",
+                                    figure=px.scatter(
+                                        iris,
+                                        x="sepal_length",
+                                        y="petal_width",
+                                        color="sepal_width",
+                                        height=450,
+                                    ),
+                                ),
+                                vm.Graph(
+                                    title="Where do we get more tips?",
+                                    figure=px.bar(tips, y="tip", x="day"),
+                                ),
+                                vm.Graph(
+                                    id="BOX_GRAPH_ID_2",
+                                    figure=px.box(
+                                        iris,
+                                        x="sepal_length",
+                                        y="petal_width",
+                                        color="sepal_width",
+                                    ),
+                                ),
+                            ],
+                        )
                     ],
-                )
-            ],
+                ),
+            ]
         ),
-        #     ]
-        # ),
         vm.Graph(
             id="BOX_GRAPH_ID",
             figure=px.box(
@@ -169,41 +170,7 @@ page2 = vm.Page(
             ),
         ),
     ],
-    controls=[
-        vm.Filter(
-            column="species",
-            targets=["SCATTER_GRAPH_ID", "BOX_GRAPH_ID"],
-            selector=vm.Dropdown(id="DROPDOWN_FILTER_FILTERS_PAGE"),
-        ),
-        vm.Filter(
-            column="species",
-            targets=["SCATTER_GRAPH_ID", "BOX_GRAPH_ID"],
-            selector=vm.RadioItems(
-                id="RADIO_ITEMS_FILTER_FILTERS_PAGE",
-                options=["setosa", "versicolor", "virginica"],
-            ),
-        ),
-        vm.Filter(
-            column="species",
-            targets=["SCATTER_GRAPH_ID"],
-            selector=vm.Checklist(
-                id="CHECK_LIST_FILTER_FILTERS_PAGE",
-                options=["setosa", "versicolor", "virginica"],
-            ),
-        ),
-        vm.Filter(
-            column="petal_width",
-            targets=["SCATTER_GRAPH_ID"],
-            selector=vm.Slider(id="SLIDER_FILTER_FILTERS_PAGE", step=0.5),
-        ),
-        vm.Filter(
-            column="sepal_length",
-            targets=["SCATTER_GRAPH_ID", "BOX_GRAPH_ID"],
-            selector=vm.RangeSlider(id="RANGE_SLIDER_FILTER_FILTERS_PAGE", step=1.0),
-        ),
-    ],
 )
-
 
 page3 = vm.Page(
     title="EXTRAS_PAGE",
@@ -217,7 +184,7 @@ page3 = vm.Page(
             components=[
                 vm.Graph(
                     figure=px.line(
-                        iris,
+                        iris2,
                         x="sepal_length",
                         y="petal_width",
                         color="sepal_width",
@@ -303,46 +270,6 @@ page3 = vm.Page(
         ),
     ],
 )
-
-
-# page11 = vm.Page(
-#     title="Flex - default - aggrid",
-#     layout=vm.Flex(),
-#     components=[vm.AgGrid(figure=dash_ag_grid(tips)) for i in range(3)],
-# )
-
-
-# page12 = vm.Page(
-#     title="Flex - gap - aggrid",
-#     layout=vm.Grid(grid=[[0]]),
-#     components=[vm.AgGrid(figure=dash_ag_grid(tips))],
-# )
-
-# page13 = vm.Page(
-#     title="Flex - row - aggrid",
-#     layout=vm.Flex(direction="row"),
-#     components=[vm.AgGrid(figure=dash_ag_grid(tips)) for i in range(3)],
-# )
-
-# page14 = vm.Page(
-#     title="Flex - default - table",
-#     layout=vm.Flex(),
-#     components=[vm.Table(figure=dash_data_table(tips)) for i in range(3)],
-# )
-
-
-# page15 = vm.Page(
-#     title="Flex - gap - table",
-#     layout=vm.Flex(gap="40px"),
-#     components=[vm.Table(figure=dash_data_table(tips)) for i in range(3)],
-# )
-
-# page16 = vm.Page(
-#     title="Flex - row - table",
-#     layout=vm.Flex(direction="row"),
-#     components=[vm.Table(figure=dash_data_table(tips)) for i in range(3)],
-# )
-
 dashboard = vm.Dashboard(
     title="Vizro dashboard for integration testing",
     pages=[page, page1, page2, page3],

--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -1,183 +1,350 @@
-"""Dev app to try things out."""
-
+# Vizro is an open-source toolkit for creating modular data visualization applications.
+# check out https://github.com/mckinsey/vizro for more info about Vizro
+# and checkout https://vizro.readthedocs.io/en/stable/ for documentation.
+import pandas as pd
 import vizro.plotly.express as px
-import vizro.models as vm
 from vizro import Vizro
-from dash import html
+import vizro.models as vm
+from vizro.actions import filter_interaction, export_data
+from vizro.tables import dash_ag_grid, dash_data_table
 
-from vizro.tables import dash_ag_grid
-from vizro.managers import data_manager
+tips = px.data.tips()
+gapminder = px.data.gapminder()
+iris = px.data.iris()
+iris["date_column"] = pd.date_range(
+    start=pd.to_datetime("2024-01-01"), periods=len(iris), freq="D"
+)
 
-
-df = px.data.gapminder()
-
-static_page = vm.Page(
-    title="Homepage with static data",
+page = vm.Page(
+    title="TABLE_INTERACTIONS_PAGE",
     components=[
         vm.Container(
-            title="Container with controls",
-            layout=vm.Grid(grid=[[0, 0], [1, 1], [1, 1], [1, 1]]),
-            variant="outlined",
+            title="container one",
+            # layout=vm.Flex(direction="column"),
             components=[
-                vm.Card(
-                    text="""
-                        # First dashboard page
-                        This pages shows the inclusion of markdown text in a page and how components
-                        can be structured using Layout.
-                    """,
-                ),
-                vm.AgGrid(
-                    figure=dash_ag_grid(data_frame=df),
-                    title="Gapminder Data Insights",
-                    header="""#### An Interactive Exploration of Global Health, Wealth, and Population""",
-                    footer="""SOURCE: **Plotly gapminder data set, 2024**""",
-                ),
-            ],
-            controls=[
-                vm.Filter(
-                    column="continent",
-                    selector=vm.Checklist(
-                        title="Continent (checklist)",
+                vm.Table(
+                    id="TABLE_INTERACTIONS_ID",
+                    title="Table Country",
+                    figure=dash_data_table(
+                        id="dash_data_table_country",
+                        data_frame=gapminder,
                     ),
-                )
+                    actions=[
+                        vm.Action(
+                            function=filter_interaction(
+                                targets=[
+                                    "LINE_INTERACTIONS_ID",
+                                ]
+                            )
+                        )
+                    ],
+                ),
             ],
-        )
+        ),
+        vm.Container(
+            title="container two",
+            components=[
+                vm.Graph(
+                    id="LINE_INTERACTIONS_ID",
+                    figure=px.line(
+                        gapminder,
+                        title="Line Country",
+                        x="year",
+                        y="gdpPercap",
+                        markers=True,
+                    ),
+                ),
+            ],
+        ),
     ],
     controls=[
-        vm.Filter(column="continent", selector=vm.Dropdown()),
-        vm.Filter(column="country", selector=vm.Dropdown(multi=False)),
-        # vm.Filter(
-        #     column="continent",
-        #     selector=vm.Dropdown(
-        #         options=[
-        #             {"label": "EUROPE", "value": "Europe"},
-        #             {"label": "AFRICA", "value": "Africa"},
-        #             {"label": "ASIA", "value": "Asia"},
-        #             # {"label": "AMERICAS", "value": "Americas"},
-        #             # {"label": "OCEANIA", "value": "Oceania"},
-        #         ],
-        #         # value=["Europe", "Africa", "Asia", "Americas", "Oceania"],
-        #         value="Asia",
-        #         multi=False,
-        #     ),
-        # ),
+        vm.Filter(
+            column="year",
+            targets=["TABLE_INTERACTIONS_ID"],
+            selector=vm.Dropdown(value=2007),
+        ),
+        vm.Filter(
+            column="continent",
+            targets=["TABLE_INTERACTIONS_ID"],
+            selector=vm.RadioItems(options=["Europe", "Africa", "Americas"]),
+        ),
     ],
 )
 
 
-def dynamic_data_load(number_of_rows: int = 1):
-    return px.data.gapminder().head(number_of_rows)
-
-
-data_manager["dynamic_df"] = dynamic_data_load
-
-
-dynamic_page = vm.Page(
-    title="Dynamic data",
+page1 = vm.Page(
+    title="FILTER_INTERACTIONS_PAGE",
+    layout=vm.Grid(grid=[[0], [2], [1]]),
     components=[
-        vm.Container(
-            components=[
-                vm.Graph(
-                    id="page-2-graph-1",
-                    figure=px.scatter("dynamic_df", x="gdpPercap", y="lifeExp", color="continent"),
-                )
-            ],
-            controls=[
-                vm.Filter(id="page-2-filter-1", column="country"),
-                vm.Filter(id="page-2-filter-2", column="continent", selector=vm.Checklist()),
-            ],
-        )
-    ],
-    controls=[
-        vm.Parameter(
-            id="page-2-parameter-1",
-            targets=["page-2-graph-1.data_frame.number_of_rows"],
-            selector=vm.Slider(
-                id="number-of-rows-slider",
-                title="Number of Rows",
-                min=1,
-                max=1000,
-                step=100,
-                value=1,
+        vm.Graph(
+            id="SCATTER_INTERACTIONS_ID",
+            figure=px.scatter(
+                iris,
+                x="sepal_length",
+                y="petal_width",
+                color="species",
+                custom_data=["species"],
             ),
-        )
-    ],
-)
-
-
-dynamic_page_all_combinations = vm.Page(
-    title="Dynamic data all combinations",
-    components=[
-        vm.Container(
-            components=[
-                vm.Graph(
-                    id="page-3-graph-1",
-                    figure=px.scatter("dynamic_df", x="gdpPercap", y="lifeExp", color="continent"),
-                )
+            actions=[
+                vm.Action(function=filter_interaction(targets=["BOX_INTERACTIONS_ID"])),
             ],
-        )
+        ),
+        vm.Card(id="CARD_INTERACTIONS_ID", text="### No data clicked."),
+        vm.Graph(
+            id="BOX_INTERACTIONS_ID",
+            figure=px.box(
+                iris,
+                x="sepal_length",
+                y="petal_width",
+                color="species",
+            ),
+        ),
     ],
     controls=[
-        vm.Filter(column="continent", selector=vm.Checklist()),
-        vm.Filter(column="continent"),
-        vm.Filter(column="continent", selector=vm.Dropdown(multi=False)),
-        vm.Filter(column="continent", selector=vm.Checklist(value=["Asia", "Americas"])),
-        vm.Filter(column="continent", selector=vm.Dropdown(multi=True, value=["Asia", "Americas"])),
-        vm.Filter(column="continent", selector=vm.Dropdown(multi=False, value="Asia")),
+        vm.Filter(
+            column="species",
+            targets=["BOX_INTERACTIONS_ID"],
+            selector=vm.Dropdown(id="DROPDOWN_INTER_FILTER"),
+        ),
         vm.Parameter(
-            targets=["page-3-graph-1.data_frame.number_of_rows"],
-            selector=vm.Slider(
-                title="Number of Rows",
-                min=1,
-                max=1000,
-                step=100,
-                value=1,
+            targets=["BOX_INTERACTIONS_ID.title"],
+            selector=vm.RadioItems(
+                id="RADIOITEM_INTER_PARAM", options=["red", "blue"], value="blue"
             ),
         ),
     ],
 )
 
-url_dynamic_page = vm.Page(
-    title="Dynamic data from URL",
+
+page2 = vm.Page(
+    title="FILTERS_PAGE",
     components=[
+        # vm.Tabs(
+        #     tabs=[
         vm.Container(
+            id="FILTERS_TAB_CONTAINER",
+            title="FILTERS_TAB_CONTAINER",
             components=[
-                vm.Graph(
-                    id="page-4-graph-1",
-                    figure=px.scatter("dynamic_df", x="gdpPercap", y="lifeExp", color="continent"),
+                vm.Container(
+                    id="FILTERS_COMPONENTS_CONTAINER",
+                    title="FILTERS_COMPONENTS_CONTAINER",
+                    layout=vm.Grid(grid=[[0, 1], [0, 1], [0, 2]]),
+                    components=[
+                        vm.Graph(
+                            id="SCATTER_GRAPH_ID",
+                            figure=px.scatter(
+                                iris,
+                                x="sepal_length",
+                                y="petal_width",
+                                color="sepal_width",
+                                height=450,
+                            ),
+                        ),
+                        vm.Graph(
+                            title="Where do we get more tips?",
+                            figure=px.bar(tips, y="tip", x="day"),
+                        ),
+                        vm.Graph(
+                            id="BOX_GRAPH_ID_2",
+                            figure=px.box(
+                                iris,
+                                x="sepal_length",
+                                y="petal_width",
+                                color="sepal_width",
+                            ),
+                        ),
+                    ],
                 )
             ],
-            controls=[
-                vm.Filter(id="page-3-filter-1", column="country", show_in_url=True),
-                vm.Filter(id="page-3-filter-2", column="continent", selector=vm.Checklist(), show_in_url=True),
-            ],
-        )
+        ),
+        #     ]
+        # ),
+        vm.Graph(
+            id="BOX_GRAPH_ID",
+            figure=px.box(
+                iris,
+                x="sepal_length",
+                y="petal_width",
+                color="sepal_width",
+            ),
+        ),
     ],
     controls=[
-        vm.Parameter(
-            id="page-4-parameter-1",
-            targets=["page-4-graph-1.data_frame.number_of_rows"],
-            show_in_url=True,
-            selector=vm.Slider(
-                id="number-of-rows-slider-url",
-                title="Number of Rows",
-                min=1,
-                max=1000,
-                step=100,
-                value=1,
+        vm.Filter(
+            column="species",
+            targets=["SCATTER_GRAPH_ID", "BOX_GRAPH_ID"],
+            selector=vm.Dropdown(id="DROPDOWN_FILTER_FILTERS_PAGE"),
+        ),
+        vm.Filter(
+            column="species",
+            targets=["SCATTER_GRAPH_ID", "BOX_GRAPH_ID"],
+            selector=vm.RadioItems(
+                id="RADIO_ITEMS_FILTER_FILTERS_PAGE",
+                options=["setosa", "versicolor", "virginica"],
             ),
-        )
+        ),
+        vm.Filter(
+            column="species",
+            targets=["SCATTER_GRAPH_ID"],
+            selector=vm.Checklist(
+                id="CHECK_LIST_FILTER_FILTERS_PAGE",
+                options=["setosa", "versicolor", "virginica"],
+            ),
+        ),
+        vm.Filter(
+            column="petal_width",
+            targets=["SCATTER_GRAPH_ID"],
+            selector=vm.Slider(id="SLIDER_FILTER_FILTERS_PAGE", step=0.5),
+        ),
+        vm.Filter(
+            column="sepal_length",
+            targets=["SCATTER_GRAPH_ID", "BOX_GRAPH_ID"],
+            selector=vm.RangeSlider(id="RANGE_SLIDER_FILTER_FILTERS_PAGE", step=1.0),
+        ),
     ],
 )
 
-dashboard = vm.Dashboard(
-    pages=[
-        static_page,
-        dynamic_page,
-        dynamic_page_all_combinations,
-        url_dynamic_page,
-    ]
+
+page3 = vm.Page(
+    title="EXTRAS_PAGE",
+    components=[
+        vm.Container(
+            extra={
+                "class_name": "bg-container",
+                "fluid": False,
+                "style": {"height": "900px"},
+            },
+            components=[
+                vm.Graph(
+                    figure=px.line(
+                        iris,
+                        x="sepal_length",
+                        y="petal_width",
+                        color="sepal_width",
+                    ),
+                ),
+                vm.Card(
+                    text="""
+    ![icon-top](assets/images/icons/content/features.svg)
+
+    Leads to the home page on click.
+    """,
+                    href="/",
+                    extra={"style": {"backgroundColor": "#377a6b"}},
+                ),
+                vm.Button(
+                    text="Export data",
+                    extra={"color": "success", "outline": True},
+                    actions=[
+                        vm.Action(
+                            function=export_data(
+                                file_format="csv",
+                            )
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    ],
+    controls=[
+        vm.Filter(
+            column="species",
+            selector=vm.Dropdown(
+                extra={
+                    "clearable": True,
+                    "placeholder": "Select an option...",
+                    "style": {"width": "150px"},
+                },
+            ),
+        ),
+        vm.Filter(
+            column="species",
+            selector=vm.RadioItems(
+                description="RADIOITEMS_TOOLTIP_TEXT",
+                options=["setosa", "versicolor", "virginica"],
+                extra={"inline": True},
+            ),
+        ),
+        vm.Filter(
+            column="species",
+            selector=vm.Checklist(
+                options=["setosa", "versicolor", "virginica"],
+                extra={"switch": True, "inline": True},
+            ),
+        ),
+        vm.Filter(
+            column="petal_width",
+            selector=vm.Slider(
+                step=0.5,
+                extra={"tooltip": {"placement": "bottom", "always_visible": True}},
+            ),
+        ),
+        vm.Filter(
+            column="sepal_length",
+            selector=vm.RangeSlider(
+                step=1.0,
+                extra={
+                    "tooltip": {"placement": "bottom", "always_visible": True},
+                    "pushable": 20,
+                },
+            ),
+        ),
+        vm.Filter(
+            column="date_column",
+            selector=vm.DatePicker(
+                title="Custom styled date picker",
+                range=False,
+                extra={
+                    "size": "lg",
+                    "valueFormat": "YYYY/MM/DD",
+                    "placeholder": "Select a date",
+                },
+            ),
+        ),
+    ],
 )
 
-if __name__ == "__main__":
-    Vizro().build(dashboard).run()
+
+# page11 = vm.Page(
+#     title="Flex - default - aggrid",
+#     layout=vm.Flex(),
+#     components=[vm.AgGrid(figure=dash_ag_grid(tips)) for i in range(3)],
+# )
+
+
+# page12 = vm.Page(
+#     title="Flex - gap - aggrid",
+#     layout=vm.Grid(grid=[[0]]),
+#     components=[vm.AgGrid(figure=dash_ag_grid(tips))],
+# )
+
+# page13 = vm.Page(
+#     title="Flex - row - aggrid",
+#     layout=vm.Flex(direction="row"),
+#     components=[vm.AgGrid(figure=dash_ag_grid(tips)) for i in range(3)],
+# )
+
+# page14 = vm.Page(
+#     title="Flex - default - table",
+#     layout=vm.Flex(),
+#     components=[vm.Table(figure=dash_data_table(tips)) for i in range(3)],
+# )
+
+
+# page15 = vm.Page(
+#     title="Flex - gap - table",
+#     layout=vm.Flex(gap="40px"),
+#     components=[vm.Table(figure=dash_data_table(tips)) for i in range(3)],
+# )
+
+# page16 = vm.Page(
+#     title="Flex - row - table",
+#     layout=vm.Flex(direction="row"),
+#     components=[vm.Table(figure=dash_data_table(tips)) for i in range(3)],
+# )
+
+dashboard = vm.Dashboard(
+    title="Vizro dashboard for integration testing",
+    pages=[page, page1, page2, page3],
+)
+Vizro().build(dashboard).run()

--- a/vizro-core/src/vizro/static/css/flex-grid.css
+++ b/vizro-core/src/vizro/static/css/flex-grid.css
@@ -44,3 +44,9 @@ as it may result in unexpected layouts.
 .flex-row .flex-item {
   flex: 1;
 }
+
+.container-fluid > .grid-layout {
+  flex: 1;
+  height: auto;
+  overflow: auto;
+}

--- a/vizro-core/src/vizro/static/css/layout.css
+++ b/vizro-core/src/vizro/static/css/layout.css
@@ -65,7 +65,9 @@
   justify-content: flex-end;
 }
 
-#header-right, #header-left, #header-custom {
+#header-right,
+#header-left,
+#header-custom {
   align-items: center;
   display: flex;
   gap: 8px;
@@ -149,7 +151,6 @@
   display: inline;
 }
 
-
 #collapse-icon.material-symbols-outlined {
   background-color: var(--left-side-bg);
   border: 1px solid var(--border-subtleAlpha01);
@@ -207,15 +208,26 @@ Current logic:
   }
 
   #header,
-  #right-side,
-  #left-side {
+  #right-side {
     zoom: 80%;
+  }
+}
+
+/* Apply specific styles for landscape orientation on small screen heights */
+@media screen and (height <= 576px) and (orientation: landscape) {
+  #nav-control-panel {
+    width: 260px;
+    font-size: 12px;
   }
 }
 
 @media screen and (width <= 576px) and (orientation: portrait) {
   body:has(#collapse-left-side.show) {
     overflow: hidden;
+  }
+
+  #nav-control-panel {
+    width: 324px;
   }
 
   #collapse-left-side.show:has(#nav-control-panel:not([hidden]))

--- a/vizro-core/src/vizro/static/css/layout.css
+++ b/vizro-core/src/vizro/static/css/layout.css
@@ -219,6 +219,19 @@ Current logic:
     width: 260px;
     font-size: 12px;
   }
+
+  #nav-control-panel .accordion-button,
+  #nav-control-panel .form-label,
+  #nav-control-panel .form-check-label,
+  #nav-control-panel .mantine-DatePickerInput-input,
+  #nav-control-panel .slider-text-input-field,
+  #nav-control-panel div.Select--multi .Select-value {
+    font-size: 12px;
+  }
+
+  #nav-control-panel .mantine-DatePickerInput-input {
+    min-height: 40px;
+  }
 }
 
 @media screen and (width <= 576px) and (orientation: portrait) {


### PR DESCRIPTION
## Description

Fixed: 

Issue 1: Resolved by updating the layout CSS to prevent grid layouts from overflowing their flex parents.

Issue 4: The problem occurred due to modifying the zoom level with CSS, which caused absolutely positioned elements to shift since their top and left coordinates scale independently of the parent container. The zoom adjustment has been removed from the left side, and the layout was corrected using CSS.

Investigated:

Issue 2: The issue was caused by the grid layout switching to display: flex on smaller screens, which broke the grid ordering.  

Issue 3: Plotly did not have enough space to render the scatter plot, resulting in the error: `Something went wrong with axis scaling`.


## Screenshot

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
