### PR TITLE
[Fix] Formatting issues in vizro-dash-components auto version bump

### DIFF
--- a/.github/workflows/release-if-needed.yml
+++ b/.github/workflows/release-if-needed.yml
@@ -121,6 +121,8 @@ jobs:
             hatch run schema
           fi
           if [ "${{ needs.check-version.outputs.package_name }}" == "vizro-dash-components" ]; then
+            # hatch-nodejs-version writes package.json with 4-space indent; reformat to match biome config.
+            npx biome format --write package.json
             npm install --package-lock-only --legacy-peer-deps
           fi
           git config user.email "145135826+vizro-svc@users.noreply.github.com"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,7 +90,7 @@ repos:
             --wrap=no,
             --align-semantic-breaks-in-lists,
           ]
-        exclude: ^vizro-core/docs/pages/API-reference|^vizro-ai/docs/pages/API-reference|^vizro-mcp/docs/pages/API-reference|vizro-core/docs/pages/user-guides/custom-components.md|vizro-core/docs/pages/user-guides/custom-actions.md|^vizro-core/changelog.d|^vizro-ai/changelog.d
+        exclude: ^vizro-core/docs/pages/API-reference|^vizro-ai/docs/pages/API-reference|^vizro-mcp/docs/pages/API-reference|vizro-core/docs/pages/user-guides/custom-components.md|vizro-core/docs/pages/user-guides/custom-actions.md|^vizro-core/changelog.d|^vizro-ai/changelog.d|^vizro-dash-components/changelog.d
         additional_dependencies:
           - mdformat-mkdocs[recommended]==4.3.0
 

--- a/vizro-dash-components/package.json
+++ b/vizro-dash-components/package.json
@@ -1,54 +1,54 @@
 {
-    "name": "vizro-dash-components",
-    "version": "0.1.1-dev0",
-    "description": "Vizro Dash Components are used by the Vizro framework but can be used in a pure Dash app",
-    "main": "index.ts",
-    "scripts": {
-        "build:js": "webpack",
-        "build:backends": "dash-generate-components ./src/ts/components vizro_dash_components -p package-info.json  --ignore \\.test\\.",
-        "build": "npm run build:js && npm run build:backends",
-        "watch": "webpack --mode development -- --watch"
-    },
-    "devDependencies": {
-        "@biomejs/biome": "2.3.14",
-        "@plotly/webpack-dash-dynamic-import": "^1.3.0",
-        "@types/ramda": "^0.30.0",
-        "@types/react": "^18.2.0",
-        "@types/react-dom": "^18.2.0",
-        "css-loader": "^6.10.0",
-        "path-browserify": "^1.0.1",
-        "process": "^0.11.10",
-        "react": "18.2.0",
-        "react-docgen": "^5.4.3",
-        "react-dom": "18.2.0",
-        "style-loader": "^3.3.4",
-        "ts-loader": "^9.3.1",
-        "typescript": "^5.6.3",
-        "webpack": "^5.101.0",
-        "webpack-cli": "^5.1.4"
-    },
-    "dependencies": {
-        "@plotly/dash-component-plugins": "^1.2.3",
-        "mathjax": "^3.2.2",
-        "prop-types": "^15.8.1",
-        "ramda": "^0.30.0",
-        "react-jsx-parser": "^2.4.1",
-        "react-markdown": "^4.3.1",
-        "remark-math": "^3.0.1"
-    },
-    "peerDependencies": {
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-    },
-    "author": "Vizro Team",
-    "license": "Apache-2.0",
-    "overrides": {
-        "ajv": ">=8.18.0",
-        "minimatch": ">=3.1.3",
-        "trim": ">=0.0.3"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/mckinsey/vizro.git"
-    }
+  "name": "vizro-dash-components",
+  "version": "0.1.1-dev0",
+  "description": "Vizro Dash Components are used by the Vizro framework but can be used in a pure Dash app",
+  "main": "index.ts",
+  "scripts": {
+    "build:js": "webpack",
+    "build:backends": "dash-generate-components ./src/ts/components vizro_dash_components -p package-info.json  --ignore \\.test\\.",
+    "build": "npm run build:js && npm run build:backends",
+    "watch": "webpack --mode development -- --watch"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.3.14",
+    "@plotly/webpack-dash-dynamic-import": "^1.3.0",
+    "@types/ramda": "^0.30.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "css-loader": "^6.10.0",
+    "path-browserify": "^1.0.1",
+    "process": "^0.11.10",
+    "react": "18.2.0",
+    "react-docgen": "^5.4.3",
+    "react-dom": "18.2.0",
+    "style-loader": "^3.3.4",
+    "ts-loader": "^9.3.1",
+    "typescript": "^5.6.3",
+    "webpack": "^5.101.0",
+    "webpack-cli": "^5.1.4"
+  },
+  "dependencies": {
+    "@plotly/dash-component-plugins": "^1.2.3",
+    "mathjax": "^3.2.2",
+    "prop-types": "^15.8.1",
+    "ramda": "^0.30.0",
+    "react-jsx-parser": "^2.4.1",
+    "react-markdown": "^4.3.1",
+    "remark-math": "^3.0.1"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "author": "Vizro Team",
+  "license": "Apache-2.0",
+  "overrides": {
+    "ajv": ">=8.18.0",
+    "minimatch": ">=3.1.3",
+    "trim": ">=0.0.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mckinsey/vizro.git"
+  }
 }


### PR DESCRIPTION
Closes https://github.com/McK-Internal/vizro-internal/issues/2545

## Description

Made the following update to avoid future [unexpected vdc file edits](https://github.com/mckinsey/vizro/commit/5c873c17128cd66ac3ee3f4f07c66aa37073d24e)

  - Add vizro-dash-components/changelog.d to mdformat exclude list,
    matching vizro-core and vizro-ai                                                                                                                                            
  - Reformat package.json with biome after hatch version bump to fix                                                                                                          
    4-space indent caused by hatch-nodejs-version                                                                                                                               
  - Fix current package.json to use 2-space indent

## Screenshot

## Notice

- [ ] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
