### PR TITLE
[Tidy] Fix flex layout

### DIFF
--- a/vizro-core/changelog.d/20250724_145237_vladimir_nikolic_flex_layout.md
+++ b/vizro-core/changelog.d/20250724_145237_vladimir_nikolic_flex_layout.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/src/vizro/static/css/flex-grid.css
+++ b/vizro-core/src/vizro/static/css/flex-grid.css
@@ -41,10 +41,6 @@ as it may result in unexpected layouts.
   width: 100%;
 }
 
-.flex-row .flex-item {
-  flex: 1;
-}
-
 .container-fluid > .grid-layout {
   flex: 1;
   height: auto;

--- a/vizro-core/src/vizro/static/css/tabs.css
+++ b/vizro-core/src/vizro/static/css/tabs.css
@@ -37,6 +37,10 @@ To ensure the dynamic height adjustment and prevent scrolling, the height must b
   height: 100%;
 }
 
+.tab-pane > div > .container-fluid .flex-row {
+  align-content: flex-start;
+}
+
 .inner-tabs-title {
   align-items: center;
   display: flex;


### PR DESCRIPTION
## Description

Close [#2002](https://github.com/McK-Internal/vizro-internal/issues/2002)

This PR resolves a layout issue caused by flex growth. 

- Removed flex: 1 from flex items to prevent them from expanding and overflowing their container.
- Aligned the flex row to flex-start to ensure consistent and predictable item positioning.

## Screenshot

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
