### PR TITLE
[PoC] Vizro action logs in debug mode using hooks.devtools

### DIFF
--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -10,219 +10,51 @@ from vizro.tables import dash_ag_grid
 
 df = px.data.iris()
 
+import dash_bootstrap_components as dbc
+from dash import hooks, html, clientside_callback, Output, Input, State
 
-page_1 = vm.Page(
-    title="Graph filter interactions and drill-through source page",
-    components=[
-        vm.Container(
-            title="Two filter interactions within Page 1",
-            layout=vm.Grid(grid=[[0, 1]]),
-            variant="outlined",
-            components=[
-                vm.Graph(
-                    title="Filter interaction to AgGrid below",
-                    figure=px.scatter(df, x="sepal_width", y="sepal_length", color="species", custom_data=["species"]),
-                    actions=[
-                        set_control(control="p1_filter_1", value="species"),
-                        set_control(control="p1_filter_2", value="customdata[0]"),
-                    ],
-                ),
-                vm.Container(
-                    components=[
-                        vm.AgGrid(id="p1_ag_grid_1", figure=dash_ag_grid(df)),
-                    ],
-                    controls=[
-                        # multi=True
-                        vm.Filter(id="p1_filter_1", column="species", targets=["p1_ag_grid_1"]),
-                        # multi=False
-                        vm.Filter(
-                            id="p1_filter_2",
-                            column="species",
-                            targets=["p1_ag_grid_1"],
-                            selector=vm.Dropdown(multi=False),
-                        ),
-                    ],
-                ),
-            ],
-        ),
-        vm.Container(
-            title="Graph Drill-through to Page 2",
-            variant="outlined",
-            layout=vm.Grid(grid=[[0, 1]]),
-            components=[
-                vm.Graph(
-                    title="Drill-through to multi=True Page-2",
-                    figure=px.scatter(df, x="sepal_width", y="sepal_length", color="species", custom_data=["species"]),
-                    actions=set_control(control="p2_filter_1", value="species"),
-                ),
-                vm.Graph(
-                    title="Drill-through to multi=False Page-2",
-                    figure=px.scatter(df, x="sepal_width", y="sepal_length", color="species", custom_data=["species"]),
-                    actions=set_control(control="p2_filter_2", value="species"),
-                ),
-            ],
-        ),
-    ],
+o = dbc.Offcanvas(
+    id="vizro_logs_offcanvas",
+    placement="bottom",
+    scrollable=True,
+    backdrop=False,
+    is_open=False,
+    children=html.Pre(id="vizro_logs", children=[]),
 )
 
-page_2 = vm.Page(
-    title="Graph Drill-through target page",
+c = html.Button("Vizro logs", className="dash-debug-menu__button", id="open_vizro_logs")
+
+c = c.to_plotly_json()
+o = o.to_plotly_json()
+
+hooks.devtool(namespace=c["namespace"], component_type=c["type"], props=c["props"])
+hooks.devtool(namespace=o["namespace"], component_type=o["type"], props=o["props"])
+
+clientside_callback(
+    "function(_, is_open) { return !is_open }",
+    Output("vizro_logs_offcanvas", "is_open"),
+    Input("open_vizro_logs", "n_clicks"),
+    State("vizro_logs_offcanvas", "is_open"),
+)
+
+import vizro.plotly.express as px
+from vizro import Vizro
+import vizro.models as vm
+
+df = px.data.iris()
+
+page = vm.Page(
+    title="My first dashboard",
     components=[
-        vm.Graph(
-            figure=px.scatter(df, x="sepal_width", y="sepal_length", color="species"),
-        )
+        vm.Graph(figure=px.scatter(df, x="sepal_length", y="petal_width", color="species")),
+        vm.Graph(figure=px.histogram(df, x="sepal_width", color="species")),
     ],
     controls=[
-        # multi=True
-        vm.Filter(id="p2_filter_1", column="species", show_in_url=True, selector=vm.Checklist()),
-        # multi=False
-        vm.Filter(id="p2_filter_2", column="species", show_in_url=True, selector=vm.RadioItems()),
+        vm.Filter(column="species"),
     ],
 )
 
-# ====== Graph drill-down ======
-
-vm.Page.add_type("controls", vm.Button)
-
-
-@capture("graph")
-def graph_with_dynamic_title(data_frame, title="ALL", **kwargs):
-    return px.scatter(data_frame, title=f"Graph shows `{title}` species.", **kwargs)
-
-
-page_3 = vm.Page(
-    title="Graph Drill-down page",
-    components=[
-        vm.Graph(
-            id="p3_graph_1",
-            figure=graph_with_dynamic_title(
-                data_frame=df, x="sepal_width", y="sepal_length", color="species", custom_data=["species"]
-            ),
-            actions=[
-                set_control(control="p3-filter-1", value="species"),
-                set_control(control="p3-parameter-1", value="species"),
-            ],
-        )
-    ],
-    controls=[
-        # Hidden with the custom css
-        vm.Filter(id="p3-filter-1", column="species"),
-        vm.Parameter(
-            id="p3-parameter-1",
-            targets=["p3_graph_1.title"],
-            selector=vm.Dropdown(options=["setosa", "versicolor", "virginica"]),
-        ),
-        vm.Button(
-            text="Reset drill down",
-            icon="Reset Focus",
-            actions=[
-                vm.Action(
-                    function=capture("action")(
-                        lambda: [["setosa", "versicolor", "virginica"], ["setosa", "versicolor", "virginica"]]
-                    )(),
-                    outputs=["p3-filter-1", "p3-parameter-1"],
-                ),
-                # Forget the button right now!!
-                # set_control(control="p3-filter-1", value=["setosa", "versicolor", "virginica"])
-                # set_control(control="p3-parameter-1", value=["setosa", "versicolor", "virginica"])
-            ],
-        ),
-    ],
-)
-
-
-# ====== AG-GRID ======
-
-page_4 = vm.Page(
-    title="AgGrid filter interactions and drill-through source page",
-    components=[
-        vm.Container(
-            title="Two filter interactions within Page 1",
-            layout=vm.Grid(grid=[[0, 1]]),
-            variant="outlined",
-            components=[
-                vm.AgGrid(
-                    title="Filter interaction to Graph below",
-                    figure=dash_ag_grid(df, dashGridOptions={"rowSelection": {"checkboxes": True}}),
-                    actions=[
-                        set_control(control="p4_filter_1", value="species"),
-                        set_control(control="p4_filter_2", value="species"),
-                        set_control(control="p4_filter_3", value="species"),
-                        set_control(control="p4_filter_4", value="species"),
-                    ],
-                ),
-                vm.Container(
-                    components=[
-                        vm.Graph(
-                            id="p4_graph_1", figure=px.scatter(df, x="sepal_width", y="sepal_length", color="species")
-                        ),
-                    ],
-                    controls=[
-                        # multi=True
-                        vm.Filter(id="p4_filter_1", column="species", targets=["p4_graph_1"]),
-                        # multi=False
-                        vm.Filter(
-                            id="p4_filter_2",
-                            column="species",
-                            targets=["p4_graph_1"],
-                            selector=vm.Dropdown(multi=False),
-                        ),
-                        # multi=False
-                        vm.Filter(id="p4_filter_3", column="species", targets=["p4_graph_1"], selector=vm.RadioItems()),
-                        # multi=True
-                        vm.Filter(id="p4_filter_4", column="species", targets=["p4_graph_1"], selector=vm.Checklist()),
-                    ],
-                ),
-            ],
-        ),
-        vm.Container(
-            title="AgGrid Drill-through to Page 5",
-            variant="outlined",
-            layout=vm.Grid(grid=[[0, 1]]),
-            components=[
-                vm.AgGrid(
-                    figure=dash_ag_grid(df),
-                    title="Drill-through to multi=True Page-5",
-                    actions=set_control(control="p5_filter_1", value="species"),
-                ),
-                vm.AgGrid(
-                    figure=dash_ag_grid(df),
-                    title="Drill-through to multi=False Page-5",
-                    actions=set_control(control="p5_filter_2", value="species"),
-                ),
-            ],
-        ),
-    ],
-)
-
-page_5 = vm.Page(
-    title="AgGrid Drill-through target page",
-    components=[vm.Graph(figure=px.scatter(df, x="sepal_width", y="sepal_length", color="species"))],
-    controls=[
-        # multi=True
-        vm.Filter(id="p5_filter_1", column="species", show_in_url=True, selector=vm.Checklist()),
-        # multi=False
-        vm.Filter(id="p5_filter_2", column="species", show_in_url=True, selector=vm.RadioItems()),
-    ],
-)
-
-
-dashboard = vm.Dashboard(
-    pages=[page_1, page_2, page_3, page_4, page_5],
-    navigation=vm.Navigation(
-        pages={
-            "Graph as source": [
-                "Graph filter interactions and drill-through source page",
-                "Graph Drill-through target page",
-                "Graph Drill-down page",
-            ],
-            "AgGrid as source": [
-                "AgGrid filter interactions and drill-through source page",
-                "AgGrid Drill-through target page",
-            ],
-        }
-    ),
-)
+dashboard = vm.Dashboard(pages=[page])
 
 if __name__ == "__main__":
-    Vizro().build(dashboard).run()
+    Vizro().build(dashboard).run(debug=True)

--- a/vizro-core/src/vizro/models/_action/_action.py
+++ b/vizro-core/src/vizro/models/_action/_action.py
@@ -9,7 +9,7 @@ from collections.abc import Collection, Iterable, Mapping
 from pprint import pformat
 from typing import TYPE_CHECKING, Annotated, Any, Callable, ClassVar, Literal, Union, cast
 
-from dash import ClientsideFunction, Input, Output, State, callback, clientside_callback, dcc, no_update, Patch, html
+from dash import ClientsideFunction, Input, Output, Patch, State, callback, clientside_callback, dcc, html, no_update
 from dash.development.base_component import Component
 from pydantic import BeforeValidator, Field, PrivateAttr, TypeAdapter, field_validator
 from pydantic.json_schema import SkipJsonSchema

--- a/vizro-core/src/vizro/models/_action/_action.py
+++ b/vizro-core/src/vizro/models/_action/_action.py
@@ -9,7 +9,7 @@ from collections.abc import Collection, Iterable, Mapping
 from pprint import pformat
 from typing import TYPE_CHECKING, Annotated, Any, Callable, ClassVar, Literal, Union, cast
 
-from dash import ClientsideFunction, Input, Output, State, callback, clientside_callback, dcc, no_update
+from dash import ClientsideFunction, Input, Output, State, callback, clientside_callback, dcc, no_update, Patch, html
 from dash.development.base_component import Component
 from pydantic import BeforeValidator, Field, PrivateAttr, TypeAdapter, field_validator
 from pydantic.json_schema import SkipJsonSchema
@@ -384,6 +384,8 @@ class _BaseAction(VizroBaseModel):
                 "action_progress_indicator": Output(
                     "action-progress-indicator-placeholder", "children", allow_duplicate=True
                 ),
+                "action_log": Output("vizro_logs", "children", allow_duplicate=True),
+                # Need allow_optional for Output - make Dash ticket.
             },
         }
 
@@ -407,10 +409,17 @@ class _BaseAction(VizroBaseModel):
         @callback(output=callback_outputs, inputs=callback_inputs, prevent_initial_call=True)
         def action_callback(external: Union[list[Any], dict[str, Any]], internal: dict[str, Any]) -> dict[str, Any]:
             external_return = self._action_callback_function(inputs=external, outputs=callback_outputs.get("external"))
+            # logger.debug("===== Running action with id %s, function %s =====", self.id, self._action_name)
+            # if logger.isEnabledFor(logging.DEBUG):
+            #     logger.debug("Action inputs:\n%s", pformat(inputs, depth=3, width=200))
+            #     logger.debug("Action outputs:\n%s", pformat(outputs, width=200))
+            action_log = Patch()
+            action_log.append(html.Pre(f"===== Running action with id {self.id}, function {self._action_name} ====="))
             return_value = {
                 "internal": {
                     "action_finished": time.time(),
                     "action_progress_indicator": no_update,
+                    "action_log": action_log,
                 }
             }
             if "external" in callback_outputs:


### PR DESCRIPTION
## Description

FYI @petar-qb. This isn't at all urgent, I just made a rough PoC when I was on the train last week and wanted to show you.

Very rough PoC:
![2025-09-30_15-03-07 (1)](https://github.com/user-attachments/assets/f5aeef94-58a1-4cf7-bb2c-16f0215cab5b)

Benefit of this compared to console logs:
* we can put clientside and serverside stuff here (`Patch` is now possible in clientside callbacks 🎉)
* it's easier to refer to than switching between console logs and the app

Still needs resolving:
* need `Output(allow_optional=True)` - see https://github.com/plotly/dash/issues/3462
* (not so important) work out how to style it - see https://github.com/plotly/dash/issues/3461
* why does it not work for [this more complex example app](https://github.com/mckinsey/vizro/blob/4103093580332e552de634d14cb586affddd717a/vizro-core/examples/scratch_dev/app.py)? Weird behaviour where `trigger` is `None` - not sure if this is a Vizro or Dash bug

## Screenshot

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
