### PR TITLE
Ignore dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+ignore:
+  - dependency-name: "urllib3"
+    versions: [ ">=2.2.3" ]
+  - dependency-name: "requests"
+    versions: [ ">=2.32.3" ]


### PR DESCRIPTION
## Description

So we've always been closing these PRs: https://github.com/mckinsey/vizro/pulls?q=is%3Apr+is%3Aclosed+bump+the+pip To prevent Dependabot from creating them permanently, we should ignore them. These are not direct dependencies for our project, so it's safe to do so. These PRs only affect our demo dashboards, where the requirements file is generated automatically, and therefore should not be modified manually.



## Screenshot

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
