### PR TITLE
[Tidy] Simplify `id` for `reset-button`

### DIFF
--- a/vizro-core/changelog.d/20251124_095404_90609403+huong-li-nguyen_remove_id_from_reset_btn.md
+++ b/vizro-core/changelog.d/20251124_095404_90609403+huong-li-nguyen_remove_id_from_reset_btn.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/src/vizro/models/_dashboard.py
+++ b/vizro-core/src/vizro/models/_dashboard.py
@@ -329,10 +329,10 @@ class Dashboard(VizroBaseModel):
             children=html.Div(id="action-progress-indicator-placeholder"),
         )
         reset_controls_button = dbc.Button(
-            id=f"{page.id}_reset_button",
+            id="reset-button",
             children=[
                 html.Span("reset_settings", className="material-symbols-outlined tooltip-icon"),
-                dbc.Tooltip(children="Reset all page controls", target=f"{page.id}_reset_button"),
+                dbc.Tooltip(children="Reset all page controls", target="reset-button"),
             ],
             class_name="btn-circular",
         )
@@ -367,7 +367,7 @@ class Dashboard(VizroBaseModel):
             text = html.Span("Reset controls", className="btn-text")
 
             control_panel.children.append(
-                dbc.Button(id=f"{page.id}_reset_button", children=[icon, text]),
+                dbc.Button(id="reset-button", children=[icon, text]),
             )
 
         nav_control_panel_content = [nav_panel, control_panel]

--- a/vizro-core/src/vizro/models/_page.py
+++ b/vizro-core/src/vizro/models/_page.py
@@ -172,7 +172,7 @@ class Page(VizroBaseModel):
                 Output(f"{ON_PAGE_LOAD_ACTION_PREFIX}_trigger_{self.id}", "data", allow_duplicate=True),
                 *selector_outputs,
                 *selector_guard_outputs,
-                Input(f"{self.id}_reset_button", "n_clicks"),
+                Input("reset-button", "n_clicks"),
                 State("vizro_controls_store", "data"),
                 State(self.id, "id"),  # Assigned to outermost Div in Dashboard._make_page_layout.
                 prevent_initial_call=True,

--- a/vizro-core/tests/e2e/vizro/test_dom_elements/test_reset_controls.py
+++ b/vizro-core/tests/e2e/vizro/test_dom_elements/test_reset_controls.py
@@ -21,7 +21,7 @@ def test_reset_controls_tooltip(dash_br):
         dash_br, page_path=cnst.FILTERS_INSIDE_CONTAINERS_PAGE_PATH, page_name=cnst.FILTERS_INSIDE_CONTAINERS_PAGE
     )
     # hover over reset controls icon and wait for the tooltip appear
-    hover_over_element_by_xpath_selenium(dash_br, "//*[contains(@id, '_reset_button')]")
+    hover_over_element_by_xpath_selenium(dash_br, "//*[contains(@id, 'reset-button')]")
     dash_br.wait_for_text_to_equal(".tooltip-inner", "Reset all page controls")
 
 
@@ -50,7 +50,7 @@ def test_reset_controls_header(dash_br):
     dash_br.multiple_click(switch_path_using_filter_control_id(filter_control_id=cnst.SWITCH_INSIDE_CONTAINERS), 1)
 
     # click reset controls icon
-    dash_br.multiple_click("button[id$='_reset_button']", 1, delay=0.1)
+    dash_br.multiple_click("button[id$='reset-button']", 1, delay=0.1)
 
     # check all controls were reset
     # dropdown
@@ -114,7 +114,7 @@ def test_reset_controls_page(dash_br):
     )
 
     # click reset controls button
-    dash_br.multiple_click("button[id$='_reset_button']", 1, delay=0.1)
+    dash_br.multiple_click("button[id$='reset-button']", 1, delay=0.1)
 
     # check all controls were reset
     # dropdown

--- a/vizro-core/tests/e2e/vizro/test_http_requests/test_http_requests.py
+++ b/vizro-core/tests/e2e/vizro/test_http_requests/test_http_requests.py
@@ -316,7 +316,7 @@ def test_reset_controls_header(page, http_requests_paths):
     check_http_requests_count(page, http_requests_paths, 2)
 
     # click on the reset_controls button (1 http)
-    page.locator("button[id$='reset_button']").click()
+    page.locator("button[id$='reset-button']").click()
     check_http_requests_count(page, http_requests_paths, 3)
 
     # checking that no additional http has occurred
@@ -330,7 +330,7 @@ def test_reset_controls_page(page, http_requests_paths):
     check_http_requests_count(page, http_requests_paths, 2)
 
     # click on the reset_controls button (1 http)
-    page.locator("button[id$='reset_button']").click()
+    page.locator("button[id$='reset-button']").click()
     check_http_requests_count(page, http_requests_paths, 3, sleep=3000)
 
     # checking that no additional http has occurred

--- a/vizro-core/tests/e2e/vizro/test_screenshots/test_screenshots.py
+++ b/vizro-core/tests/e2e/vizro/test_screenshots/test_screenshots.py
@@ -381,7 +381,7 @@ def test_reset_controls_page(dash_br):
     dash_br.multiple_click(f"#{cnst.DROPDOWN_AG_GRID_INTERACTIONS_ID}_select_all", 1)
 
     # click reset controls button
-    dash_br.multiple_click("button[id$='_reset_button']", 1, delay=0.1)
+    dash_br.multiple_click("button[id$='reset-button']", 1, delay=0.1)
 
     # open dropdown menu to check on the screenshot if select_all is unchecked
     dash_br.multiple_click(dropdown_arrow_path(dropdown_id=cnst.DROPDOWN_AG_GRID_INTERACTIONS_ID), 1)


### PR DESCRIPTION
## Description
Closes https://github.com/McK-Internal/vizro-internal/issues/2366

- Remove `page-id` from `reset-button` - I don't think we need it? Similar to the `theme-switch`, it only appears once pn a Page, hence can just have a static `id` unless I am missing something? @petar-qb @antonymilne 
- Simplifies styling and hiding it throughout the entire app as you can target directly via `id`  e.g. 

For global hiding
```
#reset-button { 
    display: none
}
```

For page-specific hiding
```
#page-id #reset-button { 
    display: none
}
```


## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
