### PR TITLE
[Docs] Fix broken links to markdown from docstrings (zensical)

### DIFF
--- a/vizro-core/schemas/0.1.55.dev0.json
+++ b/vizro-core/schemas/0.1.55.dev0.json
@@ -2,7 +2,7 @@
   "$defs": {
     "Accordion": {
       "additionalProperties": false,
-      "description": "Accordion to be used as `nav_selector` in [`Navigation`][vizro.models.Navigation].\n\nAbstract: Usage documentation\n    [How to use an accordion](../user-guides/navigation.md/#group-pages)",
+      "description": "Accordion to be used as `nav_selector` in [`Navigation`][vizro.models.Navigation].\n\nAbstract: Usage documentation\n    [How to use an accordion](user-guides/navigation.md/#group-pages)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -33,7 +33,7 @@
     },
     "Action": {
       "additionalProperties": false,
-      "description": "Custom action to be inserted into `actions` of source component.\n\nAbstract: Usage documentation\n    [How to create custom actions](../user-guides/custom-actions.md)",
+      "description": "Custom action to be inserted into `actions` of source component.\n\nAbstract: Usage documentation\n    [How to create custom actions](user-guides/custom-actions.md)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -79,7 +79,7 @@
     },
     "AgGrid": {
       "additionalProperties": false,
-      "description": "Wrapper for `dash_ag_grid.AgGrid` to visualize grids in dashboard.\n\nAbstract: Usage documentation\n    [How to use an AgGrid](../user-guides/table.md/#ag-grid)",
+      "description": "Wrapper for `dash_ag_grid.AgGrid` to visualize grids in dashboard.\n\nAbstract: Usage documentation\n    [How to use an AgGrid](user-guides/table.md/#ag-grid)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -156,7 +156,7 @@
     },
     "Button": {
       "additionalProperties": false,
-      "description": "Button that can trigger actions or navigate.\n\nAbstract: Usage documentation\n    [How to use buttons](../user-guides/button.md)",
+      "description": "Button that can trigger actions or navigate.\n\nAbstract: Usage documentation\n    [How to use buttons](user-guides/button.md)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -240,7 +240,7 @@
     },
     "Card": {
       "additionalProperties": false,
-      "description": "Card based on Markdown syntax.\n\nAbstract: Usage documentation\n    [How to use cards](../user-guides/card.md)",
+      "description": "Card based on Markdown syntax.\n\nAbstract: Usage documentation\n    [How to use cards](user-guides/card.md)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -323,7 +323,7 @@
     },
     "Cascader": {
       "additionalProperties": false,
-      "description": "Cascader selector for [`Filter`][vizro.models.Filter] and [`Parameter`][vizro.models.Parameter].\n\nAbstract: Usage documentation\n    [Hierarchical selectors](../user-guides/selectors.md#hierarchical-selectors)",
+      "description": "Cascader selector for [`Filter`][vizro.models.Filter] and [`Parameter`][vizro.models.Parameter].\n\nAbstract: Usage documentation\n    [Hierarchical selectors](user-guides/selectors.md#hierarchical-selectors)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -449,7 +449,7 @@
     },
     "Checklist": {
       "additionalProperties": false,
-      "description": "Categorical multi-option selector.\n\nCan be provided to [`Filter`][vizro.models.Filter] or [`Parameter`][vizro.models.Parameter].\n\nAbstract: Usage documentation\n    [How to use categorical selectors](../user-guides/selectors.md#categorical-selectors)",
+      "description": "Categorical multi-option selector.\n\nCan be provided to [`Filter`][vizro.models.Filter] or [`Parameter`][vizro.models.Parameter].\n\nAbstract: Usage documentation\n    [How to use categorical selectors](user-guides/selectors.md#categorical-selectors)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -591,7 +591,7 @@
     },
     "Container": {
       "additionalProperties": false,
-      "description": "Container to group together a set of components on a page.\n\nAbstract: Usage documentation\n    [How to use containers](../user-guides/container.md)",
+      "description": "Container to group together a set of components on a page.\n\nAbstract: Usage documentation\n    [How to use containers](user-guides/container.md)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -753,7 +753,7 @@
     },
     "ControlGroup": {
       "additionalProperties": false,
-      "description": "Container to group together a set of controls.\n\nAbstract: Usage documentation\n    [How to group controls](../user-guides/controls.md/#group-controls)\n\nExample:\n    ```python\n    import vizro.models as vm\n\n    vm.ControlGroup(\n        title=\"Control group title\",\n        controls=[vm.Filter(column=\"species\"), vm.Filter(column=\"sepal_length\")],\n    )\n    ```",
+      "description": "Container to group together a set of controls.\n\nAbstract: Usage documentation\n    [How to group controls](user-guides/controls.md/#group-controls)\n\nExample:\n    ```python\n    import vizro.models as vm\n\n    vm.ControlGroup(\n        title=\"Control group title\",\n        controls=[vm.Filter(column=\"species\"), vm.Filter(column=\"sepal_length\")],\n    )\n    ```",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -814,7 +814,7 @@
     },
     "DatePicker": {
       "additionalProperties": false,
-      "description": "Temporal single/range option selector.\n\nCan be provided to [`Filter`][vizro.models.Filter] or [`Parameter`][vizro.models.Parameter].\n\nAbstract: Usage documentation\n    [How to use temporal selectors](../user-guides/selectors.md#temporal-selectors)",
+      "description": "Temporal single/range option selector.\n\nCan be provided to [`Filter`][vizro.models.Filter] or [`Parameter`][vizro.models.Parameter].\n\nAbstract: Usage documentation\n    [How to use temporal selectors](user-guides/selectors.md#temporal-selectors)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -934,7 +934,7 @@
     },
     "Dropdown": {
       "additionalProperties": false,
-      "description": "Categorical single/multi-option selector.\n\nCan be provided to [`Filter`][vizro.models.Filter] or\n[`Parameter`][vizro.models.Parameter].\n\nAbstract: Usage documentation\n    [How to use categorical selectors](../user-guides/selectors.md#categorical-selectors)",
+      "description": "Categorical single/multi-option selector.\n\nCan be provided to [`Filter`][vizro.models.Filter] or\n[`Parameter`][vizro.models.Parameter].\n\nAbstract: Usage documentation\n    [How to use categorical selectors](user-guides/selectors.md#categorical-selectors)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -1096,7 +1096,7 @@
     },
     "Figure": {
       "additionalProperties": false,
-      "description": "Object that is reactive to controls, for example a KPI card.\n\nAbstract: Usage documentation\n    [How to use figures](../user-guides/figure.md)",
+      "description": "Object that is reactive to controls, for example a KPI card.\n\nAbstract: Usage documentation\n    [How to use figures](user-guides/figure.md)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -1143,7 +1143,7 @@
     },
     "Filter": {
       "additionalProperties": false,
-      "description": "Filter the data supplied to `targets`.\n\nAbstract: Usage documentation\n    [How to use filters](../user-guides/filters.md)\n\nExample:\n    ```python\n    import vizro.models as vm\n\n    vm.Filter(column=\"species\")\n    vm.Filter(column=[\"continent\", \"country\"])\n    ```",
+      "description": "Filter the data supplied to `targets`.\n\nAbstract: Usage documentation\n    [How to use filters](user-guides/filters.md)\n\nExample:\n    ```python\n    import vizro.models as vm\n\n    vm.Filter(column=\"species\")\n    vm.Filter(column=[\"continent\", \"country\"])\n    ```",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -1250,7 +1250,7 @@
     },
     "Flex": {
       "additionalProperties": false,
-      "description": "Flex layout for components on a [`Page`][vizro.models.Page] or in a [`Container`][vizro.models.Container].\n\nAbstract: Usage documentation\n    [How to use the Flex layout](../user-guides/layouts.md#flex-layout)",
+      "description": "Flex layout for components on a [`Page`][vizro.models.Page] or in a [`Container`][vizro.models.Container].\n\nAbstract: Usage documentation\n    [How to use the Flex layout](user-guides/layouts.md#flex-layout)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -1289,7 +1289,7 @@
     },
     "Graph": {
       "additionalProperties": false,
-      "description": "Wrapper for `dcc.Graph` to visualize charts.\n\nAbstract: Usage documentation\n    [How to use graphs](../user-guides/graph.md)",
+      "description": "Wrapper for `dcc.Graph` to visualize charts.\n\nAbstract: Usage documentation\n    [How to use graphs](user-guides/graph.md)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -1366,7 +1366,7 @@
     },
     "Grid": {
       "additionalProperties": false,
-      "description": "Grid layout for components on a [`Page`][vizro.models.Page] or in a [`Container`][vizro.models.Container].\n\nAbstract: Usage documentation\n    [How to use the Grid layout](../user-guides/layouts.md#grid-layout)",
+      "description": "Grid layout for components on a [`Page`][vizro.models.Page] or in a [`Container`][vizro.models.Container].\n\nAbstract: Usage documentation\n    [How to use the Grid layout](user-guides/layouts.md#grid-layout)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -1485,7 +1485,7 @@
     },
     "NavBar": {
       "additionalProperties": false,
-      "description": "Navigation bar to be used as a `nav_selector` for `Navigation`.\n\nAbstract: Usage documentation\n    [How to use the navigation bar](../user-guides/navigation.md#use-a-navigation-bar-with-icons)",
+      "description": "Navigation bar to be used as a `nav_selector` for `Navigation`.\n\nAbstract: Usage documentation\n    [How to use the navigation bar](user-guides/navigation.md#use-a-navigation-bar-with-icons)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -1531,7 +1531,7 @@
     },
     "NavLink": {
       "additionalProperties": false,
-      "description": "Icon that serves as a navigation link to be used in a [`NavBar`][vizro.models.NavBar].\n\nAbstract: Usage documentation\n    [How to customize the NavBar icons](../user-guides/navigation.md#change-icons)",
+      "description": "Icon that serves as a navigation link to be used in a [`NavBar`][vizro.models.NavBar].\n\nAbstract: Usage documentation\n    [How to customize the NavBar icons](user-guides/navigation.md#change-icons)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -1577,7 +1577,7 @@
     },
     "Navigation": {
       "additionalProperties": false,
-      "description": "Navigation to arrange hierarchy of [`Pages`][vizro.models.Page].\n\nAbstract: Usage documentation\n    [How to customize the navigation](../user-guides/navigation.md)",
+      "description": "Navigation to arrange hierarchy of [`Pages`][vizro.models.Page].\n\nAbstract: Usage documentation\n    [How to customize the navigation](user-guides/navigation.md)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -1638,7 +1638,7 @@
     },
     "Page": {
       "additionalProperties": false,
-      "description": "A page in [`Dashboard`][vizro.models.Dashboard] with its own URL path and place in the `Navigation`.\n\nAbstract: Usage documentation\n    [How to make dashboard pages](../user-guides/pages.md)",
+      "description": "A page in [`Dashboard`][vizro.models.Dashboard] with its own URL path and place in the `Navigation`.\n\nAbstract: Usage documentation\n    [How to make dashboard pages](user-guides/pages.md)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -1807,7 +1807,7 @@
     },
     "Parameter": {
       "additionalProperties": false,
-      "description": "Alter the arguments supplied to any `targets`.\n\nAbstract: Usage documentation\n    [How to use parameters](../user-guides/parameters.md)\n\nExample:\n    ```python\n    import vizro.models as vm\n\n    vm.Parameter(targets=[\"scatter.x\"], selector=vm.Slider(min=0, max=1, default=0.8, title=\"Bubble opacity\"))\n    ```",
+      "description": "Alter the arguments supplied to any `targets`.\n\nAbstract: Usage documentation\n    [How to use parameters](user-guides/parameters.md)\n\nExample:\n    ```python\n    import vizro.models as vm\n\n    vm.Parameter(targets=[\"scatter.x\"], selector=vm.Slider(min=0, max=1, default=0.8, title=\"Bubble opacity\"))\n    ```",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -1890,7 +1890,7 @@
     },
     "RadioItems": {
       "additionalProperties": false,
-      "description": "Categorical single-option selector.\n\nCan be provided to [`Filter`][vizro.models.Filter] or\n[`Parameter`][vizro.models.Parameter].\n\nAbstract: Usage documentation\n    [How to use categorical selectors](../user-guides/selectors.md/#categorical-selectors)",
+      "description": "Categorical single-option selector.\n\nCan be provided to [`Filter`][vizro.models.Filter] or\n[`Parameter`][vizro.models.Parameter].\n\nAbstract: Usage documentation\n    [How to use categorical selectors](user-guides/selectors.md/#categorical-selectors)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -2014,7 +2014,7 @@
     },
     "RangeSlider": {
       "additionalProperties": false,
-      "description": "Numeric multi-option selector.\n\nCan be provided to [`Filter`][vizro.models.Filter] or\n[`Parameter`][vizro.models.Parameter].\n\nAbstract: Usage documentation\n    [How to use numerical selectors](../user-guides/selectors.md/#numerical-selectors)",
+      "description": "Numeric multi-option selector.\n\nCan be provided to [`Filter`][vizro.models.Filter] or\n[`Parameter`][vizro.models.Parameter].\n\nAbstract: Usage documentation\n    [How to use numerical selectors](user-guides/selectors.md/#numerical-selectors)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -2151,7 +2151,7 @@
     },
     "Slider": {
       "additionalProperties": false,
-      "description": "Numeric single-option selector.\n\nCan be provided to [`Filter`][vizro.models.Filter] or\n[`Parameter`][vizro.models.Parameter].\n\nAbstract: Usage documentation\n    [How to use numerical selectors](../user-guides/selectors.md/#numerical-selectors)",
+      "description": "Numeric single-option selector.\n\nCan be provided to [`Filter`][vizro.models.Filter] or\n[`Parameter`][vizro.models.Parameter].\n\nAbstract: Usage documentation\n    [How to use numerical selectors](user-guides/selectors.md/#numerical-selectors)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -2284,7 +2284,7 @@
     },
     "Switch": {
       "additionalProperties": false,
-      "description": "Boolean single-option selector.\n\nCan be provided to [`Filter`][vizro.models.Filter] or [`Parameter`][vizro.models.Parameter].\n\nAbstract: Usage documentation\n    [How to use boolean selectors](../user-guides/selectors.md/#boolean-selectors)",
+      "description": "Boolean single-option selector.\n\nCan be provided to [`Filter`][vizro.models.Filter] or [`Parameter`][vizro.models.Parameter].\n\nAbstract: Usage documentation\n    [How to use boolean selectors](user-guides/selectors.md/#boolean-selectors)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -2355,7 +2355,7 @@
     },
     "Table": {
       "additionalProperties": false,
-      "description": "Wrapper for `dash_table.DataTable` to visualize tables in dashboard.\n\nAbstract: Usage documentation\n    [How to use tables](../user-guides/table.md)",
+      "description": "Wrapper for `dash_table.DataTable` to visualize tables in dashboard.\n\nAbstract: Usage documentation\n    [How to use tables](user-guides/table.md)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -2432,7 +2432,7 @@
     },
     "Tabs": {
       "additionalProperties": false,
-      "description": "Tabs to group together a set of [`Containers`][vizro.models.Container].\n\nAbstract: Usage documentation\n    [How to use tabs](../user-guides/tabs.md)",
+      "description": "Tabs to group together a set of [`Containers`][vizro.models.Container].\n\nAbstract: Usage documentation\n    [How to use tabs](user-guides/tabs.md)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -2478,7 +2478,7 @@
     },
     "Text": {
       "additionalProperties": false,
-      "description": "Text based on Markdown syntax.\n\nAbstract: Usage documentation\n    [How to add text to your page](../user-guides/text.md)",
+      "description": "Text based on Markdown syntax.\n\nAbstract: Usage documentation\n    [How to add text to your page](user-guides/text.md)",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -2503,7 +2503,7 @@
     },
     "Tooltip": {
       "additionalProperties": false,
-      "description": "A tooltip that displays text when hovering over an icon.\n\nAbstract: Usage documentation\n    Read more about usage in the guides on [dashboards](../user-guides/dashboard.md#add-a-dashboard-tooltip),\n    [pages](../user-guides/pages.md#add-a-tooltip),\n    [containers](../user-guides/container.md#add-a-tooltip),\n    [graphs](../user-guides/graph.md#add-a-tooltip),\n    [tables](../user-guides/table.md#add-a-tooltip), [tabs](../user-guides/tabs.md#add-a-tooltip),\n    [selectors](../user-guides/selectors.md#add-a-tooltip) and\n    [buttons](../user-guides/button.md#add-a-tooltip).\n\nExample: `Tooltip` on a [`Checklist`][vizro.models.Checklist] selector\n    ```python\n    import vizro.models as vm\n\n    vm.Checklist(\n        title=\"Select Species\",\n        description=vm.Tooltip(text=\"Select something\", icon=\"start\"),\n    )\n    ```",
+      "description": "A tooltip that displays text when hovering over an icon.\n\nAbstract: Usage documentation\n    Read more about usage in the guides on [dashboards](user-guides/dashboard.md#add-a-dashboard-tooltip),\n    [pages](user-guides/pages.md#add-a-tooltip),\n    [containers](user-guides/container.md#add-a-tooltip),\n    [graphs](user-guides/graph.md#add-a-tooltip),\n    [tables](user-guides/table.md#add-a-tooltip), [tabs](user-guides/tabs.md#add-a-tooltip),\n    [selectors](user-guides/selectors.md#add-a-tooltip) and\n    [buttons](user-guides/button.md#add-a-tooltip).\n\nExample: `Tooltip` on a [`Checklist`][vizro.models.Checklist] selector\n    ```python\n    import vizro.models as vm\n\n    vm.Checklist(\n        title=\"Select Species\",\n        description=vm.Tooltip(text=\"Select something\", icon=\"start\"),\n    )\n    ```",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -2558,7 +2558,7 @@
     },
     "export_data": {
       "additionalProperties": false,
-      "description": "Exports data of target charts, tables and figures.\n\nAbstract: Usage documentation\n    [How to export data](../user-guides/data-actions.md#export-data)\n\nExample:\n    ```python\n    import vizro.actions as va\n\n    vm.Button(\n        text=\"Export data\",\n        actions=va.export_data(targets=[\"graph_id\", \"table_id\"], file_format=\"xlsx\"),\n    )\n    ```",
+      "description": "Exports data of target charts, tables and figures.\n\nAbstract: Usage documentation\n    [How to export data](user-guides/data-actions.md#export-data)\n\nExample:\n    ```python\n    import vizro.actions as va\n\n    vm.Button(\n        text=\"Export data\",\n        actions=va.export_data(targets=[\"graph_id\", \"table_id\"], file_format=\"xlsx\"),\n    )\n    ```",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -2622,7 +2622,7 @@
     },
     "set_control": {
       "additionalProperties": false,
-      "description": "Sets the value of a control, which then updates its targets.\n\nAbstract: Usage documentation\n    [Graph and table interactions](../user-guides/graph-table-actions.md)\n\nThe following Vizro models can be a source of `set_control`:\n\n* [`AgGrid`][vizro.models.AgGrid]: triggers `set_control` when `cellClicked` or `selectedRows` changes (for example\nafter a cell click or when the row selection changes). `value` can be:\n\n    * `\"cell\"`, `\"column\"`, or `\"row\"` to use the clicked cell's value, column id, or row id respectively.\n    * Any other string to treat as a column name, taking values from the selected row(s).\n* [`Graph`][vizro.models.Graph]: triggers `set_control` when user clicks on data in the graph. `value` is string\nthat can be used in two ways to specify how to set `control`:\n\n    * Column from which to take the value. This requires you to set `custom_data` in the graph's `figure` function.\n    * String to [traverse a Box](https://github.com/cdgriffith/Box/wiki/Types-of-Boxes#box-dots) that contains the\n    trigger data [`clickData[\"points\"][0]`](https://dash.plotly.com/interactive-graphing). This is typically\n    useful for a positional variable, for example `\"x\"`, and does not require setting `custom_data`.\n\n* [`Figure`][vizro.models.Figure]: triggers `set_control` when user clicks on the figure. `value` specifies a\nliteral value to set `control` to.\n* [`Button`][vizro.models.Button]: triggers `set_control` when user clicks on the button. `value` specifies a\nliteral value to set `control` to.\n* [`Card`][vizro.models.Card]: triggers `set_control` when user clicks on the card. `value` specifies a\nliteral value to set `control` to.\n\nExample: `AgGrid` as trigger\n    ```python\n    import vizro.actions as va\n\n    vm.AgGrid(\n        figure=dash_ag_grid(iris),\n        actions=va.set_control(control=\"target_control\", value=\"species\"),\n    )\n    ```\n\nExample: `Graph` as trigger with `custom_data`\n    ```python\n    import vizro.actions as va\n\n    vm.Graph(\n        figure=px.scatter(iris, x=\"sepal_width\", y=\"sepal_length\", custom_data=\"species\"),\n        actions=va.set_control(control=\"target_control\", value=\"species\"),\n    )\n    ```\n\nExample: `Graph` as trigger without `custom_data`\n    ```python\n    import vizro.actions as va\n\n    vm.Graph(\n        figure=px.box(iris, x=\"species\", y=\"sepal_length\"),\n        actions=va.set_control(control=\"target_control\", value=\"x\"),\n    )\n    ```\n\nExample: `Figure` as trigger\n    ```python\n    import vizro.actions as va\n    from vizro.figures import kpi_card\n\n    vm.Figure(\n        figure=kpi_card(tips, value_column=\"tip\", title=\"Click KPI to set control to A\"),\n        actions=va.set_control(control=\"target_control\", value=\"A\"),\n    )\n    ```\n\nExample: `Button` as trigger\n    ```python\n    import vizro.actions as va\n\n    vm.Button(\n        text=\"Click to set control to A\",\n        actions=va.set_control(control=\"target_control\", value=\"A\"),\n    )\n    ```\n\nExample: `Card` as trigger\n    ```python\n    import vizro.actions as va\n\n    vm.Card(\n        title=\"Click Card to set control to A\",\n        actions=va.set_control(control=\"target_control\", value=\"A\"),\n    )\n    ```",
+      "description": "Sets the value of a control, which then updates its targets.\n\nAbstract: Usage documentation\n    [Graph and table interactions](user-guides/graph-table-actions.md)\n\nThe following Vizro models can be a source of `set_control`:\n\n* [`AgGrid`][vizro.models.AgGrid]: triggers `set_control` when `cellClicked` or `selectedRows` changes (for example\nafter a cell click or when the row selection changes). `value` can be:\n\n    * `\"cell\"`, `\"column\"`, or `\"row\"` to use the clicked cell's value, column id, or row id respectively.\n    * Any other string to treat as a column name, taking values from the selected row(s).\n* [`Graph`][vizro.models.Graph]: triggers `set_control` when user clicks on data in the graph. `value` is string\nthat can be used in two ways to specify how to set `control`:\n\n    * Column from which to take the value. This requires you to set `custom_data` in the graph's `figure` function.\n    * String to [traverse a Box](https://github.com/cdgriffith/Box/wiki/Types-of-Boxes#box-dots) that contains the\n    trigger data [`clickData[\"points\"][0]`](https://dash.plotly.com/interactive-graphing). This is typically\n    useful for a positional variable, for example `\"x\"`, and does not require setting `custom_data`.\n\n* [`Figure`][vizro.models.Figure]: triggers `set_control` when user clicks on the figure. `value` specifies a\nliteral value to set `control` to.\n* [`Button`][vizro.models.Button]: triggers `set_control` when user clicks on the button. `value` specifies a\nliteral value to set `control` to.\n* [`Card`][vizro.models.Card]: triggers `set_control` when user clicks on the card. `value` specifies a\nliteral value to set `control` to.\n\nExample: `AgGrid` as trigger\n    ```python\n    import vizro.actions as va\n\n    vm.AgGrid(\n        figure=dash_ag_grid(iris),\n        actions=va.set_control(control=\"target_control\", value=\"species\"),\n    )\n    ```\n\nExample: `Graph` as trigger with `custom_data`\n    ```python\n    import vizro.actions as va\n\n    vm.Graph(\n        figure=px.scatter(iris, x=\"sepal_width\", y=\"sepal_length\", custom_data=\"species\"),\n        actions=va.set_control(control=\"target_control\", value=\"species\"),\n    )\n    ```\n\nExample: `Graph` as trigger without `custom_data`\n    ```python\n    import vizro.actions as va\n\n    vm.Graph(\n        figure=px.box(iris, x=\"species\", y=\"sepal_length\"),\n        actions=va.set_control(control=\"target_control\", value=\"x\"),\n    )\n    ```\n\nExample: `Figure` as trigger\n    ```python\n    import vizro.actions as va\n    from vizro.figures import kpi_card\n\n    vm.Figure(\n        figure=kpi_card(tips, value_column=\"tip\", title=\"Click KPI to set control to A\"),\n        actions=va.set_control(control=\"target_control\", value=\"A\"),\n    )\n    ```\n\nExample: `Button` as trigger\n    ```python\n    import vizro.actions as va\n\n    vm.Button(\n        text=\"Click to set control to A\",\n        actions=va.set_control(control=\"target_control\", value=\"A\"),\n    )\n    ```\n\nExample: `Card` as trigger\n    ```python\n    import vizro.actions as va\n\n    vm.Card(\n        title=\"Click Card to set control to A\",\n        actions=va.set_control(control=\"target_control\", value=\"A\"),\n    )\n    ```",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -2651,7 +2651,7 @@
     },
     "show_notification": {
       "additionalProperties": false,
-      "description": "Shows a notification message.\n\nAbstract: Usage documentation\n    [Notifications](../user-guides/notification-actions.md)\n\nExample:\n    ```python\n    import vizro.actions as va\n    import vizro.models as vm\n\n    vm.Button(\n        text=\"Save\",\n        actions=va.show_notification(\n            title=\"Useful information\",\n            text=\"This is some useful information that you should know.\",\n        ),\n    )\n    ```",
+      "description": "Shows a notification message.\n\nAbstract: Usage documentation\n    [Notifications](user-guides/notification-actions.md)\n\nExample:\n    ```python\n    import vizro.actions as va\n    import vizro.models as vm\n\n    vm.Button(\n        text=\"Save\",\n        actions=va.show_notification(\n            title=\"Useful information\",\n            text=\"This is some useful information that you should know.\",\n        ),\n    )\n    ```",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -2708,7 +2708,7 @@
     },
     "update_notification": {
       "additionalProperties": false,
-      "description": "Updates an existing notification message.\n\nThis action updates notifications that were previously created with\n[`show_notification`][vizro.actions.show_notification]. `notification` must match the `id` of the original\n`show_notification` action.\n\nAbstract: Usage documentation\n    [Update notification](../user-guides/notification-actions.md#update-existing-notification)\n\nExample:\n    ```python\n    import vizro.actions as va\n    import vizro.models as vm\n\n    vm.Button(\n        text=\"Save\",\n        actions=[\n            va.show_notification(id=\"save_notification\", text=\"Saving data...\", variant=\"progress\"),\n            va.export_data(),\n            va.update_notification(\n                notification=\"save_notification\", text=\"Data saved successfully!\", variant=\"success\"\n            ),\n        ],\n    )\n    ```",
+      "description": "Updates an existing notification message.\n\nThis action updates notifications that were previously created with\n[`show_notification`][vizro.actions.show_notification]. `notification` must match the `id` of the original\n`show_notification` action.\n\nAbstract: Usage documentation\n    [Update notification](user-guides/notification-actions.md#update-existing-notification)\n\nExample:\n    ```python\n    import vizro.actions as va\n    import vizro.models as vm\n\n    vm.Button(\n        text=\"Save\",\n        actions=[\n            va.show_notification(id=\"save_notification\", text=\"Saving data...\", variant=\"progress\"),\n            va.export_data(),\n            va.update_notification(\n                notification=\"save_notification\", text=\"Data saved successfully!\", variant=\"success\"\n            ),\n        ],\n    )\n    ```",
       "properties": {
         "id": {
           "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",
@@ -2770,7 +2770,7 @@
     }
   },
   "additionalProperties": false,
-  "description": "Dashboard that is supplied to [`Vizro.build`][vizro.Vizro.build].\n\nAbstract: Usage documentation\n    [How to create a dashboard](../user-guides/dashboard.md)",
+  "description": "Dashboard that is supplied to [`Vizro.build`][vizro.Vizro.build].\n\nAbstract: Usage documentation\n    [How to create a dashboard](user-guides/dashboard.md)",
   "properties": {
     "id": {
       "description": "ID to identify model. Must be unique throughout the whole dashboard. When no ID is chosen, ID will be automatically generated.",

--- a/vizro-core/src/vizro/_vizro.py
+++ b/vizro-core/src/vizro/_vizro.py
@@ -35,7 +35,7 @@ class Vizro:
         """Initialize a Vizro app.
 
         Abstract: Usage documentation
-            [How to run or deploy a dashboard](../user-guides/run-deploy/#advanced-dockerfile-configuration)
+            [How to run or deploy a dashboard](user-guides/run-deploy/#advanced-dockerfile-configuration)
 
         Keyword Arguments:
             **kwargs: Arbitrary keyword arguments passed through to `Dash`, for example `assets_folder`,
@@ -117,7 +117,7 @@ class Vizro:
         """Builds the `dashboard`.
 
         Abstract: Usage documentation
-            [How to create a dashboard](../user-guides/dashboard.md)
+            [How to create a dashboard](user-guides/dashboard.md)
 
         Args:
             dashboard (Dashboard): configured dashboard model.
@@ -164,7 +164,7 @@ class Vizro:
                 arguments
 
         Abstract: Usage documentation
-            [How to develop in Python script](../user-guides/run-deploy.md#develop-in-python-script)
+            [How to develop in Python script](user-guides/run-deploy.md#develop-in-python-script)
         """
         data_manager._frozen_state = True
         model_manager._frozen_state = True

--- a/vizro-core/src/vizro/actions/__init__.py
+++ b/vizro-core/src/vizro/actions/__init__.py
@@ -1,7 +1,7 @@
 """Built-in actions, typically aliased as `va` using `import vizro.actions as va`.
 
 Abstract: Usage documentation
-    [How to use actions](../user-guides/actions.md)
+    [How to use actions](user-guides/actions.md)
 """
 
 from vizro.actions._export_data import export_data

--- a/vizro-core/src/vizro/actions/_export_data.py
+++ b/vizro-core/src/vizro/actions/_export_data.py
@@ -17,7 +17,7 @@ class export_data(_AbstractAction):
     """Exports data of target charts, tables and figures.
 
     Abstract: Usage documentation
-        [How to export data](../user-guides/data-actions.md#export-data)
+        [How to export data](user-guides/data-actions.md#export-data)
 
     Example:
         ```python

--- a/vizro-core/src/vizro/actions/_notifications.py
+++ b/vizro-core/src/vizro/actions/_notifications.py
@@ -32,7 +32,7 @@ class show_notification(_AbstractAction):
     """Shows a notification message.
 
     Abstract: Usage documentation
-        [Notifications](../user-guides/notification-actions.md)
+        [Notifications](user-guides/notification-actions.md)
 
     Example:
         ```python
@@ -116,7 +116,7 @@ class update_notification(show_notification):
     `show_notification` action.
 
     Abstract: Usage documentation
-        [Update notification](../user-guides/notification-actions.md#update-existing-notification)
+        [Update notification](user-guides/notification-actions.md#update-existing-notification)
 
     Example:
         ```python

--- a/vizro-core/src/vizro/actions/_set_control.py
+++ b/vizro-core/src/vizro/actions/_set_control.py
@@ -32,7 +32,7 @@ class set_control(_AbstractAction):
     """Sets the value of a control, which then updates its targets.
 
     Abstract: Usage documentation
-        [Graph and table interactions](../user-guides/graph-table-actions.md)
+        [Graph and table interactions](user-guides/graph-table-actions.md)
 
     The following Vizro models can be a source of `set_control`:
 

--- a/vizro-core/src/vizro/figures/__init__.py
+++ b/vizro-core/src/vizro/figures/__init__.py
@@ -1,7 +1,7 @@
 """Built-in figure functions.
 
 Abstract: Usage documentation
-    [How to use figures](../user-guides/figure.md)
+    [How to use figures](user-guides/figure.md)
 """
 
 from vizro.models.types import capture

--- a/vizro-core/src/vizro/integrations/kedro/__init__.py
+++ b/vizro-core/src/vizro/integrations/kedro/__init__.py
@@ -1,7 +1,7 @@
 """Functions to use the Kedro Data Catalog inside Vizro.
 
 Abstract: Usage documentation
-    [How to integrate Vizro with the Kedro Data Catalog](../user-guides/kedro-data-catalog.md)
+    [How to integrate Vizro with the Kedro Data Catalog](user-guides/kedro-data-catalog.md)
 """
 
 from ._data_manager import catalog_from_project, datasets_from_catalog, pipelines_from_project

--- a/vizro-core/src/vizro/models/_action/_action.py
+++ b/vizro-core/src/vizro/models/_action/_action.py
@@ -434,7 +434,7 @@ class Action(_BaseAction):
     """Custom action to be inserted into `actions` of source component.
 
     Abstract: Usage documentation
-        [How to create custom actions](../user-guides/custom-actions.md)
+        [How to create custom actions](user-guides/custom-actions.md)
 
     """
 

--- a/vizro-core/src/vizro/models/_base.py
+++ b/vizro-core/src/vizro/models/_base.py
@@ -215,7 +215,7 @@ class VizroBaseModel(BaseModel):
     """All Vizro models inherit from this class.
 
     Abstract: Usage documentation
-        [Custom components](../user-guides/custom-components.md)
+        [Custom components](user-guides/custom-components.md)
 
     """
 

--- a/vizro-core/src/vizro/models/_components/ag_grid.py
+++ b/vizro-core/src/vizro/models/_components/ag_grid.py
@@ -67,7 +67,7 @@ class AgGrid(VizroBaseModel):
     """Wrapper for `dash_ag_grid.AgGrid` to visualize grids in dashboard.
 
     Abstract: Usage documentation
-        [How to use an AgGrid](../user-guides/table.md/#ag-grid)
+        [How to use an AgGrid](user-guides/table.md/#ag-grid)
 
     """
 

--- a/vizro-core/src/vizro/models/_components/button.py
+++ b/vizro-core/src/vizro/models/_components/button.py
@@ -16,7 +16,7 @@ class Button(VizroBaseModel):
     """Button that can trigger actions or navigate.
 
     Abstract: Usage documentation
-        [How to use buttons](../user-guides/button.md)
+        [How to use buttons](user-guides/button.md)
 
     """
 

--- a/vizro-core/src/vizro/models/_components/card.py
+++ b/vizro-core/src/vizro/models/_components/card.py
@@ -16,7 +16,7 @@ class Card(VizroBaseModel):
     """Card based on Markdown syntax.
 
     Abstract: Usage documentation
-        [How to use cards](../user-guides/card.md)
+        [How to use cards](user-guides/card.md)
 
     """
 

--- a/vizro-core/src/vizro/models/_components/container.py
+++ b/vizro-core/src/vizro/models/_components/container.py
@@ -34,7 +34,7 @@ class Container(VizroBaseModel):
     """Container to group together a set of components on a page.
 
     Abstract: Usage documentation
-        [How to use containers](../user-guides/container.md)
+        [How to use containers](user-guides/container.md)
 
     """
 

--- a/vizro-core/src/vizro/models/_components/control_group.py
+++ b/vizro-core/src/vizro/models/_components/control_group.py
@@ -21,7 +21,7 @@ class ControlGroup(VizroBaseModel):
     """Container to group together a set of controls.
 
     Abstract: Usage documentation
-        [How to group controls](../user-guides/controls.md/#group-controls)
+        [How to group controls](user-guides/controls.md/#group-controls)
 
     Example:
         ```python

--- a/vizro-core/src/vizro/models/_components/figure.py
+++ b/vizro-core/src/vizro/models/_components/figure.py
@@ -15,7 +15,7 @@ class Figure(VizroBaseModel):
     """Object that is reactive to controls, for example a KPI card.
 
     Abstract: Usage documentation
-        [How to use figures](../user-guides/figure.md)
+        [How to use figures](user-guides/figure.md)
 
     """
 

--- a/vizro-core/src/vizro/models/_components/form/cascader.py
+++ b/vizro-core/src/vizro/models/_components/form/cascader.py
@@ -116,7 +116,7 @@ class Cascader(VizroBaseModel):
     """Cascader selector for [`Filter`][vizro.models.Filter] and [`Parameter`][vizro.models.Parameter].
 
     Abstract: Usage documentation
-        [Hierarchical selectors](../user-guides/selectors.md#hierarchical-selectors)
+        [Hierarchical selectors](user-guides/selectors.md#hierarchical-selectors)
 
     """
 

--- a/vizro-core/src/vizro/models/_components/form/checklist.py
+++ b/vizro-core/src/vizro/models/_components/form/checklist.py
@@ -26,7 +26,7 @@ class Checklist(VizroBaseModel):
     Can be provided to [`Filter`][vizro.models.Filter] or [`Parameter`][vizro.models.Parameter].
 
     Abstract: Usage documentation
-        [How to use categorical selectors](../user-guides/selectors.md#categorical-selectors)
+        [How to use categorical selectors](user-guides/selectors.md#categorical-selectors)
 
     """
 

--- a/vizro-core/src/vizro/models/_components/form/date_picker.py
+++ b/vizro-core/src/vizro/models/_components/form/date_picker.py
@@ -24,7 +24,7 @@ class DatePicker(VizroBaseModel):
     Can be provided to [`Filter`][vizro.models.Filter] or [`Parameter`][vizro.models.Parameter].
 
     Abstract: Usage documentation
-        [How to use temporal selectors](../user-guides/selectors.md#temporal-selectors)
+        [How to use temporal selectors](user-guides/selectors.md#temporal-selectors)
 
     """
 

--- a/vizro-core/src/vizro/models/_components/form/dropdown.py
+++ b/vizro-core/src/vizro/models/_components/form/dropdown.py
@@ -38,7 +38,7 @@ class Dropdown(VizroBaseModel):
     [`Parameter`][vizro.models.Parameter].
 
     Abstract: Usage documentation
-        [How to use categorical selectors](../user-guides/selectors.md#categorical-selectors)
+        [How to use categorical selectors](user-guides/selectors.md#categorical-selectors)
 
     """
 

--- a/vizro-core/src/vizro/models/_components/form/radio_items.py
+++ b/vizro-core/src/vizro/models/_components/form/radio_items.py
@@ -23,7 +23,7 @@ class RadioItems(VizroBaseModel):
     [`Parameter`][vizro.models.Parameter].
 
     Abstract: Usage documentation
-        [How to use categorical selectors](../user-guides/selectors.md/#categorical-selectors)
+        [How to use categorical selectors](user-guides/selectors.md/#categorical-selectors)
 
     """
 

--- a/vizro-core/src/vizro/models/_components/form/range_slider.py
+++ b/vizro-core/src/vizro/models/_components/form/range_slider.py
@@ -28,7 +28,7 @@ class RangeSlider(VizroBaseModel):
     [`Parameter`][vizro.models.Parameter].
 
     Abstract: Usage documentation
-        [How to use numerical selectors](../user-guides/selectors.md/#numerical-selectors)
+        [How to use numerical selectors](user-guides/selectors.md/#numerical-selectors)
 
     """
 

--- a/vizro-core/src/vizro/models/_components/form/slider.py
+++ b/vizro-core/src/vizro/models/_components/form/slider.py
@@ -28,7 +28,7 @@ class Slider(VizroBaseModel):
     [`Parameter`][vizro.models.Parameter].
 
     Abstract: Usage documentation
-        [How to use numerical selectors](../user-guides/selectors.md/#numerical-selectors)
+        [How to use numerical selectors](user-guides/selectors.md/#numerical-selectors)
 
     """
 

--- a/vizro-core/src/vizro/models/_components/form/switch.py
+++ b/vizro-core/src/vizro/models/_components/form/switch.py
@@ -17,7 +17,7 @@ class Switch(VizroBaseModel):
     Can be provided to [`Filter`][vizro.models.Filter] or [`Parameter`][vizro.models.Parameter].
 
     Abstract: Usage documentation
-        [How to use boolean selectors](../user-guides/selectors.md/#boolean-selectors)
+        [How to use boolean selectors](user-guides/selectors.md/#boolean-selectors)
 
     """
 

--- a/vizro-core/src/vizro/models/_components/graph.py
+++ b/vizro-core/src/vizro/models/_components/graph.py
@@ -40,7 +40,7 @@ class Graph(VizroBaseModel):
     """Wrapper for `dcc.Graph` to visualize charts.
 
     Abstract: Usage documentation
-        [How to use graphs](../user-guides/graph.md)
+        [How to use graphs](user-guides/graph.md)
 
     """
 

--- a/vizro-core/src/vizro/models/_components/table.py
+++ b/vizro-core/src/vizro/models/_components/table.py
@@ -35,7 +35,7 @@ class Table(VizroBaseModel):
     """Wrapper for `dash_table.DataTable` to visualize tables in dashboard.
 
     Abstract: Usage documentation
-        [How to use tables](../user-guides/table.md)
+        [How to use tables](user-guides/table.md)
 
     """
 

--- a/vizro-core/src/vizro/models/_components/tabs.py
+++ b/vizro-core/src/vizro/models/_components/tabs.py
@@ -25,7 +25,7 @@ class Tabs(VizroBaseModel):
     """Tabs to group together a set of [`Containers`][vizro.models.Container].
 
     Abstract: Usage documentation
-        [How to use tabs](../user-guides/tabs.md)
+        [How to use tabs](user-guides/tabs.md)
 
     """
 

--- a/vizro-core/src/vizro/models/_components/text.py
+++ b/vizro-core/src/vizro/models/_components/text.py
@@ -13,7 +13,7 @@ class Text(VizroBaseModel):
     """Text based on Markdown syntax.
 
     Abstract: Usage documentation
-        [How to add text to your page](../user-guides/text.md)
+        [How to add text to your page](user-guides/text.md)
 
     """
 

--- a/vizro-core/src/vizro/models/_controls/filter.py
+++ b/vizro-core/src/vizro/models/_controls/filter.py
@@ -113,7 +113,7 @@ class Filter(VizroBaseModel):
     """Filter the data supplied to `targets`.
 
     Abstract: Usage documentation
-        [How to use filters](../user-guides/filters.md)
+        [How to use filters](user-guides/filters.md)
 
     Example:
         ```python

--- a/vizro-core/src/vizro/models/_controls/parameter.py
+++ b/vizro-core/src/vizro/models/_controls/parameter.py
@@ -58,7 +58,7 @@ class Parameter(VizroBaseModel):
     """Alter the arguments supplied to any `targets`.
 
     Abstract: Usage documentation
-        [How to use parameters](../user-guides/parameters.md)
+        [How to use parameters](user-guides/parameters.md)
 
     Example:
         ```python

--- a/vizro-core/src/vizro/models/_dashboard.py
+++ b/vizro-core/src/vizro/models/_dashboard.py
@@ -91,7 +91,7 @@ class Dashboard(VizroBaseModel):
     """Dashboard that is supplied to [`Vizro.build`][vizro.Vizro.build].
 
     Abstract: Usage documentation
-        [How to create a dashboard](../user-guides/dashboard.md)
+        [How to create a dashboard](user-guides/dashboard.md)
 
     """
 

--- a/vizro-core/src/vizro/models/_flex.py
+++ b/vizro-core/src/vizro/models/_flex.py
@@ -14,7 +14,7 @@ class Flex(VizroBaseModel):
     """Flex layout for components on a [`Page`][vizro.models.Page] or in a [`Container`][vizro.models.Container].
 
     Abstract: Usage documentation
-        [How to use the Flex layout](../user-guides/layouts.md#flex-layout)
+        [How to use the Flex layout](user-guides/layouts.md#flex-layout)
 
     """
 

--- a/vizro-core/src/vizro/models/_grid.py
+++ b/vizro-core/src/vizro/models/_grid.py
@@ -169,7 +169,7 @@ class Grid(VizroBaseModel):
     """Grid layout for components on a [`Page`][vizro.models.Page] or in a [`Container`][vizro.models.Container].
 
     Abstract: Usage documentation
-        [How to use the Grid layout](../user-guides/layouts.md#grid-layout)
+        [How to use the Grid layout](user-guides/layouts.md#grid-layout)
 
     """
 

--- a/vizro-core/src/vizro/models/_navigation/accordion.py
+++ b/vizro-core/src/vizro/models/_navigation/accordion.py
@@ -23,7 +23,7 @@ class Accordion(VizroBaseModel):
     """Accordion to be used as `nav_selector` in [`Navigation`][vizro.models.Navigation].
 
     Abstract: Usage documentation
-        [How to use an accordion](../user-guides/navigation.md/#group-pages)
+        [How to use an accordion](user-guides/navigation.md/#group-pages)
 
     """
 

--- a/vizro-core/src/vizro/models/_navigation/nav_bar.py
+++ b/vizro-core/src/vizro/models/_navigation/nav_bar.py
@@ -25,7 +25,7 @@ class NavBar(VizroBaseModel):
     """Navigation bar to be used as a `nav_selector` for `Navigation`.
 
     Abstract: Usage documentation
-        [How to use the navigation bar](../user-guides/navigation.md#use-a-navigation-bar-with-icons)
+        [How to use the navigation bar](user-guides/navigation.md#use-a-navigation-bar-with-icons)
     """
 
     type: Literal["nav_bar"] = "nav_bar"

--- a/vizro-core/src/vizro/models/_navigation/nav_link.py
+++ b/vizro-core/src/vizro/models/_navigation/nav_link.py
@@ -20,7 +20,7 @@ class NavLink(VizroBaseModel):
     """Icon that serves as a navigation link to be used in a [`NavBar`][vizro.models.NavBar].
 
     Abstract: Usage documentation
-        [How to customize the NavBar icons](../user-guides/navigation.md#change-icons)
+        [How to customize the NavBar icons](user-guides/navigation.md#change-icons)
 
     """
 

--- a/vizro-core/src/vizro/models/_navigation/navigation.py
+++ b/vizro-core/src/vizro/models/_navigation/navigation.py
@@ -17,7 +17,7 @@ class Navigation(VizroBaseModel):
     """Navigation to arrange hierarchy of [`Pages`][vizro.models.Page].
 
     Abstract: Usage documentation
-        [How to customize the navigation](../user-guides/navigation.md)
+        [How to customize the navigation](user-guides/navigation.md)
 
     """
 

--- a/vizro-core/src/vizro/models/_page.py
+++ b/vizro-core/src/vizro/models/_page.py
@@ -54,7 +54,7 @@ class Page(VizroBaseModel):
     """A page in [`Dashboard`][vizro.models.Dashboard] with its own URL path and place in the `Navigation`.
 
     Abstract: Usage documentation
-        [How to make dashboard pages](../user-guides/pages.md)
+        [How to make dashboard pages](user-guides/pages.md)
 
     """
 

--- a/vizro-core/src/vizro/models/_tooltip.py
+++ b/vizro-core/src/vizro/models/_tooltip.py
@@ -26,13 +26,13 @@ class Tooltip(VizroBaseModel):
     """A tooltip that displays text when hovering over an icon.
 
     Abstract: Usage documentation
-        Read more about usage in the guides on [dashboards](../user-guides/dashboard.md#add-a-dashboard-tooltip),
-        [pages](../user-guides/pages.md#add-a-tooltip),
-        [containers](../user-guides/container.md#add-a-tooltip),
-        [graphs](../user-guides/graph.md#add-a-tooltip),
-        [tables](../user-guides/table.md#add-a-tooltip), [tabs](../user-guides/tabs.md#add-a-tooltip),
-        [selectors](../user-guides/selectors.md#add-a-tooltip) and
-        [buttons](../user-guides/button.md#add-a-tooltip).
+        Read more about usage in the guides on [dashboards](user-guides/dashboard.md#add-a-dashboard-tooltip),
+        [pages](user-guides/pages.md#add-a-tooltip),
+        [containers](user-guides/container.md#add-a-tooltip),
+        [graphs](user-guides/graph.md#add-a-tooltip),
+        [tables](user-guides/table.md#add-a-tooltip), [tabs](user-guides/tabs.md#add-a-tooltip),
+        [selectors](user-guides/selectors.md#add-a-tooltip) and
+        [buttons](user-guides/button.md#add-a-tooltip).
 
     Example: `Tooltip` on a [`Checklist`][vizro.models.Checklist] selector
         ```python

--- a/vizro-core/src/vizro/models/types.py
+++ b/vizro-core/src/vizro/models/types.py
@@ -471,10 +471,10 @@ class capture:
     """Captures a function call to create a custom [`CapturedCallable`][vizro.models.types.CapturedCallable].
 
     Abstract: Usage documentation
-        [How to create custom actions](../user-guides/custom-actions.md),
-        [How to create custom charts](../user-guides/custom-charts.md),
-        [How to create custom tables](../user-guides/custom-tables.md),
-        [How to create figures](../user-guides/custom-figures.md).
+        [How to create custom actions](user-guides/custom-actions.md),
+        [How to create custom charts](user-guides/custom-charts.md),
+        [How to create custom tables](user-guides/custom-tables.md),
+        [How to create figures](user-guides/custom-figures.md).
 
     Args:
         mode: The mode of the captured callable.

--- a/vizro-core/src/vizro/tables/__init__.py
+++ b/vizro-core/src/vizro/tables/__init__.py
@@ -1,7 +1,7 @@
 """Built-in table functions.
 
 Abstract: Usage documentation
-    [How to use tables](../user-guides/table.md)
+    [How to use tables](user-guides/table.md)
 """
 
 from vizro.tables._dash_ag_grid import dash_ag_grid

--- a/vizro-core/src/vizro/tables/_dash_ag_grid.py
+++ b/vizro-core/src/vizro/tables/_dash_ag_grid.py
@@ -53,7 +53,7 @@ def dash_ag_grid(data_frame: pd.DataFrame, **kwargs: Any) -> dag.AgGrid:
     """Implementation of `dash_ag_grid.AgGrid` with sensible defaults to be used in [`AgGrid`][vizro.models.AgGrid].
 
     Abstract: Usage documentation
-        [How to use AG Grid](../user-guides/table.md#ag-grid)
+        [How to use AG Grid](user-guides/table.md#ag-grid)
 
     Args:
         data_frame: DataFrame containing the data to be displayed.

--- a/vizro-core/src/vizro/tables/_dash_table.py
+++ b/vizro-core/src/vizro/tables/_dash_table.py
@@ -14,7 +14,7 @@ def dash_data_table(data_frame: pd.DataFrame, **kwargs: Any) -> dash_table.DataT
     """Standard `dash.dash_table.DataTable` with sensible defaults to be used in [`Table`][vizro.models.Table].
 
     Abstract: Usage documentation
-        [How to use Dash DataTable](../user-guides/table.md#dash-datatable)
+        [How to use Dash DataTable](user-guides/table.md#dash-datatable)
 
     Args:
         data_frame: DataFrame containing the data to be displayed.

--- a/vizro-core/src/vizro/themes/__init__.py
+++ b/vizro-core/src/vizro/themes/__init__.py
@@ -1,7 +1,7 @@
 """Palettes and colors.
 
 Abstract: Usage documentation
-    [How to use palettes](../user-guides/themes.md#palettes)
+    [How to use palettes](user-guides/themes.md#palettes)
 """
 
 from ._colors import colors

--- a/vizro-core/src/vizro/themes/_colors.py
+++ b/vizro-core/src/vizro/themes/_colors.py
@@ -125,5 +125,5 @@ Examples:
     # gives "#0F766E"
     ```
 
-![Colors](../../assets/user_guides/themes/colors.png)
+![Colors](../assets/user_guides/themes/colors.png)
 """

--- a/vizro-core/src/vizro/themes/_palettes.py
+++ b/vizro-core/src/vizro/themes/_palettes.py
@@ -233,6 +233,6 @@ Examples:
 
 | Dark Theme | Light Theme |
 | --- | --- |
-| ![Qualitative Palette Dark](../../assets/user_guides/themes/palette_qualitative_dark.png) | ![Qualitative Palette Light](../../assets/user_guides/themes/palette_qualitative_light.png) |
-| ![Continuous Palettes Dark](../../assets/user_guides/themes/palettes_continuous_dark.png) | ![Continuous Palettes Light](../../assets/user_guides/themes/palettes_continuous_light.png) |
+| ![Qualitative Palette Dark](../assets/user_guides/themes/palette_qualitative_dark.png) | ![Qualitative Palette Light](../assets/user_guides/themes/palette_qualitative_light.png) |
+| ![Continuous Palettes Dark](../assets/user_guides/themes/palettes_continuous_dark.png) | ![Continuous Palettes Light](../assets/user_guides/themes/palettes_continuous_light.png) |
 """  # noqa: E501


### PR DESCRIPTION
## Description
Closes https://github.com/McK-Internal/vizro-internal/issues/2711


Zensical docs seem to have started doing linking to assets differently, so our API docs have broken where they link to markdown. This set of fixes now resolves it...and ensures linkchecker tests pass (when combined with #1709).

[Built docs for API reference](https://vizro--1710.org.readthedocs.build/en/1710/pages/API-reference/vizro/) Links in the admonitions labelled "Usage documentation" will now resolve correctly.

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
