### PR TITLE
[CI] Fix `vizro-mcp` and `vizro-core` unit tests to work with `black>=26`

### DIFF
--- a/vizro-core/tests/unit/vizro/models/test_base.py
+++ b/vizro-core/tests/unit/vizro/models/test_base.py
@@ -383,7 +383,6 @@ def complete_dashboard():
 expected_card = """############ Imports ##############
 import vizro.models as vm
 
-
 ########### Model code ############
 model = vm.Card(text="Foo")
 """
@@ -392,7 +391,6 @@ model = vm.Card(text="Foo")
 expected_graph = """############ Imports ##############
 import vizro.plotly.express as px
 import vizro.models as vm
-
 
 ####### Data Manager Settings #####
 #######!!! UNCOMMENT BELOW !!!#####
@@ -433,7 +431,6 @@ import vizro.plotly.express as px
 import vizro.models as vm
 import vizro.actions as va
 
-
 ####### Data Manager Settings #####
 #######!!! UNCOMMENT BELOW !!!#####
 # from vizro.managers import data_manager
@@ -453,7 +450,6 @@ model = vm.Page(
 
 excepted_graph_dynamic = """############ Imports ##############
 import vizro.models as vm
-
 
 ####### Data Manager Settings #####
 #######!!! UNCOMMENT BELOW !!!#####
@@ -556,7 +552,6 @@ expected_code_px_via_json = """############ Imports ##############
 import vizro.plotly.express as px
 import vizro.models as vm
 
-
 ####### Data Manager Settings #####
 #######!!! UNCOMMENT BELOW !!!#####
 # from vizro.managers import data_manager
@@ -596,7 +591,6 @@ model = vm.Graph(
 
 expected_code_pass_validation_via_json = """############ Imports ##############
 import vizro.models as vm
-
 
 ####### Data Manager Settings #####
 #######!!! UNCOMMENT BELOW !!!#####

--- a/vizro-mcp/tests/unit/vizro_mcp/test_server.py
+++ b/vizro-mcp/tests/unit/vizro_mcp/test_server.py
@@ -60,7 +60,6 @@ differences to previous `app.py`""",
 import vizro.models as vm
 from vizro import Vizro
 
-
 ########### Model code ############
 model = vm.Dashboard(
     pages=[


### PR DESCRIPTION
closes https://github.com/McK-Internal/vizro-internal/issues/2427

## Description from the ticket
The following PR in `black` library introduced the change that "Two blank lines after an import should be reduced to one" -> https://github.com/psf/black/pull/ 4489

- [x] - Adjust `vizro-core` and `vizro-mcp` unit tests so they pass.

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
