### PR TITLE
[Docs] Update cheatsheet to replace link to Vizro docs with relative link

### DIFF
--- a/vizro-core/docs/pages/cheatsheet/cheatsheet.html
+++ b/vizro-core/docs/pages/cheatsheet/cheatsheet.html
@@ -29,9 +29,7 @@
           <p class="header-subtitle">Essential commands & syntax reference</p>
         </div>
       </div>
-      <a href="../../" class="cta-button">
-        Go to Vizro docs <span>→</span>
-      </a>
+      <a href="../../" class="cta-button"> Go to Vizro docs <span>→</span> </a>
     </header>
     <div class="main-container">
       <div class="sidebar">

--- a/vizro-core/docs/pages/cheatsheet/cheatsheet.html
+++ b/vizro-core/docs/pages/cheatsheet/cheatsheet.html
@@ -29,7 +29,7 @@
           <p class="header-subtitle">Essential commands & syntax reference</p>
         </div>
       </div>
-      <a href="https://vizro.readthedocs.io/en/stable/" class="cta-button">
+      <a href="../../" class="cta-button">
         Go to Vizro docs <span>→</span>
       </a>
     </header>


### PR DESCRIPTION
## Description
One line change to enable relative link to whichever version of docs the user is reading.

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
