### PR TITLE
[Feature] Make Vizro compatible with Kedro 1.0.0

### DIFF
--- a/vizro-core/pyproject.toml
+++ b/vizro-core/pyproject.toml
@@ -41,7 +41,7 @@ requires-python = ">=3.9"
 
 [project.optional-dependencies]
 kedro = [
-  "kedro>=0.19.0,<1.0",  # remove once we have tested the released Kedro 1.0
+  "kedro>=0.19.0",  # do we want to still be compatible with `0.19` series? Probably yes
   "kedro-datasets"  # no longer a dependency of kedro for kedro>=0.19.2
 ]
 

--- a/vizro-core/src/vizro/integrations/kedro/_data_manager.py
+++ b/vizro-core/src/vizro/integrations/kedro/_data_manager.py
@@ -15,21 +15,22 @@ if TYPE_CHECKING:
     from kedro.io import CatalogProtocol
 
 
+# TODO: Need to decide if we want to keep 0.19 compatibility, the current change would be even a breaking change for Vizro...
 def catalog_from_project(
-    project_path: Union[str, Path], env: Optional[str] = None, extra_params: Optional[dict[str, Any]] = None
+    project_path: Union[str, Path], env: Optional[str] = None, runtime_params: Optional[dict[str, Any]] = None
 ) -> CatalogProtocol:
     """Return the Kedro Data Catalog associated to a Kedro project.
 
     Args:
         project_path: Path to the Kedro project root directory.
         env: Kedro configuration environment to be used. Defaults to "local".
-        extra_params: Optional dictionary containing extra project parameters
+        runtime_params: Optional dictionary containing extra project parameters
             for underlying KedroContext. If specified, will update (and therefore
             take precedence over) the parameters retrieved from the project
             configuration.
 
     Returns:
-         A Kedro Data Catalog.
+        A Kedro Data Catalog.
 
     Examples:
         >>> from vizro.integrations import kedro as kedro_integration
@@ -37,7 +38,7 @@ def catalog_from_project(
     """
     bootstrap_project(project_path)
     with KedroSession.create(
-        project_path=project_path, env=env, save_on_close=False, extra_params=extra_params
+        project_path=project_path, env=env, save_on_close=False, runtime_params=runtime_params
     ) as session:
         return session.load_context().catalog
 
@@ -49,7 +50,7 @@ def pipelines_from_project(project_path: Union[str, Path]) -> dict[str, Pipeline
         project_path: Path to the Kedro project root directory.
 
     Returns:
-         A dictionary mapping pipeline names to Kedro Pipelines.
+        A dictionary mapping pipeline names to Kedro Pipelines.
 
     Examples:
         >>> from vizro.integrations import kedro as kedro_integration


### PR DESCRIPTION
## Description
Closes https://github.com/mckinsey/vizro/issues/1446

On the following PR we need to decide:
- Do we keep compatibility with `0.19` series of Kedro
- Do we want to change the `extra_params` to `runtime_params` only in the background, or do we also want to change it?
  - If yes, do we want to make it breaking, or keep backwards compatibility?
  - If keeping backwards compatibility, do we want to deprecate the argument?

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
