### PR TITLE
fix(vizro-dash-components): guard against undefined code in Markdown renderers

### DIFF
--- a/vizro-dash-components/src/ts/fragments/Markdown.react.js
+++ b/vizro-dash-components/src/ts/fragments/Markdown.react.js
@@ -115,16 +115,17 @@ export default class DashMarkdown extends Component {
     // for built-in copy button and to avoid DOM manipulation anti-patterns.
     // These are loaded via React.lazy from DMCComponents.js.
     const codeRenderer = ({ language, value }) => {
+      const code = value || "";
       return (
         <Suspense
           fallback={
             <pre>
-              <code>{value}</code>
+              <code>{code}</code>
             </pre>
           }
         >
           <DMCCodeHighlight
-            code={value}
+            code={code}
             language={language || "text"}
             withCopyButton={true}
           />
@@ -166,11 +167,14 @@ export default class DashMarkdown extends Component {
 
             // DEVIATION FROM ORIGINAL DCC:
             // Inline code rendering using DMC's InlineCodeHighlight via window global
-            inlineCode: ({ value }) => (
-              <Suspense fallback={<code>{value}</code>}>
-                <DMCInlineCodeHighlight code={value} language="text" />
-              </Suspense>
-            ),
+            inlineCode: ({ value }) => {
+              const code = value || "";
+              return (
+                <Suspense fallback={<code>{code}</code>}>
+                  <DMCInlineCodeHighlight code={code} language="text" />
+                </Suspense>
+              );
+            },
 
             // HTML rendering with JSX parsing support
             // This enables dccLink, dccMarkdown, and dashMathjax in HTML blocks


### PR DESCRIPTION
## Summary
- Guard `codeRenderer` and `inlineCode` renderer in `Markdown.react.js` against `undefined` `value` prop by defaulting to `""`
- Fixes `TypeError: Cannot read properties of undefined (reading 'trim')` in `DMCCodeHighlight` / `DMCInlineCodeHighlight`

## Context
When `vdc.Markdown` is used with streaming content (e.g. SSE-based chat), `react-markdown` may parse partial/incomplete code fences mid-stream and pass `undefined` as the `value` prop to the code renderers. The downstream DMC components call `.trim()` on the value, which crashes.

## Test plan
- [ ] Verify `vdc.Markdown` renders normally with complete markdown (no regression)
- [ ] Verify streaming use case: pass progressively growing markdown text containing code fences to `vdc.Markdown` — no crash on partial fences

🤖 Generated with [Claude Code](https://claude.com/claude-code)