### PR TITLE
Feat/add action trigger builtin argument

### DIFF
--- a/vizro-core/changelog.d/20250901_091405_petar_pejovic_add_action_trigger_builtin_argument.md
+++ b/vizro-core/changelog.d/20250901_091405_petar_pejovic_add_action_trigger_builtin_argument.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -78,18 +78,6 @@ page_table_of_contents = vm.Page(
             figure=dash_ag_grid(
                 columnSize="autoSize",
                 dashGridOptions={"pagination": False},
-                getRowStyle={
-                    "styleConditions": [
-                        {
-                            "condition": "params.data.Component == 'Filter'",
-                            "style": {"backgroundColor": "rgb(40, 80, 120)"},
-                        },
-                        {
-                            "condition": "params.data.Component == 'Parameter'",
-                            "style": {"backgroundColor": "rgb(40, 80, 120)"},
-                        },
-                    ],
-                },
                 data_frame=pd.DataFrame(
                     columns=[
                         "Component",
@@ -276,7 +264,6 @@ page_figures_figures = vm.Page(
                         "table-2-id.figure",
                         "figure-2-id.figure",
                     ],
-                    # TODO-REVIEWER-CHECK: This is also a valid output
                     # outputs=[
                     #     "graph-2-id",
                     #     "aggrid-2-id",
@@ -301,8 +288,6 @@ page_ag_grid_underlying_id_shortcuts = vm.Page(
             title="Click button to update the figure",
             figure=dash_ag_grid(df_3_rows, dashGridOptions={"rowSelection": "multiple"}),
             actions=[
-                # TODO-REVIEWER-CHECK: Before this PR, users had to assign the underlying-id to the dash_ag_grid
-                #  and then to input it like "underlying_ag_grid_id.cellClicked"
                 vm.Action(
                     function=capture("action")(lambda x: str(x))("outer-aggrid-3-id.cellClicked"), outputs=["card-3-id"]
                 )
@@ -320,8 +305,6 @@ page_ag_grid_underlying_id_shortcuts = vm.Page(
                 vm.Action(
                     function=action_select_ag_grid_rows("trigger-aggrid-3-id-button-id.n_clicks"),
                     outputs=[
-                        # TODO-REVIEWER-CHECK: Before this PR, users had to assign the underlying-id to the dash_ag_grid
-                        #  and then to output it like "underlying_ag_grid_id.selectedRows"
                         "outer-aggrid-3-id.selectedRows",
                     ],
                 )
@@ -414,7 +397,6 @@ page_card_text_components = vm.Page(
                         "text-id.text",
                         "button-id.text",
                     ],
-                    # TODO-REVIEWER-CHECK: This is also a valid output
                     # outputs=[
                     #   "card-id",
                     #   "text-id",
@@ -591,7 +573,6 @@ page_tooltip_text_icon = vm.Page(
                     outputs=[
                         "tooltip-id.text",
                     ],
-                    # TODO-REVIEWER-CHECK: This is also a valid output
                     # outputs=[
                     #     "text-area-tooltip-id.description"
                     # ]
@@ -758,8 +739,6 @@ page_filters_default_title_description = vm.Page(
             id="trigger-filter-all-selectors-default-title-description-button-id",
             actions=[
                 vm.Action(
-                    # TODO-REVIEWER-CHECK: Before this PR, users had to assign the filter selector and selector's id
-                    #  and then to output it like "selector-id.title" or "selector-id.description"
                     function=action_return_text(
                         "trigger-filter-all-selectors-default-title-description-button-id.n_clicks"
                     ),
@@ -792,8 +771,6 @@ page_filters_default_title_description = vm.Page(
                         "trigger-filter-all-selectors-default-title-description-button-id.n_clicks"
                     ),
                     outputs=[
-                        # TODO-REVIEWER-CHECK: Before this PR, users had to assign the filter selector and selector's id
-                        #  and then to output it like "selector-id" or "selector-id.value"
                         "filter-checklist-id",
                         "filter-dropdown-id",
                         "filter-radio-items-id",
@@ -882,8 +859,6 @@ page_filters_underlying_value_property = vm.Page(
             id="trigger-filter-all-selectors-underlying-value-property-button-id",
             actions=[
                 vm.Action(
-                    # TODO-REVIEWER-CHECK: Before this PR, users had to assign the filter selector and selector's id
-                    #  and then to output it like "selector-id" or "selector-id.value"
                     function=update_control_values(
                         "trigger-filter-all-selectors-underlying-value-property-button-id.n_clicks",
                         "filter-checklist-2-id.value",
@@ -1002,8 +977,6 @@ page_parameters_default_title_description = vm.Page(
             id="trigger-parameter-all-selectors-default-title-description-button-id",
             actions=[
                 vm.Action(
-                    # TODO-REVIEWER-CHECK: Before this PR, users had to assign the parameter selector's id
-                    #  and then to output it like "selector-id.title" or "selector-id.description"
                     function=action_return_text(
                         "trigger-parameter-all-selectors-default-title-description-button-id.n_clicks"
                     ),
@@ -1032,8 +1005,6 @@ page_parameters_default_title_description = vm.Page(
                     ],
                 ),
                 vm.Action(
-                    # TODO-REVIEWER-CHECK: Before this PR, users had to assign the parameter selector and selector's id
-                    #  and then to output it like "selector-id" or "selector-id.value"
                     function=update_control_values(
                         "trigger-parameter-all-selectors-default-title-description-button-id.n_clicks"
                     ),
@@ -1126,8 +1097,6 @@ page_parameters_underlying_value_property = vm.Page(
             id="trigger-parameter-all-selectors-underlying-value-property-button-id",
             actions=[
                 vm.Action(
-                    # TODO-REVIEWER-CHECK: Before this PR, users had to assign the parameter selector's id
-                    #  and then to output it like "selector-id" or "selector-id.value"
                     function=update_control_values(
                         "trigger-parameter-all-selectors-underlying-value-property-button-id.n_clicks",
                         "parameter-checklist-2-id.value",
@@ -1167,8 +1136,6 @@ page_filter_interaction_over_control = vm.Page(
                 vm.Graph(
                     id="source_graph",
                     figure=px.scatter(df, x="sepal_width", y="sepal_length", color="species", custom_data=["species"]),
-                    # TODO-REVIEWER-CHECK: Before this PR, users had to assign the filter selector and selector's id
-                    #  and then to output it like "filter-selector-id" or "filter-selector-id.value"
                     actions=vm.Action(
                         function=capture("action")(lambda x: x["points"][0]["customdata"][0])("source_graph.clickData"),
                         outputs="target_filter",
@@ -1181,6 +1148,117 @@ page_filter_interaction_over_control = vm.Page(
             controls=[vm.Filter(id="target_filter", column="species")],
             components=[vm.AgGrid(figure=dash_ag_grid(df))],
         ),
+    ],
+)
+
+
+# === _trigger ===
+# ====== Page using _trigger: Filter interaction over a control ======
+
+page_filter_interaction_over_control_using_trigger = vm.Page(
+    title="Filter interaction over a control using _trigger",
+    id="Filter interaction over a control using _trigger",
+    components=[
+        vm.Container(
+            title="Source graph",
+            components=[
+                vm.Graph(
+                    id="source_graph_trigger_page",
+                    figure=px.scatter(df, x="sepal_width", y="sepal_length", color="species", custom_data=["species"]),
+                    actions=vm.Action(
+                        # TODO-REVIEWER-CHECK: Before this PR, users had to assign the trigger-id to the actions
+                        #  function like:"source_graph.clickData"
+                        function=capture("action")(lambda _trigger: _trigger["points"][0]["customdata"][0])(),
+                        outputs="_trigger_page_target_filter",
+                    ),
+                ),
+            ],
+        ),
+        vm.Container(
+            title="Target table",
+            controls=[vm.Filter(id="_trigger_page_target_filter", column="species")],
+            components=[vm.AgGrid(figure=dash_ag_grid(df))],
+        ),
+    ],
+)
+
+
+# ====== Page with chain of actions all using _trigger
+
+
+@capture("action")
+def propagate_trigger_to_output(_trigger):
+    return f"_trigger: {_trigger}"
+
+
+page_chain_of_actions_all_using_trigger = vm.Page(
+    title="Chain of actions all using _trigger",
+    id="Chain of actions all using _trigger",
+    components=[
+        vm.Card(id="card-1", text="Action 1 output"),
+        vm.Card(id="card-2", text="Action 2 output"),
+        vm.Card(id="card-3", text="Action 3 output"),
+    ],
+    controls=[
+        vm.Button(
+            actions=[
+                vm.Action(function=propagate_trigger_to_output(), outputs="card-1"),
+                vm.Action(function=propagate_trigger_to_output(), outputs="card-2"),
+                vm.Action(function=propagate_trigger_to_output(), outputs="card-3"),
+            ]
+        )
+    ],
+)
+
+
+# ====== Page with chain of actions all using _trigger and other inputs
+
+
+@capture("action")
+def propagate_trigger_and_other_inputs_to_output(other_input_1, _controls, other_input_2, _trigger):
+    return (
+        f"other_input_1: {other_input_1}, _controls: {_controls}, other_input_2: {other_input_2}, _trigger: {_trigger}"
+    )
+
+
+vm.Page.add_type("components", vm.RadioItems)
+vm.Page.add_type("components", vm.Slider)
+
+page_chain_of_actions_all_using_trigger_and_other_inputs = vm.Page(
+    title="Chain of actions all using _trigger and other inputs",
+    id="Chain of actions all using _trigger and other inputs",
+    components=[
+        vm.RadioItems(id="other_input_1", options=["A", "B", "C"], value="A"),
+        vm.Slider(id="other_input_2", min=0, max=10, value=0),
+        vm.Card(id="card-2-1", text="Action 1 output"),
+        vm.Card(id="card-2-2", text="Action 2 output"),
+        vm.Card(id="card-2-3", text="Action 3 output"),
+        vm.Graph(figure=px.scatter(df, x="sepal_width", y="sepal_length", color="species")),
+    ],
+    controls=[
+        vm.Button(
+            actions=[
+                vm.Action(
+                    function=propagate_trigger_and_other_inputs_to_output(
+                        "other_input_1", other_input_2="other_input_2"
+                    ),
+                    outputs="card-2-1",
+                ),
+                vm.Action(
+                    function=propagate_trigger_and_other_inputs_to_output(
+                        "other_input_1", other_input_2="other_input_2"
+                    ),
+                    outputs="card-2-2",
+                ),
+                vm.Action(
+                    function=propagate_trigger_and_other_inputs_to_output(
+                        "other_input_1", other_input_2="other_input_2"
+                    ),
+                    outputs="card-2-3",
+                ),
+            ]
+        ),
+        vm.Filter(id="_trigger_page_filter", column="species"),
     ],
 )
 
@@ -1203,6 +1281,9 @@ dashboard = vm.Dashboard(
         page_parameters_default_title_description,
         page_parameters_underlying_value_property,
         page_filter_interaction_over_control,
+        page_filter_interaction_over_control_using_trigger,
+        page_chain_of_actions_all_using_trigger,
+        page_chain_of_actions_all_using_trigger_and_other_inputs,
     ],
     navigation=vm.Navigation(
         pages={
@@ -1219,13 +1300,18 @@ dashboard = vm.Dashboard(
                 "Form Components - title/description",
                 "Tooltip - text and icon",
             ],
-            "**NEW** Controls": [
+            "Controls": [
                 "Filter is output of the OPL and DFP",
                 "Filter all selectors - default/title/description",
                 "Filter all selectors - underlying value property",
                 "Parameter all selectors - default/title/description",
                 "Parameter all selectors - underlying value property",
                 "Filter interaction over a control",
+            ],
+            "**NEW**: _trigger": [
+                "Filter interaction over a control using _trigger",
+                "Chain of actions all using _trigger",
+                "Chain of actions all using _trigger and other inputs",
             ],
         }
     ),

--- a/vizro-core/src/vizro/actions/_abstract_action.py
+++ b/vizro-core/src/vizro/actions/_abstract_action.py
@@ -47,6 +47,8 @@ class _AbstractAction(_BaseAction, abc.ABC):
 
         * `_controls`: state of all the controls on the page. The format of is not yet decided and is likely to
         change in future versions.
+
+        * `_trigger`: the value of the component's property that triggered the first action in the chain.
         """
         pass
 

--- a/vizro-core/src/vizro/models/_models_utils.py
+++ b/vizro-core/src/vizro/models/_models_utils.py
@@ -106,20 +106,17 @@ def make_actions_chain(self):
         else:
             converted_actions.append(action)
 
+    model_action_trigger = self._action_triggers["__default__"]
     for i, action in enumerate(converted_actions):
-        first_in_chain = i == 0
+        # First action in the chain uses the model's specified trigger. # All subsequent actions in the chain are
+        # triggered by the previous action's completion.
+        # In the future, we would allow multiple keys in the _action_triggers dictionary, and then we'd need to look up
+        # the relevant entry here. For now there's just __default__ so we always use that.
+        action._trigger = model_action_trigger if i == 0 else f"{converted_actions[i - 1].id}_finished.data"
 
-        if first_in_chain:
-            # First action in the chain uses the model's specified trigger. In future we would allow multiple keys in
-            # the _action_triggers dictionary and then we'd need to look up the relevant entry here. For now there's
-            # just __default__ so we always use that.
-            trigger = self._action_triggers["__default__"]
-        else:
-            # All subsequent actions in the chain are triggered by the previous action's completion.
-            trigger = f"{converted_actions[i - 1].id}_finished.data"
+        # Every action has to know about the model action trigger to properly set the action's builtin arg "_trigger".
+        action._first_in_chain_trigger = model_action_trigger
 
-        action._trigger = trigger
-        action._first_in_chain = first_in_chain
         # The actions chain guard should be called only for on page load.
         action._prevent_initial_call_of_guard = not isinstance(action, _on_page_load)
 

--- a/vizro-core/tests/unit/vizro/actions/test_abstract_action.py
+++ b/vizro-core/tests/unit/vizro/actions/test_abstract_action.py
@@ -101,8 +101,8 @@ class TestAbstractActionInstantiation:
     def test_action_first_in_chain_mandatory_only(self):
         action = action_with_no_args(id="action-id")
 
-        # Private attribute set by parent component's validation, not Action's.
-        action._first_in_chain = True
+        # Mock private attribute set by parent component's validation, not Action's.
+        action._first_in_chain_trigger = action._trigger = "x.x"
 
         assert hasattr(action, "id")
         assert hasattr(action, "function")
@@ -121,8 +121,9 @@ class TestAbstractActionInstantiation:
     def test_action_not_first_in_chain_mandatory_only(self):
         action = action_with_no_args(id="action-id")
 
-        # Private attribute set by parent component's validation, not Action's.
-        action._first_in_chain = False
+        # Mock private attribute set by parent component's validation, not Action's.
+        action._first_in_chain_trigger = "x.x"
+        action._trigger = "y.y"
 
         assert hasattr(action, "id")
         assert hasattr(action, "function")
@@ -194,6 +195,10 @@ class TestAbstractActionInputs:
         self, action_class, inputs, expected_transformed_inputs, manager_for_testing_actions_output_input_prop
     ):
         action = action_class(**inputs)
+
+        # Mock private attribute set by parent component's validation, not Action's.
+        action._first_in_chain_trigger = action._trigger = "x.x"
+
         assert action._transformed_inputs == expected_transformed_inputs
 
     @pytest.mark.parametrize(
@@ -207,7 +212,7 @@ class TestAbstractActionInputs:
     )
     def test_inputs_invalid_type(self, input):
         with pytest.raises(ValidationError):
-            action_with_one_runtime_arg(arg_1=input)._transformed_inputs
+            action_with_one_runtime_arg(arg_1=input)
 
     @pytest.mark.parametrize(
         "input",
@@ -216,11 +221,16 @@ class TestAbstractActionInputs:
         ],
     )
     def test_inputs_invalid_model_id(self, input):
+        action = action_with_one_runtime_arg(arg_1=input)
+
+        # Mock private attribute set by parent component's validation, not Action's.
+        action._first_in_chain_trigger = action._trigger = "x.x"
+
         with pytest.raises(
             KeyError,
             match="Model with ID .* not found. Please provide a valid component ID.",
         ):
-            action_with_one_runtime_arg(arg_1=input)._transformed_inputs
+            action._transformed_inputs
 
     @pytest.mark.parametrize(
         "input",
@@ -233,19 +243,28 @@ class TestAbstractActionInputs:
         ],
     )
     def test_inputs_invalid_dot_syntax(self, input):
+        action = action_with_one_runtime_arg(arg_1=input)
+
+        # Mock private attribute set by parent component's validation, not Action's.
+        action._first_in_chain_trigger = action._trigger = "x.x"
+
         with pytest.raises(
             ValueError,
             match="Invalid input format .*. Expected format is '<model_id>' or '<model_id>.<argument_name>'.",
         ):
-            action_with_one_runtime_arg(arg_1=input)._transformed_inputs
+            action._transformed_inputs
 
     def test_inputs_invalid_missing_action_attribute(self, manager_for_testing_actions_output_input_prop):
+        action = action_with_one_runtime_arg(arg_1="known_model_with_no_default_props")
+
+        # Mock private attribute set by parent component's validation, not Action's.
+        action._first_in_chain_trigger = action._trigger = "x.x"
+
         with pytest.raises(
             AttributeError,
             match="Model with ID 'known_model_with_no_default_props' does not have implicit input properties defined. "
             "Please specify the input explicitly as 'known_model_with_no_default_props.<property>'.",
         ):
-            action = action_with_one_runtime_arg(arg_1="known_model_with_no_default_props")._transformed_inputs
             action._transformed_inputs
 
     # TODO: Adjust this test when _controls becomes a public field. Should demonstrate that a runtime arg called
@@ -254,7 +273,14 @@ class TestAbstractActionInputs:
     @pytest.mark.xfail(reason="Private fields can't be overwritten")
     def test_builtin_runtime_arg_with_overwritten_controls(self):
         action = action_with_builtin_runtime_arg()
-        assert action._transformed_inputs == {"_controls": State("component", "property")}
+
+        # Mock private attribute set by parent component's validation, not Action's.
+        action._first_in_chain_trigger = action._trigger = "x.x"
+
+        assert action._transformed_inputs == {
+            "_controls": State("component", "property"),
+            "_trigger": State("x", "x"),
+        }
 
 
 class TestBuiltinRuntimeArgs:
@@ -262,6 +288,10 @@ class TestBuiltinRuntimeArgs:
 
     def test_builtin_runtime_arg_controls(self, page_actions_builtin_controls):
         action = action_with_builtin_runtime_arg()
+
+        # Mock private attribute set by parent component's validation, not Action's.
+        action._first_in_chain_trigger = action._trigger = "x.x"
+
         assert action._transformed_inputs == page_actions_builtin_controls
 
 

--- a/vizro-core/tests/unit/vizro/models/_action/test_action.py
+++ b/vizro-core/tests/unit/vizro/models/_action/test_action.py
@@ -45,8 +45,8 @@ class TestLegacyActionInstantiation:
         # inputs=[] added to force action to be legacy
         action = Action(id="action-id", function=function, inputs=[])
 
-        # Private attribute set by parent component's validation, not Action's.
-        action._first_in_chain = True
+        # Mock private attribute set by parent component's validation, not Action's.
+        action._first_in_chain_trigger = action._trigger = "x.x"
 
         assert hasattr(action, "id")
         assert action.function is function
@@ -69,8 +69,9 @@ class TestLegacyActionInstantiation:
         # inputs=[] added to force action to be legacy
         action = Action(id="action-id", function=function, inputs=[])
 
-        # Private attribute set by parent component's validation, not Action's.
-        action._first_in_chain = False
+        # Mock private attribute set by parent component's validation, not Action's.
+        action._first_in_chain_trigger = "x.x"
+        action._trigger = "y.y"
 
         assert hasattr(action, "id")
         assert action.function is function
@@ -367,8 +368,8 @@ class TestActionInstantiation:
         function = action_with_no_args()
         action = Action(id="action-id", function=function)
 
-        # Private attribute set by parent component's validation, not Action's.
-        action._first_in_chain = True
+        # Mock private attribute set by parent component's validation, not Action's.
+        action._first_in_chain_trigger = action._trigger = "x.x"
 
         assert hasattr(action, "id")
         assert action.function is function
@@ -388,8 +389,9 @@ class TestActionInstantiation:
         function = action_with_no_args()
         action = Action(id="action-id", function=function)
 
-        # Private attribute set by parent component's validation, not Action's.
-        action._first_in_chain = False
+        # Mock private attribute set by parent component's validation, not Action's.
+        action._first_in_chain_trigger = "x.x"
+        action._trigger = "y.y"
 
         assert hasattr(action, "id")
         assert action.function is function
@@ -448,6 +450,10 @@ class TestActionInputs:
         self, action_function, inputs, expected_transformed_inputs, manager_for_testing_actions_output_input_prop
     ):
         action = Action(function=action_function(**inputs))
+
+        # Mock private attribute set by parent component's validation, not Action's.
+        action._first_in_chain_trigger = action._trigger = "x.x"
+
         assert action._transformed_inputs == expected_transformed_inputs
 
     @pytest.mark.parametrize(
@@ -466,8 +472,13 @@ class TestActionInputs:
     )
     @pytest.mark.xfail(reason="Validation will only be performed once legacy actions are removed")
     def test_runtime_inputs_invalid(self, input):
+        action = Action(function=action_with_one_arg(input))
+
+        # Mock private attribute set by parent component's validation, not Action's.
+        action._first_in_chain_trigger = action._trigger = "x.x"
+
         with pytest.raises(ValidationError):
-            Action(function=action_with_one_arg(input))._transformed_inputs
+            action._transformed_inputs
 
     def test_inputs_invalid_missing_action_attribute(self, manager_for_testing_actions_output_input_prop):
         with pytest.raises(
@@ -476,6 +487,11 @@ class TestActionInputs:
             "Please specify the input explicitly as 'known_model_with_no_default_props.<property>'.",
         ):
             action = Action(function=action_with_one_arg("known_model_with_no_default_props"))
+
+            # Mock private attribute set by parent component's validation, not Action's.
+            action._first_in_chain_trigger = "x.x"
+            action._trigger = "x.x"
+
             action._transformed_inputs
 
 
@@ -484,6 +500,10 @@ class TestBuiltinRuntimeArgs:
 
     def test_builtin_runtime_arg_controls(self, page_actions_builtin_controls):
         action = Action(function=action_with_builtin_runtime_arg())
+
+        # Mock private attribute set by parent component's validation, not Action's.
+        action._first_in_chain_trigger = action._trigger = "x.x"
+
         assert action._transformed_inputs == page_actions_builtin_controls
 
 

--- a/vizro-core/tests/unit/vizro/models/_action/test_action.py
+++ b/vizro-core/tests/unit/vizro/models/_action/test_action.py
@@ -25,7 +25,7 @@ def action_with_two_args(arg_1, arg_2):
 
 
 @capture("action")
-def action_with_builtin_runtime_arg(arg_1, _controls):
+def action_with_builtin_runtime_args(arg_1, _trigger, _controls):
     pass
 
 
@@ -46,7 +46,7 @@ class TestLegacyActionInstantiation:
         action = Action(id="action-id", function=function, inputs=[])
 
         # Mock private attribute set by parent component's validation, not Action's.
-        action._first_in_chain_trigger = action._trigger = "x.x"
+        action._first_in_chain_trigger = action._trigger = "trigger.property"
 
         assert hasattr(action, "id")
         assert action.function is function
@@ -70,8 +70,8 @@ class TestLegacyActionInstantiation:
         action = Action(id="action-id", function=function, inputs=[])
 
         # Mock private attribute set by parent component's validation, not Action's.
-        action._first_in_chain_trigger = "x.x"
-        action._trigger = "y.y"
+        action._first_in_chain_trigger = "trigger.property"
+        action._trigger = "trigger_2.property"
 
         assert hasattr(action, "id")
         assert action.function is function
@@ -369,7 +369,7 @@ class TestActionInstantiation:
         action = Action(id="action-id", function=function)
 
         # Mock private attribute set by parent component's validation, not Action's.
-        action._first_in_chain_trigger = action._trigger = "x.x"
+        action._first_in_chain_trigger = action._trigger = "trigger.property"
 
         assert hasattr(action, "id")
         assert action.function is function
@@ -390,8 +390,8 @@ class TestActionInstantiation:
         action = Action(id="action-id", function=function)
 
         # Mock private attribute set by parent component's validation, not Action's.
-        action._first_in_chain_trigger = "x.x"
-        action._trigger = "y.y"
+        action._first_in_chain_trigger = "trigger.property"
+        action._trigger = "trigger_2.property"
 
         assert hasattr(action, "id")
         assert action.function is function
@@ -428,21 +428,22 @@ class TestActionInputs:
                 {"arg_1": State("component", "property"), "arg_2": State("component", "property")},
             ),
             (
-                action_with_builtin_runtime_arg,
+                action_with_builtin_runtime_args,
                 {},
                 {
                     "_controls": {
                         "filters": [State("known_dropdown_filter_id", "value")],
                         "parameters": [],
                         "filter_interaction": [],
-                    }
+                    },
+                    "_trigger": State("trigger", "property"),
                 },
             ),
             (
                 # Case that a builtin runtime argument is overridden by a user supplied one.
-                action_with_builtin_runtime_arg,
+                action_with_builtin_runtime_args,
                 {"_controls": "component.property"},
-                {"_controls": State("component", "property")},
+                {"_controls": State("component", "property"), "_trigger": State("trigger", "property")},
             ),
         ],
     )
@@ -452,7 +453,7 @@ class TestActionInputs:
         action = Action(function=action_function(**inputs))
 
         # Mock private attribute set by parent component's validation, not Action's.
-        action._first_in_chain_trigger = action._trigger = "x.x"
+        action._first_in_chain_trigger = action._trigger = "trigger.property"
 
         assert action._transformed_inputs == expected_transformed_inputs
 
@@ -475,7 +476,7 @@ class TestActionInputs:
         action = Action(function=action_with_one_arg(input))
 
         # Mock private attribute set by parent component's validation, not Action's.
-        action._first_in_chain_trigger = action._trigger = "x.x"
+        action._first_in_chain_trigger = action._trigger = "trigger.property"
 
         with pytest.raises(ValidationError):
             action._transformed_inputs
@@ -489,8 +490,7 @@ class TestActionInputs:
             action = Action(function=action_with_one_arg("known_model_with_no_default_props"))
 
             # Mock private attribute set by parent component's validation, not Action's.
-            action._first_in_chain_trigger = "x.x"
-            action._trigger = "x.x"
+            action._first_in_chain_trigger = action._trigger = "trigger.property"
 
             action._transformed_inputs
 
@@ -499,12 +499,17 @@ class TestBuiltinRuntimeArgs:
     """Test the actual values of the runtime args are correct in a real scenario."""
 
     def test_builtin_runtime_arg_controls(self, page_actions_builtin_controls):
-        action = Action(function=action_with_builtin_runtime_arg())
+        action = Action(function=action_with_builtin_runtime_args())
 
         # Mock private attribute set by parent component's validation, not Action's.
-        action._first_in_chain_trigger = action._trigger = "x.x"
+        action._first_in_chain_trigger = action._trigger = "trigger.property"
 
-        assert action._transformed_inputs == page_actions_builtin_controls
+        expected_transformed_input = {
+            **page_actions_builtin_controls,
+            "_trigger": State("trigger", "property"),
+        }
+
+        assert action._transformed_inputs == expected_transformed_input
 
 
 class TestActionOutputs:

--- a/vizro-core/tests/unit/vizro/models/test_models_utils.py
+++ b/vizro-core/tests/unit/vizro/models/test_models_utils.py
@@ -115,8 +115,8 @@ class TestMakeActionsChain:
         # Assign actions to a Vizro model so that make_actions_chain can be tested
         MockModelWithActions(id="model-id", actions=[action_1, action_2])
 
-        assert action_1._first_in_chain is True
-        assert action_2._first_in_chain is False
+        assert action_1._first_in_chain_trigger == "model-id.default_property"
+        assert action_2._first_in_chain_trigger == "model-id.default_property"
 
         assert action_1._trigger == "model-id.default_property"
         assert action_2._trigger == "action-1-id_finished.data"


### PR DESCRIPTION
Closes https://github.com/McK-Internal/vizro-internal/issues/2119

## Description
`_trigger` is a built-in keyword argument that can be used in actions. This should give a Dash `State` that corresponds to the trigger of the first action in the actions chain.

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
