### PR TITLE
[CI] Test `dash==4.0.0rc1`

### DIFF
--- a/vizro-core/hatch.toml
+++ b/vizro-core/hatch.toml
@@ -161,7 +161,7 @@ VIZRO_LOG_LEVEL = "DEBUG"
 
 [envs.lower-bounds]
 extra-dependencies = [
-  "dash==3.1.1",
+  "dash==4.0.0rc1",
   "dash-bootstrap-components==2.0.0",
   "dash-ag-grid==31.3.1",
   "dash-mantine-components==1.0.0",

--- a/vizro-core/pyproject.toml
+++ b/vizro-core/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13"
 ]
 dependencies = [
-  "dash>=3.1.1",  # must be >=3.1.1 to include bugfixes for persistence and suppress_callback_exception
+  "dash==4.0.0rc1",  # must be >=3.1.1 to include bugfixes for persistence and suppress_callback_exception
   "dash_bootstrap_components>=2",  # 2.0.0 needed to support dash>=3.0.0
   "dash-ag-grid>=31.3.1",  # 31.3.1 needed to support dash>=3.0.0
   "dash_mantine_components>=1",  # 1.0.0 needed to support dash>=3.0.0


### PR DESCRIPTION
## Description
Release https://github.com/plotly/dash/releases (see all 4.0.X)

Closes https://github.com/McK-Internal/vizro-internal/issues/2161

This PR was opened to check the CI tests and to record observations from the testing process.

## TODO
- [x] - Check CI tests -> ❌ they fail
- [x] - Investigate and document new features -> Currently, there are several dcc components that are modernised in the `4.0.0rc1`: `dcc.Slider`, `dcc.RangeSlider`, `dcc.Input` and `dcc.Dropdown`.

New `dcc.Dropdown` introduced "Select All"/"Deselect All" which is fantastic. This thing however breaks the current Vizro Dropdown select-all implementation, but will enable us to simplify the hacky custom dropdown select-all solution. 🎉  

I'm linking here related tickets for visibility:


## Next steps
1. Set upper bound to `dash<4` @petar-qb 
2. Create tickets for adjusting Vizro to support the new `dash>=4`


## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
