### PR TITLE
[Docs] Update docstrings in vizro-core to follow preferred style

### DIFF
--- a/vizro-core/examples/dev/app.py
+++ b/vizro-core/examples/dev/app.py
@@ -914,7 +914,7 @@ grid_layout = vm.Page(
     ],
     description="""
         Use Grid when you have a specific layout in mind—like a dashboard with clearly defined sections
-        (e.g. top summary row, bottom detail view).
+        (for example, top summary row, bottom detail view).
     """,
 )
 

--- a/vizro-core/examples/dev/yaml_version/dashboard.yaml
+++ b/vizro-core/examples/dev/yaml_version/dashboard.yaml
@@ -397,7 +397,7 @@ pages:
     title: Tabs
   - components:
       - text: |
-          A selector can be used within the **Parameter** or **Filter** component to allow the user to select a value.
+          A selector can be used within the **Parameter** or **Filter** component to enable the user to select a value.
 
           The following selectors are available:
           * Dropdown (**categorical** multi and single option selector)
@@ -731,7 +731,7 @@ pages:
         type: card
     description: |
       Use Grid when you have a specific layout in mind—like a dashboard with clearly defined sections
-      (e.g. top summary row, bottom detail view).
+      (for example, top summary row, bottom detail view).
     layout:
       grid:
         [[0, 0, 0, 0], [1, 1, 3, 3], [1, 1, 4, 4], [2, 2, 5, 5], [2, 2, 6, 6]]

--- a/vizro-core/examples/visual-vocabulary/app.py
+++ b/vizro-core/examples/visual-vocabulary/app.py
@@ -16,7 +16,7 @@ def make_chart_card(page: vm.Page | IncompletePage) -> vm.Card:
     Returns: card with svg icon, linked to the right page if page is complete.
 
     """
-    # There's one SVG per chart title, so that e.g. pages distribution-butterfly and deviation-butterfly, which both
+    # There's one SVG per chart title. For example, pages distribution-butterfly and deviation-butterfly, which both
     # have title "Butterfly", correspond to butterfly.svg.
     # Incomplete pages have page.path = "" so won't be linked to here.
     svg_name = page.title.lower().replace(" ", "-")
@@ -39,7 +39,7 @@ def make_homepage_container(chart_group: ChartGroup) -> vm.Container:
     Returns: container with cards for each chart in chart_group.
 
     """
-    # Pages are sorted in title's alphabetical order and deduplicated so that e.g. pages distribution-butterfly and
+    # Pages are sorted in title's alphabetical order and deduplicated. For example, pages distribution-butterfly and
     # deviation-butterfly, which both have title "Butterfly", correspond to a single card.
     return vm.Container(
         title=chart_group.name,
@@ -91,10 +91,10 @@ homepage = vm.Page(
 )
 
 # TODO: consider whether each chart group should have its own individual homepage,
-# e.g. at http://localhost:8050/deviation/. This could just repeat the content of the tab from the homepage and would
+# For example, at http://localhost:8050/deviation/. This could repeat the content of the tab from the homepage and would
 # work nicely with the hierarchical navigation.
 dashboard = vm.Dashboard(
-    # ALL_CHART_GROUP.pages has duplicated pages, e.g. both distribution-butterfly and deviation-butterfly.
+    # ALL_CHART_GROUP.pages has duplicated pages, for example, both distribution-butterfly and deviation-butterfly.
     title="Visual vocabulary",
     pages=[homepage, *ALL_CHART_GROUP.pages],
     navigation=vm.Navigation(

--- a/vizro-core/examples/visual-vocabulary/pages/_factories.py
+++ b/vizro-core/examples/visual-vocabulary/pages/_factories.py
@@ -116,7 +116,7 @@ def column_and_line_factory(group: str):
                 #### When should I use it?
 
                 Use this type of chart when you wish to compare quantities of one item with changes in another item.
-                It's ideal for showing patterns over time (e.g., monthly sales and growth rates) but can also be used
+                It's ideal for showing patterns over time, such as monthly sales and growth rates, but can also be used
                 for other types of data comparisons.
         """
             ),

--- a/vizro-core/examples/visual-vocabulary/pages/deviation.py
+++ b/vizro-core/examples/visual-vocabulary/pages/deviation.py
@@ -64,7 +64,7 @@ diverging_stacked_bar_page = vm.Page(
             A diverging stacked bar chart is like a stacked bar chart but aligns bars on a central baseline instead of
             the left or right. It displays positive and negative values, with each bar divided into segments for
             different categories. This type of chart is commonly used for percentage shares, especially in survey
-            results using Likert scales (e.g., Strongly Disagree, Disagree, Agree, Strongly Agree).
+            results using Likert scales (for example, Strongly Disagree, Disagree, Agree, Strongly Agree).
 
             &nbsp;
 

--- a/vizro-core/examples/visual-vocabulary/pages/part_to_whole.py
+++ b/vizro-core/examples/visual-vocabulary/pages/part_to_whole.py
@@ -348,7 +348,7 @@ gridplot_page = vm.Page(
             Use a grid plot when you need to compare distributions, trends, or relationships across multiple
             groups while preserving a consistent visual structure. The grid layout makes it easy to spot patterns
             that would be difficult to see in a single aggregated chart. Grid plots are particularly effective
-            when faceting by two dimensions (e.g., time and category), as the row and column arrangement guides
+            when faceting by two dimensions (for example, time and category), as the row and column arrangement guides
             the viewer's eye toward meaningful comparisons.
         """
         ),

--- a/vizro-core/examples/visual-vocabulary/pages/time.py
+++ b/vizro-core/examples/visual-vocabulary/pages/time.py
@@ -182,7 +182,7 @@ heatmap_page = vm.Page(
             #### When should I use it?
 
             Use a heatmap chart to visualize time patterns and identify trends between two variables.
-            Typically, the x-axis represents time intervals (e.g., hours, days, months), while the y-axis represents
+            Typically, the x-axis represents time intervals, such as hours, days, or months, while the y-axis represents
             categories or different variables. By observing color changes across the grid, you can easily spot
             patterns and correlations.
         """

--- a/vizro-core/src/vizro/__init__.py
+++ b/vizro-core/src/vizro/__init__.py
@@ -19,7 +19,7 @@ pio.templates["vizro_light"] = json.loads((base_path / "vizro_light.json").read_
 __all__ = ["Vizro"]
 __version__ = "0.1.60.dev0"
 
-# For dev versions, a branch or tag called e.g. 0.1.20.dev0 does not exist and so won't work with the CDN. We point
+# For dev versions, a branch or tag such as 0.1.20.dev0 does not exist and so won't work with the CDN. We point
 # to main instead, but this can be manually overridden to the current feature branch name if required.
 # This would only be the case where you need to test something with serve_locally=False and have changed
 # assets compared to main. In this case you need to push your assets changes to remote for the CDN to update,
@@ -40,7 +40,7 @@ bootstrap = f"{BASE_EXTERNAL_URL}static/css/vizro-bootstrap.min.css"
 # import of vizro, regardless of whether the Vizro class or any other bits are used.
 ComponentRegistry.registry.add("vizro")
 
-# Files needed to use Vizro as a library (not a framework), e.g. in a pure Dash app.
+# Files needed to use Vizro as a library (not a framework), for example, in a pure Dash app.
 # This list should be kept to the bare minimum so we don't insert any more than the minimum required CSS on pure Dash
 # apps. At the moment the only library components we support just are KPI cards. Note that anything that's not CSS
 # is handled as a script, even if it's a font file or image.

--- a/vizro-core/src/vizro/_vizro.py
+++ b/vizro-core/src/vizro/_vizro.py
@@ -108,7 +108,7 @@ class Vizro:
         # Automatically detect if Bootstrap CSS is provided in external_stylesheets
         use_vizro_bootstrap = not self._has_bootstrap_css(kwargs.get("external_stylesheets", []))
 
-        # vizro-bootstrap.min.css must be first so that it can be overridden, e.g. by bootstrap_overrides.css.
+        # vizro-bootstrap.min.css must be first so that it can be overridden, for example, by bootstrap_overrides.css.
         # After that, all other items are sorted alphabetically.
         for path in sorted(
             VIZRO_ASSETS_PATH.rglob("*.*"), key=lambda file: (file.name != "vizro-bootstrap.min.css", file)
@@ -307,7 +307,7 @@ Provide a valid import path for these in your dashboard configuration."""
     @staticmethod
     def _pre_build():
         """Runs pre_build method on all models in the model_manager."""
-        # Note that a pre_build method can itself add a model (e.g. an Action) to the model manager, and so we need to
+        # Note that a pre_build method can itself add a model, for example an Action, to the model manager. We need to
         # iterate through set(model_manager) rather than model_manager itself or we loop through something that
         # changes size.
         # Any models that are created during the pre-build process *will not* themselves have pre_build run on them.
@@ -330,7 +330,7 @@ Provide a valid import path for these in your dashboard configuration."""
     def __call__(self, environ: WSGIEnvironment, start_response: StartResponse) -> Iterable[bytes]:
         """Implements WSGI application interface.
 
-        This means you can do e.g. gunicorn app:app without needing to manually define server = app.dash.server.
+        This means you can run `gunicorn app:app` without manually defining `server = app.dash.server`.
         """
         return self.dash.server(environ, start_response)
 
@@ -381,7 +381,7 @@ class _ResourceType(TypedDict, total=False):
 
 
 def _make_resource_spec(path: Path) -> _ResourceType:
-    # For dev versions, a branch or tag called e.g. 0.1.20.dev0 does not exist and so won't work with the CDN. We point
+    # For dev versions, a branch or tag such as 0.1.20.dev0 does not exist and so won't work with the CDN. We point
     # to main instead, but this can be manually overridden to the current feature branch name if required.
     # This would only be the case where you need to test something with serve_locally=False and have changed
     # assets compared to main. In this case you need to push your assets changes to remote for the CDN to update,

--- a/vizro-core/src/vizro/actions/_abstract_action.py
+++ b/vizro-core/src/vizro/actions/_abstract_action.py
@@ -20,10 +20,10 @@ class _AbstractAction(_BaseAction, abc.ABC):
     When subclassing, you can optionally define model fields. These can be either static or runtime arguments and
     define the configuration that a user specifies to use the action:
 
-      * static arguments, e.g. `file_format = "csv"`, are fixed upfront and do not change depending on the state of the
+      * static arguments, such as `file_format = "csv"`, are fixed upfront and do not change with the state of the
       dashboard.
       * runtime arguments depend on the state of the running dashboard on the user's screen. These correspond to Dash
-      States, e.g. `country="dropdown.value"` becomes `State("dropdown", "value")`.
+      States, for example, `country="dropdown.value"` becomes `State("dropdown", "value")`.
     """
 
     # Note this model itself cannot have any fields (aside from `id` that comes from `VizroBaseModel`) or that field
@@ -36,10 +36,10 @@ class _AbstractAction(_BaseAction, abc.ABC):
         This is always called using keyword-arguments so cannot have positional-only arguments.
 
         Any static arguments should not go explicitly in the function signature but instead be accessed through
-        `self`, e.g. `self.file_format`.
+        `self`, for example, `self.file_format`.
 
         Any runtime arguments that were defined as model fields must go explicitly in the function signature,
-        e.g. `country`.
+        for example, `country`.
 
         In addition to the runtime arguments specified as model fields, you can also use the following built-in
         arguments:
@@ -65,7 +65,7 @@ class _AbstractAction(_BaseAction, abc.ABC):
         #  supply a dictionary ID but in future will probably change to use a single built-in vizro_download component.
         #  See https://github.com/mckinsey/vizro/pull/1054#discussion_r1989405177.
         #
-        # We should probably not build in behavior here e.g. to generate outputs automatically from certain reserved
+        # We should probably not build in behavior here. For example, generating outputs automatically from reserved
         # arguments since this would only work well for class-based actions and not @capture("action") ones. Instead
         # the code that does make_outputs_from_targets would be put into a reusable function.
         pass

--- a/vizro-core/src/vizro/actions/_actions_utils.py
+++ b/vizro-core/src/vizro/actions/_actions_utils.py
@@ -131,7 +131,7 @@ def _get_target_dot_separated_strings(dot_separated_strings: list[str], target: 
 
     Args:
         dot_separated_strings: list of dot separated strings that can be targeted by a vm.Parameter,
-            e.g. ["target_name.data_frame.arg", "target_name.x"]
+            for example, ["target_name.data_frame.arg", "target_name.x"]
         target: id of targeted Figure.
         data_frame: whether to return only DataFrame parameters starting "data_frame." or only non-DataFrame parameters.
 

--- a/vizro-core/src/vizro/actions/_export_data.py
+++ b/vizro-core/src/vizro/actions/_export_data.py
@@ -90,7 +90,7 @@ class export_data(_AbstractAction):
     #  to use a single built-in vizro_download component.
     #  This would mean we don't need to provide dash_components any more.
     #  If it turns out in https://github.com/McK-Internal/vizro-internal/issues/1612 that we need dash_components anyway
-    #  to do e.g. synced filters between pages then this change becomes pointless.
+    #  to do, for example, synced filters between pages then this change becomes pointless.
 
     @property
     def _transformed_outputs(self) -> dict[str, Output]:

--- a/vizro-core/src/vizro/actions/_filter_action.py
+++ b/vizro-core/src/vizro/actions/_filter_action.py
@@ -23,7 +23,7 @@ class _filter(_AbstractAction):
         """Applies _controls to charts on page once filter is applied.
 
         Returns:
-            Dict mapping target chart ids to modified figures e.g. {"my_scatter": Figure(...)}.
+            Dict mapping target chart ids to modified figures, for example, {"my_scatter": Figure(...)}.
         """
         # This is identical to _on_page_load.
         # TODO-AV2 A 1: _controls is not currently used but instead taken out of the Dash context. This

--- a/vizro-core/src/vizro/actions/_filter_interaction.py
+++ b/vizro-core/src/vizro/actions/_filter_interaction.py
@@ -52,7 +52,7 @@ class filter_interaction(_AbstractAction):
         #  triggered_model._filter_interaction_input. We should revisit this when reworking filter interaction
         #  to find a better way to reintegrate it. Possibly now that self._inner_component_id is now set in
         #  model_post_init rather than pre_build there's an easier solution here.
-        # # Check that the triggered model has the required attributes (e.g. Graph does but Button doesn't).
+        # # Check that the triggered model has the required attributes (for example, Graph does but Button doesn't).
         # # This could potentially be done with isinstance and FigureWithFilterInteractionType but filter_interaction
         # # will be removed in future anyway.
         # triggered_model = self._get_triggered_model()
@@ -70,7 +70,7 @@ class filter_interaction(_AbstractAction):
         """Applies _controls to charts on page once the page is opened (or refreshed).
 
         Returns:
-            Dict mapping target chart ids to modified figures e.g. {"my_scatter": Figure(...)}.
+            Dict mapping target chart ids to modified figures, for example, {"my_scatter": Figure(...)}.
         """
         # TODO-AV2 A 1: _controls is not currently used but instead taken out of the Dash context. This
         # will change in future once the structure of _controls has been worked out and we know how to pass ids through.

--- a/vizro-core/src/vizro/actions/_on_page_load.py
+++ b/vizro-core/src/vizro/actions/_on_page_load.py
@@ -21,7 +21,7 @@ class _on_page_load(_AbstractAction):
         """Applies controls to charts on page once the page is opened (or refreshed).
 
         Returns:
-            Dict mapping target chart ids to modified figures e.g. {"my_scatter": Figure(...)}.
+            Dict mapping target chart ids to modified figures, for example, {"my_scatter": Figure(...)}.
 
         """
         # TODO-AV2 A 1: _controls is not currently used but instead taken out of the Dash context. This

--- a/vizro-core/src/vizro/actions/_parameter_action.py
+++ b/vizro-core/src/vizro/actions/_parameter_action.py
@@ -28,7 +28,7 @@ class _parameter(_AbstractAction):
         """Applies _controls to charts on page once the page is opened (or refreshed).
 
         Returns:
-            Dict mapping target chart ids to modified figures e.g. {"my_scatter": Figure(...)}.
+            Dict mapping target chart ids to modified figures, for example, {"my_scatter": Figure(...)}.
 
         """
         # This is identical to _on_page_load but with self._target_ids rather than self.targets.

--- a/vizro-core/src/vizro/actions/_set_control.py
+++ b/vizro-core/src/vizro/actions/_set_control.py
@@ -134,7 +134,7 @@ class set_control(_AbstractAction):
         if not isinstance(self._parent_model, _SupportsSetControl):
             raise ValueError(
                 f"`set_control` action was added to the model with ID `{self._parent_model.id}`, "
-                "but this action can only be used with models that support it (e.g. Graph, AgGrid, Figure, and so on). "
+                "but this action can only be used with models that support it, such as Graph, AgGrid, and Figure. "
                 "See all models that can source a `set_control` at "
                 "https://vizro.readthedocs.io/en/stable/pages/API-reference/actions/#vizro.actions.set_control"
             )
@@ -152,7 +152,7 @@ class set_control(_AbstractAction):
         if not hasattr(control_model, "selector"):
             raise TypeError(
                 f"Model with ID `{self.control}` used as a `control` in `set_control` action must be a control model "
-                f"(e.g. Filter, Parameter)."
+                f"(for example, Filter, Parameter)."
             )
 
         if control_model_page == model_manager._get_model_page(self):

--- a/vizro-core/src/vizro/figures/library.py
+++ b/vizro-core/src/vizro/figures/library.py
@@ -120,9 +120,9 @@ def kpi_card_reference(  # noqa: PLR0913
             `value_column`.
         icon: Name of the icon from the [Google Material Icon Library](https://fonts.google.com/icons)
             to be displayed on the left side of the KPI title. If not provided, no icon is displayed.
-        reverse_color: If `False`, a positive delta will be colored positively (e.g., blue) and a negative delta
-            negatively (e.g., red). If `True`, the colors will be inverted: a positive delta will be colored
-            negatively (e.g., red) and a negative delta positively (e.g., blue).
+        reverse_color: If `False`, a positive delta will be colored positively (for example, blue) and a negative delta
+            negatively (for example, red). If `True`, the colors will be inverted: a positive delta will be colored
+            negatively (for example, red) and a negative delta positively (for example, blue).
 
     Returns:
         A Dash Bootstrap Components card (`dbc.Card`) containing the formatted KPI value and reference.

--- a/vizro-core/src/vizro/managers/_data_manager.py
+++ b/vizro-core/src/vizro/managers/_data_manager.py
@@ -109,7 +109,7 @@ class _StaticData:
         """Loads data.
 
         Returns a copy of the data. This is not necessary if we are careful to not do any inplace=True operations,
-        but safest to leave it here, e.g. in case a user-defined action mutates the data. To be even safer we could
+        but safest to leave it here in case a user-defined action mutates the data. To be even safer, we could
         additionally (but not instead) copy data when setting it in __init__ but this consumes more memory and is not
         necessary so long as data is only ever accessed through the intended API of data_manager["static_data"].load().
         """
@@ -169,12 +169,12 @@ class DataManager:
             # correctly - see https://github.com/mckinsey/vizro/blob/abb7eebb230ba7e6cfdf6150dc56b211a78b1cd5/
             # vizro-core/src/vizro/managers/_data_manager.py.
             # Once partial has been used, all dynamic data sources are on equal footing since they're all treated as
-            # functions rather than bound methods, e.g. by flask_caching.utils.function_namespace. This makes it much
+            # functions rather than bound methods. flask_caching.utils.function_namespace handles this, making it much
             # simpler to use flask-caching reliably.
             # Note that for kedro>=0.19.9 we use lambda: catalog.load(dataset_name) rather than dataset.load so the
             # bound method case no longer arises when using kedro integration.
             # It's important the __qualname__ is the same across all workers, so use the data source name rather than
-            # e.g. the repr method that includes the id of the instance so would only work in the case that gunicorn is
+            # The repr method includes the ID of the instance, so it would only work if gunicorn is
             # running with --preload.
             # __module__ is also required in flask_caching.utils.function_namespace and not defined for partial
             # functions in some versions of Python.
@@ -237,7 +237,7 @@ class DataManager:
 
     def _clear(self):
         # We do not actually call self.cache.clear() because (a) it would only work when self._cache_has_app is True,
-        # which is not the case when e.g. Vizro._reset is called, and (b) because we do not want to accidentally
+        # which is not the case when Vizro._reset is called, and (b) because we do not want to accidentally
         # clear the cache if we eventually put a call to Vizro._reset inside Vizro(), since cache should be persisted
         # across server restarts.
         self.__init__()  # type: ignore[misc]

--- a/vizro-core/src/vizro/managers/_model_manager.py
+++ b/vizro-core/src/vizro/managers/_model_manager.py
@@ -23,7 +23,7 @@ class FIGURE_MODELS:
 
 
 class DuplicateIDError(ValueError):
-    """Useful for providing a more explicit error message when a model has id set automatically, e.g. Page."""
+    """Useful for providing a more explicit error message when a model has id set automatically, for example, Page."""
 
 
 class ModelManager:

--- a/vizro-core/src/vizro/models/_action/_action.py
+++ b/vizro-core/src/vizro/models/_action/_action.py
@@ -184,7 +184,7 @@ class _BaseAction(VizroBaseModel):
 
         page = model_manager._get_model_page(self)
 
-        # States are stored in the parent model (e.g. AgGrid) whose actions contains the filter_interaction rather than
+        # States are stored in the parent model, such as AgGrid. Its actions contains the filter_interaction rather than
         # the filter_interaction model itself, hence needing to lookup action._parent_model.
         # This is also needed to trigger the parent model's `_get_value_from_trigger` method in set_control.
         # After work on the model_manager we should be able to tidy this to directly get the parent model
@@ -200,10 +200,10 @@ class _BaseAction(VizroBaseModel):
         """Transform a component dependency into its mapped property value.
 
         This method handles two formats of component dependencies:
-        1. Explicit format: "component-id.component-property" (e.g. "graph-1.figure")
+        1. Explicit format: "component-id.component-property" (for example, "graph-1.figure")
            - Returns the mapped value if it exists in the component's _action_outputs/_action_inputs
            - Returns the original dependency otherwise
-        2. Implicit format: "component-id" (e.g. "card-id")
+        2. Implicit format: "component-id" (for example, "card-id")
            - Returns the value of "__default__" key from the component's _action_outputs/_action_inputs
            - Raises an error if the component doesn't exist or doesn't have the required property
 
@@ -218,7 +218,7 @@ class _BaseAction(VizroBaseModel):
             KeyError: If component does not exist in model_manager
             KeyError: If component exists but has no "__default__" key in its _action_outputs/_action_inputs
             AttributeError: If component exists but has no _action_outputs/_action_inputs property defined
-            ValueError: If dependency format is invalid (e.g. "id.prop.prop" or "id..prop")
+            ValueError: If dependency format is invalid (for example, "id.prop.prop" or "id..prop")
         """
         attribute_type = "_action_outputs" if type == "output" else "_action_inputs"
 
@@ -242,7 +242,7 @@ class _BaseAction(VizroBaseModel):
                 return getattr(models[component_id], attribute_type)[component_property]
             except (KeyError, AttributeError):
                 # Captures these cases and returns dependency unchanged, as we want to enable the user to target
-                # Dash components, that are not registered in the model_manager (e.g. theme-selector).
+                # Dash components, that are not registered in the model_manager (for example, theme-selector).
                 # 1. component_id is not in model_manager
                 # 2. component doesn't have _action_outputs/_action_inputs defined
                 # 3. component_property is not in the _action_outputs/inputs dictionary
@@ -342,8 +342,8 @@ class _BaseAction(VizroBaseModel):
             callback_outputs = [_transform_output(output) for output in self._validated_outputs]
 
             # Need to use a single Output in the @callback decorator rather than a single element list for the case
-            # of a single output. This means the action function can return a single value (e.g. "text") rather than a
-            # single element list (e.g. ["text"]).
+            # of a single output. This means the action function can return a single value, such as "text", instead of a
+            # single element list (for example, ["text"]).
             if len(callback_outputs) == 1:
                 [callback_outputs] = callback_outputs
             return callback_outputs
@@ -564,7 +564,7 @@ class _BaseAction(VizroBaseModel):
             # prevent_initial_call=True which otherwise does not prevent initial callback execution when
             # an Input component appears if an Output already exists in the page layout:
             # https://dash.plotly.com/advanced-callbacks#prevent-callback-execution-upon-initial-component-render
-            # e.g. for the case of a dynamic filter, we want the guard to let through genuine callback triggers (user
+            # For a dynamic filter, we want the guard to let through genuine callback triggers (user
             # changes value of filter) vs. when the dropdown is created. This works as follows:
             #   1. When a new dynamic component is created, a dcc.Store component labeled *_guard_actions_chain
             #   is created at the same time with data=True.
@@ -804,7 +804,7 @@ class Action(_BaseAction):
 
     @property
     def _parameters(self) -> set[str]:
-        # TODO-AV2 B 2: in future, if we improve wrapping of __call__ inside CapturedCallable (e.g. by using wrapt),
+        # TODO-AV2 B 2: In future, we could improve wrapping of __call__ inside CapturedCallable with wrapt.
         #  this could be done the same way as in _AbstractAction and avoid looking at _function. Then we could remove
         #  this _parameters property from both Action and _AbstractAction. Possibly also the _action_name one.
         #  Try and get IDE completion to work for action arguments.

--- a/vizro-core/src/vizro/models/_base.py
+++ b/vizro-core/src/vizro/models/_base.py
@@ -272,7 +272,7 @@ class VizroBaseModel(BaseModel):
         )
         cls.model_fields[field_name] = FieldInfo.merge_field_infos(field, annotation=new_annotation)
 
-        # We need to resolve all ForwardRefs again e.g. in the case of Page, which requires update_forward_refs in
+        # We need to resolve all ForwardRefs again. For example, Page requires update_forward_refs in
         # vizro.models. The vm.__dict__.copy() is inspired by pydantic's own implementation of update_forward_refs and
         # effectively replaces all ForwardRefs defined in vizro.models.
         import vizro.models as vm

--- a/vizro-core/src/vizro/models/_components/ag_grid.py
+++ b/vizro-core/src/vizro/models/_components/ag_grid.py
@@ -158,7 +158,7 @@ class AgGrid(VizroBaseModel):
                 # `cell_clicked_value` always present in the `cell_clicked`.
                 return cell_clicked[cell_clicked_value]
             else:
-                # Keep the target control unchanged if `cellClicked` is missing (e.g. checkbox row selection)
+                # Keep the target control unchanged if `cellClicked` is missing (for example, checkbox row selection)
                 return no_update
 
         selected_rows = trigger.get("selectedRows")

--- a/vizro-core/src/vizro/models/_components/form/_form_utils.py
+++ b/vizro-core/src/vizro/models/_components/form/_form_utils.py
@@ -12,7 +12,7 @@ def get_dict_options_and_value(
     options: OptionsType, value: SingleValueType | MultiValueType | None, multi: bool
 ) -> tuple[list[_OptionsDictType], SingleValueType | MultiValueType]:
     """Returns `(dict_options, value)`. If input `value` is `None`, it is derived from `options`."""
-    # Omitted string conversion for "label" to avoid unintended formatting issues (e.g., 2002 becoming '2002.0').
+    # Omitted string conversion for "label" to avoid unintended formatting issues (for example, 2002 becoming '2002.0').
     dict_options = [option if isinstance(option, dict) else {"label": option, "value": option} for option in options]
 
     list_values = [dict_option["value"] for dict_option in dict_options]

--- a/vizro-core/src/vizro/models/_components/form/cascader.py
+++ b/vizro-core/src/vizro/models/_components/form/cascader.py
@@ -24,7 +24,7 @@ _LEAF_ADAPTER: TypeAdapter[SingleValueType] = TypeAdapter(SingleValueType)
 
 
 def _coerce_cascader_leaf_scalar(item: Any) -> Any:
-    """Coerce a leaf to `SingleValueType` so it matches how `value` gets validated (e.g. Timestamp → date)."""
+    """Coerce a leaf to `SingleValueType` so it matches how `value` gets validated (for example, Timestamp → date)."""
     try:
         return _LEAF_ADAPTER.validate_python(item)
     except Exception as exc:
@@ -53,11 +53,11 @@ def _walk_cascader_branch(node: Any, *, path: str) -> None:
         )
 
 
-# Options are not a uniform recursive dict[str, T] (e.g. JSON-style trees): branch nodes are dict[str, …] but
+# Options are not a uniform recursive dict[str, T] (for example, JSON-style trees): branch nodes are dict[str, …] but
 # leaves are list[scalar], so the shape is dict[str, dict[str, …] | list[SingleValueType]]. A forward-ref union
 # can express that in Pydantic, but we still need imperative validation for rules a single type does not capture:
 # root must be a non-empty dict (not a list), leaf lists must be non-empty, every leaf item must match
-# SingleValueType, and the tree must contain at least one leaf. The same helpers (e.g. walking the tree and
+# SingleValueType, and the tree must contain at least one leaf. The same helpers (for example, walking the tree and
 # collecting leaves in depth-first order) are required elsewhere anyway.
 def validate_cascader_options(data: Any) -> Any:
     """Ensure options are a nested dict with scalar-only leaf lists; reject root list and empty trees."""
@@ -146,7 +146,7 @@ class Cascader(VizroBaseModel):
     multi: Annotated[
         bool,
         AfterValidator(validate_multi),
-        Field(default=True, description="Whether to allow selection of multiple values", validate_default=True),
+        Field(default=True, description="Whether to enable selection of multiple values", validate_default=True),
     ]
     title: str = Field(default="", description="Title to be displayed")
     # TODO: ideally description would have json_schema_input_type=str | Tooltip attached to the BeforeValidator,

--- a/vizro-core/src/vizro/models/_components/graph.py
+++ b/vizro-core/src/vizro/models/_components/graph.py
@@ -118,11 +118,11 @@ underlying component may change in the future.""",
 
         Priority:
           1) If `value` matches a column name in self["custom_data"], take it as from customdata[index].
-          2) Otherwise treat `value` as a Box lookup (e.g. "x", "customdata[0]").
+          2) Otherwise treat `value` as a Box lookup (for example, "x", "customdata[0]").
 
         Notes:
           - Enables camelCase and snake_case value keys interchangeably (camel_killer_box=True).
-          - Enables dot-style (e.g. value="key.subkey") access to nested dict values (box_dots=True).
+          - Enables dot-style (for example, value="key.subkey") access to nested dict values (box_dots=True).
           - Automatically creates missing keys as empty boxes instead of raising errors (default_box=True). This is done
             to avoid exceptions when the `trigger` has a key with a dot in it.
 
@@ -150,7 +150,7 @@ underlying component may change in the future.""",
             lookup = f"customdata[{index}]"
         except (KeyError, ValueError):
             # Treat the value as a box lookup string, as https://github.com/cdgriffith/Box/wiki/Types-of-Boxes#box-dots
-            # This works for e.g. value="x" or value="customdata[0]".
+            # This works for values such as value="x" or value="customdata[0]".
             lookup = value
 
         unique_points = set()
@@ -160,8 +160,8 @@ underlying component may change in the future.""",
                 if isinstance(val := point[lookup], Box):
                     raise KeyError
 
-                # Certain grouped charts (e.g. pie charts) return custom data as a list of single-item lists
-                # (e.g. [["setosa"], ["setosa"]]). Since all values are identical, flatten to a single value to avoid
+                # Certain grouped charts (for example, pie charts) return custom data as a list of single-item lists
+                # (for example, [["setosa"], ["setosa"]]). Since all values are identical, flatten them to avoid
                 # returning a nested object.
                 unique_points.add(val[0] if isinstance(val, list) else val)
         except (KeyError, IndexError, TypeError):
@@ -197,7 +197,7 @@ underlying component may change in the future.""",
 
         # No "guard" component needed for vm.Graph. The reason is that vm.Graph has never been recreated after it's
         # built. Only that updates is its "figure" property after the build method.
-        # Guard components are only for components (e.g. AgGrid, dynamic Filter) that get fully recreated.
+        # Guard components are only for components (for example, AgGrid, dynamic Filter) that get fully recreated.
         return fig
 
     # Convenience wrapper/syntactic sugar.

--- a/vizro-core/src/vizro/models/_controls/_controls_utils.py
+++ b/vizro-core/src/vizro/models/_controls/_controls_utils.py
@@ -107,7 +107,7 @@ def get_selector_default_value(selector: SelectorType) -> Any:
     """Get default value for a selector if not explicitly provided.
 
     This is used to set selector.value in controls so that the "Reset controls" button works. Ideally it would be
-    done elsewhere, e.g. in the selector models themselves, but that is tricky to get in the right order because it
+    done elsewhere, such as in the selector models themselves, but that is tricky to get in the right order because it
     would require running the selector.pre_build as part of Filter.pre_build.
     """
     if selector.value is not None:

--- a/vizro-core/src/vizro/models/_controls/filter.py
+++ b/vizro-core/src/vizro/models/_controls/filter.py
@@ -44,7 +44,7 @@ DEFAULT_SELECTORS = {
 
 # This disallowed selectors for each column type map is based on the discussion at the following link:
 # See https://github.com/mckinsey/vizro/pull/319#discussion_r1524888171
-# Really numerical data should also disallow SELECTORS["boolean"], but we allow it so that a column
+# Really numerical data should also disallow SELECTORS["boolean"], but we enable it so that a column
 # of 0s and 1s can be interpreted as boolean data. We could modify the detection of data type in
 # validate_column_type to check for this case, but this would mean checking actual data values. This is
 # something we should avoid at least until we have moved to narwhals since maybe it's an unnecessary
@@ -65,7 +65,7 @@ DISALLOWED_SELECTORS = {
 
 # Accepts "HH:MM" and "HH:MM:SS" formats. These are the only that the underlying dmc.TimePicker selector can produce.
 _TIME_REGEX = re.compile(r"^\d{2}:\d{2}(:\d{2})?$")
-_TIME_PARTS_HH_MM = 2  # "HH:MM".split(":") → 2 parts, i.e. no seconds in format
+_TIME_PARTS_HH_MM = 2  # "HH:MM".split(":") → 2 parts, that is, no seconds in format
 
 # Column types whose filter options/bounds can update when the underlying data source is dynamic.
 # "time" and "boolean" are always static.
@@ -140,7 +140,7 @@ def _filter_between(series: pd.Series, value: list[float] | list[str | None]) ->
     # If needed, coerce series and value to comparable time or date objects based on value format.
     series, value = _coerce_temporal(series=series, value=value, normalize_precision=False)
 
-    # Handle time-of-day ranges that cross midnight: e.g. [21:00, 06:00] means time >= 21:00 OR time <= 06:00.
+    # Handle time-of-day ranges that cross midnight: for example, [21:00, 06:00] means time >= 21:00 OR time <= 06:00.
     if isinstance(value[0], dt_time) and value[0] > value[1]:
         return (series >= value[0]) | (series <= value[1])
     return series.between(value[0], value[1], inclusive="both")
@@ -165,13 +165,13 @@ def _iter_cascader_leaf_paths(
 
 
 # TODO: remove this parents of leaves calculation once the Cascader propagates full paths,
-#  e.g. `[("continent", "region", "country"), ...]`, instead of bare leaves.
+#  for example, `[("continent", "region", "country"), ...]`, instead of bare leaves.
 #  With full paths the new tree options can be extended directly like new_options = {**new_options, **current_value}
 #  without having to calculate the parents of leaves.
 def _add_leaf_at_path(tree: dict[str, Any], path: tuple[str, ...], leaf: Any) -> None:
     """Add `leaf` to `tree` at full `path`, creating any missing branch dicts on the way.
 
-    This is a Cascader-only problem: `current_value` is a flat list of leaves (e.g. list of country names), so if a data
+    This is a Cascader-only problem: `current_value` is a flat list of leaves, such as country names. If a data
     reload drops the rows that carried currently selected values we have to add them to the new tree options.
     Remember, current_value always has to be part of the newly calculated options. Problem is that we don't know
     where to place these leaf values, so we have to calculate their parents.
@@ -390,7 +390,7 @@ class Filter(VizroBaseModel):
         ]
 
         # TODO: Currently dynamic data functions require a default value for every argument. Even when there is a
-        #  dataframe parameter, the default value is used when pre-build the filter e.g. to find the targets,
+        #  dataframe parameter, the default value is used when pre-build the filter, for example, to find the targets,
         #  column type (and hence selector) and initial values. There are three ways to handle this:
         #  1. (Current approach) - Propagate {} and use only default arguments value in the dynamic data function.
         #  2. Propagate values from the model_manager and relax the limitation of requiring argument default values.

--- a/vizro-core/src/vizro/models/_dashboard.py
+++ b/vizro-core/src/vizro/models/_dashboard.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # This is just used for type checking. Ideally it would inherit from some dash.development.base_component.Component
-# (e.g. html.Div) as well as TypedDict, but that's not possible, and Dash does not have typing support anyway. When
+# (such as html.Div) as well as TypedDict, but that's not possible, and Dash does not have typing support anyway. When
 # this type is used, the object is actually still a dash.development.base_component.Component, but this makes it easier
 # to see what contract the component fulfills by making the expected keys explicit.
 _InnerPageContentType = TypedDict(

--- a/vizro-core/src/vizro/models/_grid.py
+++ b/vizro-core/src/vizro/models/_grid.py
@@ -39,7 +39,7 @@ def set_layout(layout, info: ValidationInfo):
     if isinstance(layout, Flex):
         return layout
 
-    # This exists only to eagerly raise the error, otherwise obscure error message on eg Page()
+    # This exists only to eagerly raise the error, otherwise obscure error message, for example, on Page()
     # Same for similar code in other places
     # TODO[MS]: find another solution that clashes less with typing
     if "components" not in info.data:

--- a/vizro-core/src/vizro/models/_models_utils.py
+++ b/vizro-core/src/vizro/models/_models_utils.py
@@ -124,7 +124,7 @@ def make_actions_chain(self):
     action_triggers property, which needs the parent model instance. Hence, it must be done as a model validator.
 
     This runs after model_post_init so that self._inner_component_id will have already been set correctly in
-    Table and AgGrid. Even though it's a model validator it is also run on assignment e.g. selector.actions = ...
+    Table and AgGrid. Even though it's a model validator, it also runs on assignment, such as `selector.actions = ...`.
     """
     from vizro.actions import export_data, filter_interaction
     from vizro.actions._on_page_load import _on_page_load

--- a/vizro-core/src/vizro/models/_navigation/_navigation_utils.py
+++ b/vizro-core/src/vizro/models/_navigation/_navigation_utils.py
@@ -96,7 +96,7 @@ def _validate_pages(pages: NavPagesType) -> NavPagesType:
 
 
 # This is just used for type checking. Ideally it would inherit from some dash.development.base_component.Component
-# (e.g. html.Div) as well as TypedDict, but that's not possible, and Dash does not have typing support anyway. When
+# (such as html.Div) as well as TypedDict, but that's not possible, and Dash does not have typing support anyway. When
 # this type is used, the object is actually still a dash.development.base_component.Component, but this makes it easier
 # to see what contract the component fulfills by making the expected keys explicit.
 _NavBuildType = TypedDict("_NavBuildType", {"nav-bar": dbc.Navbar, "nav-panel": dbc.Nav})

--- a/vizro-core/src/vizro/models/_navigation/navigation.py
+++ b/vizro-core/src/vizro/models/_navigation/navigation.py
@@ -38,8 +38,8 @@ class Navigation(VizroBaseModel):
         nav_selector = cast(NavSelectorType, self.nav_selector).build(active_page_id=active_page_id)
 
         if "nav-bar" not in nav_selector:
-            # e.g. nav_selector is Accordion and nav_selector.build returns single html.Div with id="nav-panel".
-            # This will make it match the case e.g. nav_selector is NavBar and nav_selector.build returns html.Div
+            # For example, nav_selector is Accordion and nav_selector.build returns single html.Div with id="nav-panel".
+            # This will make it match when nav_selector is NavBar and nav_selector.build returns html.Div
             # containing children with id="nav-bar" and id="nav-panel"
             nav_selector = html.Div(children=[dbc.Navbar(id="nav-bar", className="d-none invisible"), nav_selector])
 

--- a/vizro-core/src/vizro/models/_page.py
+++ b/vizro-core/src/vizro/models/_page.py
@@ -36,7 +36,7 @@ from ._tooltip import coerce_str_to_tooltip
 from .types import ComponentType, ControlType, FigureType, LayoutType
 
 # This is just used for type checking. Ideally it would inherit from some dash.development.base_component.Component
-# (e.g. html.Div) as well as TypedDict, but that's not possible, and Dash does not have typing support anyway. When
+# (such as html.Div) as well as TypedDict, but that's not possible, and Dash does not have typing support anyway. When
 # this type is used, the object is actually still a dash.development.base_component.Component, but this makes it easier
 # to see what contract the component fulfills by making the expected keys explicit.
 _PageBuildType = TypedDict("_PageBuildType", {"control-panel": html.Div, "page-components": html.Div})

--- a/vizro-core/src/vizro/models/types.py
+++ b/vizro-core/src/vizro/models/types.py
@@ -186,7 +186,7 @@ def _validate_captured_callable(cls, value: Any, info: ValidationInfo):
 
 # CapturedCallable now enables instantiation via string, which will instantiate an object with ._prevent_run = True.
 # This enables us to instantiate dashboard objects without needing to execute/import the function definition.
-# Useful in the context of untrusted code generation (e.g. by LLMs).
+# Useful in the context of untrusted code generation (for example, by LLMs).
 class CapturedCallable:
     """Stores a captured function call to use in a dashboard.
 
@@ -371,7 +371,7 @@ class CapturedCallable:
 
         This uses the hydra syntax for _target_ but none of the other bits and we don't actually use hydra
         to implement it. In future, we might like to switch to using hydra's actual implementation
-        which would enable nested functions (e.g. for transformers?) and to specify the path to a _target_ that lives
+        which would enable nested functions, for example for transformers, and specify the path to a _target_ that lives
         outside of vizro.plotly_express. See https://hydra.cc/docs/advanced/instantiate_objects/overview/.
         """
         if not isinstance(captured_callable_config, dict):
@@ -414,7 +414,7 @@ class CapturedCallable:
     def _extract_from_attribute(
         cls, captured_callable: Union[_SupportsCapturedCallable, CapturedCallable]
     ) -> CapturedCallable:
-        """Extracts CapturedCallable from _SupportCapturedCallable (e.g. _DashboardReadyFigure).
+        """Extracts CapturedCallable from _SupportCapturedCallable (for example, _DashboardReadyFigure).
 
         If captured_callable is already CapturedCallable then it just passes through untouched.
         """
@@ -484,7 +484,7 @@ def _pio_templates_default():
     """Sets pio.templates.default to "vizro_dark" and then reverts it.
 
     This is to ensure that in a Jupyter Notebook captured charts look the same as when they're in the dashboard. When
-    the context manager exits the global theme is reverted just to keep things clean (e.g. if you really wanted to,
+    the context manager exits, the global theme is reverted to keep things clean. For example, you could
     you could compare a captured vs. non-captured chart in the same Python session).
 
     This works even if users have tweaked the templates, so long as pio.templates has been updated correctly and you
@@ -592,7 +592,7 @@ class capture:
                     raise ValueError(f"{func.__name__} must supply a value to data_frame argument.") from exc
 
                 if isinstance(captured_callable["data_frame"], str):
-                    # Enable running e.g. px.scatter("iris") from the Python API. Don't actually run the function
+                    # Enable running `px.scatter("iris")` from the Python API. Don't actually run the function
                     # because it won't work as there's no data. This case is not relevant for the JSON/YAML API,
                     # which is handled separately through validation of CapturedCallable.
                     fig = _DashboardReadyFigure()
@@ -655,7 +655,7 @@ class capture:
         )
 
 
-# For "component_id.component_property", e.g. "dropdown_id.value".
+# For "component_id.component_property", for example, "dropdown_id.value".
 _IdProperty: TypeAlias = str
 """A string that must be in the format 'component-id.component-property'."""
 

--- a/vizro-core/src/vizro/plotly/express.py
+++ b/vizro-core/src/vizro/plotly/express.py
@@ -1,7 +1,7 @@
 """Functionality to enable drop-in replacement that wraps plotly express figures.
 
 Makes them compatible with the dashboard when you do `import vizro.plotly.express as px`.
-Only plotly figures are wrapped; everything else is passed through unmodified, e.g. px.data.
+Only plotly figures are wrapped; everything else is passed through unmodified, for example, px.data.
 """
 
 from typing import Any

--- a/vizro-core/src/vizro/themes/_palettes.py
+++ b/vizro-core/src/vizro/themes/_palettes.py
@@ -201,7 +201,7 @@ diverging_yellow_blue = [
 # These are necessarily the same for dark and light themes.
 # For plotly express plots, some colors are taken from the template's palettes and stored in
 # fig.data rather than fig.layout. This means they cannot be changed consistently by post-fig
-# updates to fig.layout.template (e.g. in the clientside callback we currently use).
+# updates to fig.layout.template (for example, in the clientside callback we currently use).
 palettes = SimpleNamespace(
     qualitative=qualitative,
     sequential=sequential_blue,

--- a/vizro-core/tests/unit/vizro/actions/test_filter_interaction.py
+++ b/vizro-core/tests/unit/vizro/actions/test_filter_interaction.py
@@ -312,4 +312,4 @@ class TestFilterInteraction:
     # TODO: Simplify parametrization, such that we have less repetitive code
     # TODO: Eliminate above xfails
     # TODO: Complement tests above with backend tests (currently the targets are also taken from model_manager!
-    # see _get_action_callback_mapping eg.)
+    # see _get_action_callback_mapping as an example.)

--- a/vizro-core/tests/unit/vizro/actions/test_legacy_filter_interaction.py
+++ b/vizro-core/tests/unit/vizro/actions/test_legacy_filter_interaction.py
@@ -338,4 +338,4 @@ class TestFilterInteraction:
     # TODO: Simplify parametrization, such that we have less repetitive code
     # TODO: Eliminate above xfails
     # TODO: Complement tests above with backend tests (currently the targets are also taken from model_manager!
-    # see _get_action_callback_mapping eg.)
+    # see _get_action_callback_mapping as an example.)

--- a/vizro-core/tests/unit/vizro/actions/test_set_control.py
+++ b/vizro-core/tests/unit/vizro/actions/test_set_control.py
@@ -164,7 +164,7 @@ class TestSetControlPreBuild:
             ValueError,
             match=re.escape(
                 "`set_control` action was added to the model with ID `table_1`, "
-                "but this action can only be used with models that support it (e.g. Graph, AgGrid, Figure, and so on). "
+                "but this action can only be used with models that support it, such as Graph, AgGrid, and Figure. "
                 "See all models that can source a `set_control` at "
                 "https://vizro.readthedocs.io/en/stable/pages/API-reference/actions/#vizro.actions.set_control"
             ),
@@ -211,7 +211,7 @@ class TestSetControlPreBuild:
             TypeError,
             match=re.escape(
                 "Model with ID `scatter_chart_2` used as a `control` in `set_control` action must be a control model "
-                "(e.g. Filter, Parameter)."
+                "(for example, Filter, Parameter)."
             ),
         ):
             action.pre_build()
@@ -261,7 +261,7 @@ class TestSetControlFunction:
     @pytest.mark.parametrize("same_page, expected", [(True, no_update), (False, (no_update, no_update))])
     def test_function_trigger_returns_no_update(self, same_page, expected):
         # Add action to an AgGrid as the AgGrid returns no_update if set_control value is a key from the
-        # CELL_CLICKED_MAPPING (e.g. "column"), and trigger does not contain "cellClicked"
+        # CELL_CLICKED_MAPPING (for example, "column"), and trigger does not contain "cellClicked"
         action = set_control(control="filter_page_1", value="column")
         model_manager["ag_grid_1"].actions = action
 

--- a/vizro-core/tests/unit/vizro/managers/test_data_manager.py
+++ b/vizro-core/tests/unit/vizro/managers/test_data_manager.py
@@ -20,7 +20,7 @@ from vizro.managers._data_manager import _DynamicData, _StaticData
 # tests should use freezer.tick() to advance time. This is very similar to the fixture in the pytest-freezegun package.
 # This makes it possible to test with realistic timeouts that flask-caching can handle well. Otherwise we
 # test with very low timeouts and time.sleep(1), and this is flaky since flask-caching is not designed to
-# handle such small intervals (e.g. it rounds times to the nearest second).
+# handle such small intervals (for example, it rounds times to the nearest second).
 # We use tick=True so that time continues to pass between directly consecutive calls to a load function. This makes the
 # behavior in tests as close as possible to real world.
 @pytest.fixture

--- a/vizro-core/tests/unit/vizro/models/_components/test_tabs.py
+++ b/vizro-core/tests/unit/vizro/models/_components/test_tabs.py
@@ -84,7 +84,7 @@ class TestTabsBuildMethod:
         # Test title and description
         assert_component_equal(result.children[0].children, [html.Span("Tabs Title", id="tabs-id_title"), None])
 
-        # We want to test the children created in the Tabs.build but not e.g. the
+        # We want to test the children created in the Tabs.build but not, for example, the
         # vm.Container.build() as it's tested elsewhere already
         assert_component_equal(
             result["tabs-id"].children, [dbc.Tab(label="Title-1"), dbc.Tab(label="Title-2")], keys_to_strip={"children"}
@@ -133,7 +133,7 @@ class TestTabsBuildMethod:
             result.children[0].children, [html.Span("Tabs Title", id="tabs-id_title"), *expected_description]
         )
 
-        # We want to test the children created in the Tabs.build but not e.g. the
+        # We want to test the children created in the Tabs.build but not, for example, the
         # vm.Container.build() as it's tested elsewhere already
         assert_component_equal(
             result["tabs-id"].children, [dbc.Tab(label="Title-1"), dbc.Tab(label="Title-2")], keys_to_strip={"children"}

--- a/vizro-core/tests/unit/vizro/models/_controls/test_filter.py
+++ b/vizro-core/tests/unit/vizro/models/_controls/test_filter.py
@@ -980,7 +980,7 @@ class TestFilterCall:
         # "DE" is restored under Eu from the pre_build options tree.
         assert selector_build.options == {"As": ["JP"], "Eu": ["DE"]}
 
-    # TODO: remove xfail once Cascader propagates full paths (e.g. [("Eu", "IT"), ...]) instead of bare leaves.
+    # TODO: remove xfail once Cascader propagates full paths (for example, [("Eu", "IT"), ...]) instead of bare leaves.
     #  With full paths the runtime call can restore stale selections directly, without a prev-options lookup.
     #  Right now `self.selector.options` is only set at pre_build time and never updated between reloads, so a
     #  leaf that appears during a runtime reload can't be restored on a subsequent reload.

--- a/vizro-core/tests/unit/vizro/models/test_base.py
+++ b/vizro-core/tests/unit/vizro/models/test_base.py
@@ -44,7 +44,7 @@ ChildType = Annotated[ChildX | ChildY, Field(discriminator="type")]
 # These parent classes must be done as fixtures so that each test gets a fresh, unmodified copy of the class.
 @pytest.fixture()
 def Parent():
-    # e.g. Parameter.selector: SelectorType
+    # For example, Parameter.selector: SelectorType
     class _Parent(vm.VizroBaseModel):
         child: ChildType
 
@@ -53,7 +53,7 @@ def Parent():
 
 @pytest.fixture()
 def ParentWithOptional():
-    # e.g. Filter.selector: SelectorType | None
+    # For example, Filter.selector: SelectorType | None
     class _ParentWithOptional(vm.VizroBaseModel):
         child: ChildType | None
 
@@ -62,7 +62,7 @@ def ParentWithOptional():
 
 @pytest.fixture()
 def ParentWithList():
-    # e.g. Page.controls: list[ControlType] and Page.components: list[ComponentType]
+    # For example, Page.controls: list[ControlType] and Page.components: list[ComponentType]
     class _ParentWithList(vm.VizroBaseModel):
         child: list[ChildType]
 

--- a/vizro-core/tests/unit/vizro/models/test_types.py
+++ b/vizro-core/tests/unit/vizro/models/test_types.py
@@ -352,7 +352,7 @@ def decorated_graph_function_crash(data_frame):
 
 
 # The _pio_default_template context manager resets pio.templates.default on exit, but the fixture should do this also.
-# This fixtures acts as if someone has set the pio.templates.default e.g. in a Jupyter notebook.
+# This fixtures acts as if someone has set the pio.templates.default for example, in a Jupyter notebook.
 @pytest.fixture
 def set_pio_default_template(request):
     old_default = pio.templates.default


### PR DESCRIPTION
## Summary

- Standardize docstring and comment wording across `vizro-core` to follow the preferred style from #1601.
- Replace informal abbreviations and phrasing, then update affected test expectation strings.

## Why

This improves consistency and readability in the public-facing documentation and internal code comments without changing runtime behavior.

## Validation

- `hatch run lint ruff --check .`
- `hatch run test-unit` (`1944 passed, 28 xfailed`)
