### PR TITLE
Move the dmc.NotificationContainer from Dashboard to the Page level

### DIFF
--- a/vizro-core/examples/scratch_dev/app.py
+++ b/vizro-core/examples/scratch_dev/app.py
@@ -128,6 +128,16 @@ page_two = vm.Page(
     title="Dashboard with welcome message",
     components=[
         vm.Graph(figure=px.histogram(df, x="sepal_length")),
+        vm.Button(
+            icon="check_circle",
+            text="Success Notification",
+            actions=[
+                va.show_notification(
+                    message="Operation completed successfully!",
+                    variant="success",
+                )
+            ],
+        ),
     ],
 )
 

--- a/vizro-core/src/vizro/actions/_show_notification.py
+++ b/vizro-core/src/vizro/actions/_show_notification.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal, Optional, Union
 
-from dash import dcc, html, no_update
+from dash import dcc, html
 from pydantic import AfterValidator, Field
 
 from vizro.actions._abstract_action import _AbstractAction
@@ -100,11 +100,8 @@ class show_notification(_AbstractAction):
         return ["notification-container.sendNotifications"]
 
     @_log_call
-    def function(self, _trigger):
+    def function(self):
         """Creates and returns a notification configuration for DMC NotificationContainer."""
-        if _trigger is None or _trigger == 0:
-            return no_update
-
         # Get variant-specific configuration variables
         class_name = VARIANT_CONFIG[self.variant]["className"]
         icon_name = self.icon if self.icon else VARIANT_CONFIG[self.variant]["icon"]

--- a/vizro-core/src/vizro/models/_dashboard.py
+++ b/vizro-core/src/vizro/models/_dashboard.py
@@ -206,14 +206,8 @@ class Dashboard(VizroBaseModel):
         # children=[layout] as a list rather than children=layout, so that app.dash.layout.children.append works to
         # easily add things to the Dash layout. In future we might have a neater function for patching components into
         # the Dash layout in which case this could change.
-        # NotificationContainer must be a direct child of MantineProvider to enable DMC's notification system.
-        # Actions output to "notification-container.sendNotifications" to display notifications. For more info see:
-        # https://www.dash-mantine-components.com/components/notification
         return dmc.MantineProvider(
-            children=[
-                dmc.NotificationContainer(position="top-right", limit=10, id="notification-container"),
-                layout,
-            ],
+            children=[layout],
             # Change global mantine settings here. For component specific styling, see Card example below.
             # Reference: https://www.dash-mantine-components.com/theme-object
             theme={

--- a/vizro-core/src/vizro/models/_page.py
+++ b/vizro-core/src/vizro/models/_page.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable
 from itertools import chain
 from typing import Annotated, Optional, cast
 
+import dash_mantine_components as dmc
 from dash import ClientsideFunction, Input, Output, State, clientside_callback, dcc, html
 from pydantic import (
     AfterValidator,
@@ -235,6 +236,7 @@ class Page(VizroBaseModel):
                 dcc.Store(id=f"{ON_PAGE_LOAD_ACTION_PREFIX}_trigger_{self.id}"),
                 dcc.Download(id="vizro_download"),
                 dcc.Location(id="vizro_url", refresh="callback-nav"),
+                dmc.NotificationContainer(position="top-right", limit=10, id="notification-container"),
             ]
         )
 

--- a/vizro-core/tests/unit/vizro/models/test_dashboard.py
+++ b/vizro-core/tests/unit/vizro/models/test_dashboard.py
@@ -335,7 +335,6 @@ class TestDashboardBuild:
 
         expected_dashboard_container = dmc.MantineProvider(
             children=[
-                dmc.NotificationContainer(position="top-right", limit=10, id="notification-container"),
                 html.Div(
                     id="dashboard-container",
                     children=[


### PR DESCRIPTION
## Description
Due to the following code which is quite non characteristic for Vizro action, I decided to move the `notification-container` to from Dashboard to the Page level and everything seems to work fine now. 
```py
    def function(self, _trigger):
    """Creates and returns a notification configuration for DMC NotificationContainer."""
        if _trigger is None or _trigger == 0:
            return no_update
```

## Screenshot
https://github.com/user-attachments/assets/9c547990-5665-4f57-bdb2-6c2b745b68fc

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
