### PR TITLE
MCP Trust Score

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 [![Python version](https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue.svg)](https://pypi.org/project/vizro/) [![PyPI version](https://badge.fury.io/py/vizro.svg)](https://badge.fury.io/py/vizro) [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/mckinsey/vizro/blob/main/LICENSE.md) [![Documentation](https://readthedocs.org/projects/vizro/badge/?version=stable)](https://vizro.readthedocs.io/) [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/7858/badge)](https://www.bestpractices.dev/projects/7858)
 
+[![Trust Score](https://archestra.ai/mcp-catalog/api/badge/quality/mckinsey/vizro)](https://archestra.ai/mcp-catalog/mckinsey__vizro)
+
 [Documentation](https://vizro.readthedocs.io/en/stable/) | [Get Started](https://vizro.readthedocs.io/en/stable/pages/tutorials/first_dashboard/) | [Vizro examples gallery](http://vizro.mckinsey.com/)
 
 <picture>


### PR DESCRIPTION
Hi!

This PR adds the "Trust Score" badge from our new Open Source MCP catalog.

Our catalog evaluates MCP servers based on technical quality—like protocol feature implementation and dependency health—rather than vanity metrics like GitHub stars.

The scoring process is fully transparent and reproducible:
- Evaluation Script: https://github.com/archestra-ai/website/blob/main/app/app/mcp-catalog/scripts/evaluate-catalog.ts
- Your Server's Page: https://archestra.ai/mcp-catalog/mckinsey__vizro

The badge is designed to be respectful to the structure of your readme, example: [![Trust Score](https://archestra.ai/mcp-catalog/api/badge/quality/topoteretes/cognee/cognee-mcp)](https://archestra.ai/mcp-catalog/topoteretes__cognee__cognee-mcp)

Projects like Grafana MCP (https://github.com/grafana/mcp-grafana) are already participating. 

We believe that transparent and truly open source MCP catalog should help the community to identify great MCP servers like yours 😊

We'd appreciate your support by merging this PR!