### PR TITLE
[Docs] Add yaml frontmatter to docs MD pages

### DIFF
--- a/vizro-core/changelog.d/20260728_151626_jo_stichbury_add_yaml_frontmatter.md
+++ b/vizro-core/changelog.d/20260728_151626_jo_stichbury_add_yaml_frontmatter.md
@@ -1,0 +1,45 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+### Added
+
+- Added `description:` YAML front matter to every documentation page under `vizro-core/docs/pages/` to improve agent semantic search and page snippets.
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-core/docs/index.md
+++ b/vizro-core/docs/index.md
@@ -1,5 +1,5 @@
 ---
-description: "Index page for Vizro includes links to key pages and sections including a curated cheatsheet for agents and llms.txt"
+description: "Index page for Vizro docs with links to key pages and sections, including a curated cheatsheet for agents and `llms.txt`."
 hide:
   - navigation
   - toc

--- a/vizro-core/docs/index.md
+++ b/vizro-core/docs/index.md
@@ -1,4 +1,5 @@
 ---
+description: "Index page for Vizro includes links to key pages and sections including a curated cheatsheet for agents and llms.txt"
 hide:
   - navigation
   - toc

--- a/vizro-core/docs/pages/API-reference/actions.md
+++ b/vizro-core/docs/pages/API-reference/actions.md
@@ -1,3 +1,7 @@
+---
+description: "Signatures for every built-in action in `vizro.actions`: `export_data`, `filter_interaction`, `set_control`, `show_notification`, `update_notification`, and the `AbstractAction` base."
+---
+
 # Actions
 <!-- vale off -->
 

--- a/vizro-core/docs/pages/API-reference/deprecations.md
+++ b/vizro-core/docs/pages/API-reference/deprecations.md
@@ -1,3 +1,7 @@
+---
+description: "Migration notes for deprecations ahead of Vizro 0.2.0: `Layout` renamed to `Grid`, changes to `Action.inputs`, static custom-action arguments, and `filter_interaction`."
+---
+
 # Deprecations and breaking changes
 
 This page lists Vizro features that are now deprecated and forthcoming breaking changes for Vizro 0.2.0.

--- a/vizro-core/docs/pages/API-reference/figure-callables.md
+++ b/vizro-core/docs/pages/API-reference/figure-callables.md
@@ -1,3 +1,7 @@
+---
+description: "Reference for the built-in figure functions `kpi_card` and `kpi_card_reference` in `vizro.figures`, reusable inside a `Figure` or a pure Dash app."
+---
+
 <!-- vale off -->
 # Figure functions
 

--- a/vizro-core/docs/pages/API-reference/kedro-integration.md
+++ b/vizro-core/docs/pages/API-reference/kedro-integration.md
@@ -1,3 +1,7 @@
+---
+description: "Reference for the helpers in `vizro.integrations.kedro` that load a Kedro Data Catalog into Vizro's `data_manager`."
+---
+
 <!-- vale off -->
 # Kedro integration
 

--- a/vizro-core/docs/pages/API-reference/models.md
+++ b/vizro-core/docs/pages/API-reference/models.md
@@ -1,3 +1,7 @@
+---
+description: "Full reference for every model in `vizro.models`, including Dashboard, Page, Container, Tabs, Grid, Flex, Graph, Table, Filter, Parameter, and Action."
+---
+
 # Models
 
 Vizro's grammar of dashboards is defined by a small set of Pydantic models in `vizro.models`, typically aliased as `vm` (`import vizro.models as vm`). Every dashboard is built by composing these models. Use the [Model index](#model-index) below to jump to the reference entry for a specific model; the full auto-generated reference for every public model follows in the [full model reference](#full-model-reference) section.

--- a/vizro-core/docs/pages/API-reference/table-callables.md
+++ b/vizro-core/docs/pages/API-reference/table-callables.md
@@ -1,3 +1,7 @@
+---
+description: "Reference for the `dash_ag_grid` and `dash_data_table` callables in `vizro.tables`, passed to a `Table` or `AgGrid` component's `figure` argument."
+---
+
 <!-- vale off -->
 # Table functions
 

--- a/vizro-core/docs/pages/API-reference/themes.md
+++ b/vizro-core/docs/pages/API-reference/themes.md
@@ -1,3 +1,7 @@
+---
+description: "Reference for `vizro.themes.colors` and `vizro.themes.palettes`, the color values and palettes used by Vizro's dark and light Plotly templates."
+---
+
 <!-- vale off -->
 # Themes
 

--- a/vizro-core/docs/pages/API-reference/vizro.md
+++ b/vizro-core/docs/pages/API-reference/vizro.md
@@ -1,3 +1,7 @@
+---
+description: "Reference for the `Vizro` class: `build()` to assemble a `Dashboard`, `run()` for local development, and `dash` to access the underlying Dash app."
+---
+
 # Vizro
 
 <!-- vale off -->

--- a/vizro-core/docs/pages/explanation/actions-explanation.md
+++ b/vizro-core/docs/pages/explanation/actions-explanation.md
@@ -1,3 +1,7 @@
+---
+description: "Conceptual model behind Vizro actions: how they wrap Dash callbacks, resolve inputs and outputs, and chain sequentially or run in parallel."
+---
+
 # Actions
 
 Actions control how your app responds to user input such as clicking a button or a point on a graph. Vizro provides [built-in actions](../user-guides/actions.md) and also enables you to write your own [custom actions](../user-guides/custom-actions.md).

--- a/vizro-core/docs/pages/explanation/authors.md
+++ b/vizro-core/docs/pages/explanation/authors.md
@@ -1,3 +1,7 @@
+---
+description: "Roll call of the current and previous Vizro core team members and external code contributors, with GitHub links to each person."
+---
+
 ## Current team members
 
 <!-- vale off -->

--- a/vizro-core/docs/pages/explanation/contributing.md
+++ b/vizro-core/docs/pages/explanation/contributing.md
@@ -1,3 +1,7 @@
+---
+description: "Contribute to Vizro: GitHub Codespaces setup, local development with Hatch, PR review requirements, and the code of conduct."
+---
+
 # Contributing
 
 Contributions of all experience levels are welcome! There are many ways to contribute, and we appreciate any help: it doesn't have to be a pull request (PR) on our code. You can also [report a bug](faq.md#how-can-i-report-a-bug), [request a feature](faq.md#how-can-i-request-a-feature), or [ask and answer community questions](faq.md#i-still-have-a-question-where-can-i-ask-it). Before making significant changes to Vizro code, you should first use [GitHub issues](https://github.com/mckinsey/vizro/issues) to discuss your contribution.

--- a/vizro-core/docs/pages/explanation/documentation-style-guide.md
+++ b/vizro-core/docs/pages/explanation/documentation-style-guide.md
@@ -1,3 +1,7 @@
+---
+description: "Vizro docs conventions: product lexicon, sentence-case headings, admonition types, hyperlink phrasing, code formatting, and pitfalls to avoid."
+---
+
 # Vizro documentation style guide
 
 <!-- vale off -->

--- a/vizro-core/docs/pages/explanation/faq.md
+++ b/vizro-core/docs/pages/explanation/faq.md
@@ -1,4 +1,5 @@
 ---
+description: "Answers on Vizro versioning, Python and browser support, licensing, how it compares to Dash, Streamlit, and BI tools, and where to ask for help."
 hide:
   - toc
 ---

--- a/vizro-core/docs/pages/explanation/schema.md
+++ b/vizro-core/docs/pages/explanation/schema.md
@@ -1,3 +1,7 @@
+---
+description: "Explains the Vizro JSON schema, its Pydantic origins, its grammar of dashboards, and the role of `extra` for pass-through arguments."
+---
+
 # Vizro schema and grammar of dashboards
 
 This page explains the [Vizro JSON schema](#what-is-the-vizro-json-schema), which is our attempt to create a ["grammar of dashboards"](#the-grammar-of-dashboards), and the [role of Pydantic](#the-role-of-pydantic).

--- a/vizro-core/docs/pages/explanation/your-examples.md
+++ b/vizro-core/docs/pages/explanation/your-examples.md
@@ -1,3 +1,7 @@
+---
+description: "Curated gallery of external Vizro material: community videos, blog posts, and dashboards published on GitHub or PyCafe."
+---
+
 # Examples from Vizro users
 
 This page lists videos, blog posts, and examples of Vizro usage in repositories on GitHub. We've curated the list so it is a snapshot of the best projects and content that Vizro users have created.

--- a/vizro-core/docs/pages/for-llms.md
+++ b/vizro-core/docs/pages/for-llms.md
@@ -1,3 +1,7 @@
+---
+description: "Compact reference for LLMs: minimum runnable Vizro app, model and action indices, `@capture` matrix, selector auto-selection, top errors, and schema link."
+---
+
 # Vizro for LLMs
 
 This page is a single-file cheatsheet for LLMs and coding agents. It restates only what an agent needs to write correct Vizro code in one pass, and links out to canonical reference for everything else. Do not duplicate content from linked pages here — follow the links.

--- a/vizro-core/docs/pages/tutorials/custom-actions-tutorial.md
+++ b/vizro-core/docs/pages/tutorials/custom-actions-tutorial.md
@@ -1,3 +1,7 @@
+---
+description: "Walkthrough of writing a custom action: runtime inputs, multiple inputs and outputs, action chains, parallel actions, error handling, and security."
+---
+
 # Write your own actions
 
 Actions control how your app responds to user input such as clicking a button or a point on a graph. Vizro provides [built-in actions](../user-guides/actions.md) and also enables you to write your own [custom actions](../user-guides/custom-actions.md). In this tutorial you will learn how to write your own custom actions.

--- a/vizro-core/docs/pages/tutorials/explore-components.md
+++ b/vizro-core/docs/pages/tutorials/explore-components.md
@@ -1,3 +1,7 @@
+---
+description: "Half-hour tutorial that builds a three-page Iris and Gapminder dashboard, adding charts, controls, filters, parameters, and navigation step by step."
+---
+
 # Explore Vizro
 
 In this tutorial, you'll learn how to build an interactive dashboard with multiple pages, incorporating a wide range of Vizro's components. You can follow along using the written guide below or join in with the accompanying video tutorial.

--- a/vizro-core/docs/pages/tutorials/quickstart-tutorial.md
+++ b/vizro-core/docs/pages/tutorials/quickstart-tutorial.md
@@ -1,3 +1,7 @@
+---
+description: "Five-line first Vizro dashboard on PyCafe, plus prompts for what to change next and pointers to a deeper tutorial."
+---
+
 # Quickstart tutorial
 
 There is no setup needed for your first dashboard, so you can get started with Vizro quickly, thanks to [PyCafe](https://py.cafe/).

--- a/vizro-core/docs/pages/user-guides/actions.md
+++ b/vizro-core/docs/pages/user-guides/actions.md
@@ -1,3 +1,7 @@
+---
+description: "Attach built-in actions with `import vizro.actions as va`, trigger them from buttons or graphs, and chain multiple actions on a single trigger."
+---
+
 # How to use actions
 
 Actions control how your app responds to user input such as clicking a button or a point on a graph. If an action is not built into Vizro then you can [write your own custom action](custom-actions.md). In these guides we show how to use built-in actions across a range of areas:

--- a/vizro-core/docs/pages/user-guides/assets.md
+++ b/vizro-core/docs/pages/user-guides/assets.md
@@ -1,3 +1,7 @@
+---
+description: "Add images, CSS, and JS via an `assets/` folder: favicon, logo, custom folder path, social meta-tag image, and CSS load order."
+---
+
 # How to add static assets
 
 This guide shows you how to add static assets to your dashboard. Static assets are images that you would like to show in your dashboard, or custom CSS and JS files with which you would like to enhance/change the appearance of your dashboard.

--- a/vizro-core/docs/pages/user-guides/button.md
+++ b/vizro-core/docs/pages/user-guides/button.md
@@ -1,3 +1,7 @@
+---
+description: "Configure `Button` text, link URLs, action triggers, use as a control, styled variants, tooltips, icons, and the `extra` pass-through argument."
+---
+
 # How to use buttons
 
 This guide shows you how to use buttons to interact with your data in the dashboard.

--- a/vizro-core/docs/pages/user-guides/card.md
+++ b/vizro-core/docs/pages/user-guides/card.md
@@ -1,3 +1,7 @@
+---
+description: "Configure `Card` text, header and footer, embedded images, theme-aware icons, navigation tiles, KPI cards, tooltips, action triggers, and `extra`."
+---
+
 # How to use cards
 
 This guide shows you how to use cards in your dashboard.

--- a/vizro-core/docs/pages/user-guides/components.md
+++ b/vizro-core/docs/pages/user-guides/components.md
@@ -1,3 +1,7 @@
+---
+description: "Decision table for picking between `Graph`, `Table`, `AgGrid`, `Figure`, `Card`, `Text`, `Button`, `Container`, and `Tabs` for a piece of page content."
+---
+
 # Components
 
 Components are the visual building blocks of a Vizro dashboard page. You add them to the `components` argument of a [`Page`][vizro.models.Page] (or [`Container`][vizro.models.Container]) to display charts and tables, present text, group related content into sections, or expose interactive elements such as buttons.

--- a/vizro-core/docs/pages/user-guides/container.md
+++ b/vizro-core/docs/pages/user-guides/container.md
@@ -1,3 +1,7 @@
+---
+description: "Basic, nested, styled, and collapsible `Container`s, scoping controls to a container, adding tooltips, and passing extra Dash arguments."
+---
+
 # How to use containers
 
 This guide shows you how to use containers to group your components into sections and subsections within the page.

--- a/vizro-core/docs/pages/user-guides/controls.md
+++ b/vizro-core/docs/pages/user-guides/controls.md
@@ -1,3 +1,7 @@
+---
+description: "Cross-cutting control patterns: set a control's value programmatically via `set_control`, reset controls to defaults, and group controls in the panel."
+---
+
 # Controls
 
 Vizro supports _controls_ to perform common business intelligence (BI) operations. This guide gives an overview of the different ways you can configure controls.

--- a/vizro-core/docs/pages/user-guides/custom-actions.md
+++ b/vizro-core/docs/pages/user-guides/custom-actions.md
@@ -1,3 +1,7 @@
+---
+description: "Write actions with `@capture('action')`: triggers, runtime inputs, multiple actions, targeting specific model parts, and emitting notifications."
+---
+
 # How to create custom actions
 
 Actions control how your app responds to user input such as clicking a button or a point on a graph. If an action is not available in Vizro's [built-in actions](actions.md) then you can create a custom action. In this guide we show how to do this.

--- a/vizro-core/docs/pages/user-guides/custom-charts.md
+++ b/vizro-core/docs/pages/user-guides/custom-charts.md
@@ -1,3 +1,7 @@
+---
+description: "Wrap a Plotly function with `@capture('graph')` for post-update calls, reference lines, or `go.Figure` charts like waterfalls that Express cannot express."
+---
+
 # How to create custom charts
 
 This guide shows you how to create custom charts and how to add them to your dashboard. The [`Graph`][vizro.models.Graph] model accepts the `figure` argument, where you can enter _any_ [`plotly.express`](https://plotly.com/python/plotly-express/) chart as explained in the [user guide on graphs](graph.md).

--- a/vizro-core/docs/pages/user-guides/custom-components.md
+++ b/vizro-core/docs/pages/user-guides/custom-components.md
@@ -1,3 +1,7 @@
+---
+description: "Extend an existing Vizro model or subclass `VizroBaseModel` to wrap any Dash component, wire it to actions, and enable persistence."
+---
+
 # How to create custom components
 
 The number of [built-in Vizro models][vizro.models] is deliberately kept quite small to enable quick and easy configuration of a dashboard. However, Vizro is also extensible, so that you can modify any model or create an entirely new one. This guide shows you how to do so.

--- a/vizro-core/docs/pages/user-guides/custom-css.md
+++ b/vizro-core/docs/pages/user-guides/custom-css.md
@@ -1,3 +1,7 @@
+---
+description: "Identify Vizro CSS selectors, override styles globally or per page or per component, with worked examples for fonts, cards, logo, and theme switching."
+---
+
 # How to customize dashboard CSS
 
 Vizro is opinionated about visual formatting, and some elements, such as the layout of the navigation and controls, are fixed. You can customize some settings such as background colors, fonts, and other styles via CSS overrides.

--- a/vizro-core/docs/pages/user-guides/custom-figures.md
+++ b/vizro-core/docs/pages/user-guides/custom-figures.md
@@ -1,3 +1,7 @@
+---
+description: "Write reactive Dash figure functions with `@capture('figure')`, with examples of custom KPI cards, dynamic HTML headers, and a dynamic number of cards."
+---
+
 # How to create custom figures
 
 This guide explains how to create custom figures, which is useful when you need a component that reacts to [filter](filters.md) and [parameter](parameters.md) controls.

--- a/vizro-core/docs/pages/user-guides/custom-tables.md
+++ b/vizro-core/docs/pages/user-guides/custom-tables.md
@@ -1,3 +1,7 @@
+---
+description: "Wrap AG Grid or Dash DataTable options with `@capture('ag_grid')` or `@capture('table')` to configure grids beyond Vizro's built-in `dash_ag_grid`."
+---
+
 # How to create custom Dash AG Grids and Dash DataTables
 
 In cases where the available arguments for the [`dash_ag_grid`][vizro.tables.dash_ag_grid] or [`dash_data_table`][vizro.tables.dash_data_table] models are not sufficient, you can create a custom Dash AG Grid or Dash DataTable.

--- a/vizro-core/docs/pages/user-guides/dashboard.md
+++ b/vizro-core/docs/pages/user-guides/dashboard.md
@@ -1,3 +1,7 @@
+---
+description: "Configure `Dashboard` in pydantic, dict, YAML, or JSON, and set the title, logo, tooltip, header, social meta tags, and browser tab title."
+---
+
 # How to create a dashboard
 
 This guide shows you how to configure and call a [`Dashboard`][vizro.models.Dashboard] model using either pydantic models, Python dictionaries, YAML, or JSON.

--- a/vizro-core/docs/pages/user-guides/data-actions.md
+++ b/vizro-core/docs/pages/user-guides/data-actions.md
@@ -1,3 +1,7 @@
+---
+description: "Trigger `export_data` from a button to download every graph, table, and figure on the current page, respecting active filters and dynamic-data parameters."
+---
+
 # How to use actions to handle data
 
 ## Export data

--- a/vizro-core/docs/pages/user-guides/data.md
+++ b/vizro-core/docs/pages/user-guides/data.md
@@ -1,3 +1,7 @@
+---
+description: "Choose between static pandas data and dynamic data-loading functions, control caching, refresh at runtime, and drive parameters from dynamic data."
+---
+
 # How to connect your dashboard to data
 
 Vizro supports two different types of data:

--- a/vizro-core/docs/pages/user-guides/extensions.md
+++ b/vizro-core/docs/pages/user-guides/extensions.md
@@ -1,3 +1,7 @@
+---
+description: "Four ways to extend Vizro: model customizations (`@capture`), raw Dash callbacks and components, CSS overrides, and React.js customizations."
+---
+
 # How to extend and customize Vizro dashboards
 
 At its simplest, Vizro enables low-code configuration, but you can also customize it to go beyond its default capabilities by incorporating any Dash component, Dash callback, or Plotly chart.

--- a/vizro-core/docs/pages/user-guides/figure.md
+++ b/vizro-core/docs/pages/user-guides/figure.md
@@ -1,3 +1,7 @@
+---
+description: "Render arbitrary reactive Dash components inside a `Figure`, and use built-in `kpi_card` and `kpi_card_reference` for KPI tiles with aggregation and delta references."
+---
+
 # How to use figures
 
 This guide shows you how to add any [Dash component](https://dash.plotly.com/#open-source-component-libraries) that needs to be reactive to [controls](controls.md) such as [filters](filters.md) and [parameters](parameters.md). If you want to add a static Dash component to your page, use [custom components](custom-components.md) instead.

--- a/vizro-core/docs/pages/user-guides/filters.md
+++ b/vizro-core/docs/pages/user-guides/filters.md
@@ -1,3 +1,7 @@
+---
+description: "Configure basic and hierarchical `Filter`s, target specific components, swap the selector widget, and customize title, tooltip, and label."
+---
+
 # How to use filters
 
 This guide shows you how to add filters to your dashboard. A filter selects a subset of rows of a component's data to alter the appearance of that component. The following [components](components.md) are reactive to filters:

--- a/vizro-core/docs/pages/user-guides/graph-table-actions.md
+++ b/vizro-core/docs/pages/user-guides/graph-table-actions.md
@@ -1,3 +1,7 @@
+---
+description: "Cross-filter, cross-parameter, and cross-highlight between graphs and tables via `set_control`, including multi-select, cross-container, cross-page, and pivoted-data variants."
+---
+
 # Graph and table interactions
 
 In this guide we show you how to configure interactions between graphs and tables, as is commonly done in business intelligence (BI) tools. In Vizro, all such interactions are enabled by an intermediate [control](controls.md) that you must explicitly define. For example:

--- a/vizro-core/docs/pages/user-guides/graph.md
+++ b/vizro-core/docs/pages/user-guides/graph.md
@@ -1,3 +1,7 @@
+---
+description: "Insert Plotly Express and `plotly.graph_objects` charts in `Graph`, customize the figure, wire cross-filter interactions, add captions, and pass through `extra` arguments."
+---
+
 # How to use graphs
 
 This guide shows you how to use graphs to visualize your data in the dashboard.

--- a/vizro-core/docs/pages/user-guides/install.md
+++ b/vizro-core/docs/pages/user-guides/install.md
@@ -1,3 +1,7 @@
+---
+description: "Install Vizro with pip or uv, verify the version, upgrade to new releases, and enable IDE autocompletion via the Pydantic plugins."
+---
+
 # Installation Guide for Vizro
 
 ## Overview

--- a/vizro-core/docs/pages/user-guides/kedro-data-catalog.md
+++ b/vizro-core/docs/pages/user-guides/kedro-data-catalog.md
@@ -1,3 +1,7 @@
+---
+description: "Install the Kedro extra, create or reuse a Kedro Data Catalog, and register its datasets (including dataset factories) with Vizro's `data_manager`."
+---
+
 # How to integrate Vizro with the Kedro Data Catalog
 
 This page describes how to integrate Vizro with [Kedro](https://docs.kedro.org/en/stable/), an open-source Python framework to create reproducible, maintainable, and modular data science code. Vizro provides a convenient way to visualize Pandas datasets registered in a [Kedro Data Catalog](https://docs.kedro.org/en/stable/catalog-data/data_catalog/).

--- a/vizro-core/docs/pages/user-guides/layouts.md
+++ b/vizro-core/docs/pages/user-guides/layouts.md
@@ -1,3 +1,7 @@
+---
+description: "Choose between `Grid` (row/column) and `Flex` (flexible box) on a `Page` or `Container`, and see alternative approaches like tabs and containers."
+---
+
 # How to change the layout of your page
 
 The [`Page`][vizro.models.Page] and [`Container`][vizro.models.Container] models accept a `layout` argument that enables custom arrangement of charts and components on the screen. This guide shows how to customize the `layout` with:

--- a/vizro-core/docs/pages/user-guides/navigation.md
+++ b/vizro-core/docs/pages/user-guides/navigation.md
@@ -1,3 +1,7 @@
+---
+description: "Default navigation, subset selection, grouped sections, side navigation bar with icons, custom navigation bars, and horizontal top-bar navigation."
+---
+
 # How to configure dashboard navigation
 
 This guide shows you how to use and customize the navigation in your dashboard.

--- a/vizro-core/docs/pages/user-guides/notification-actions.md
+++ b/vizro-core/docs/pages/user-guides/notification-actions.md
@@ -1,3 +1,7 @@
+---
+description: "Show toast notifications with `show_notification` (variants, custom title/icon, auto-close, chaining) and modify them in place with `update_notification`."
+---
+
 # How to use actions to show notifications
 
 This guide shows you how to display notifications and alerts in your dashboard to provide feedback to users about their interactions with the UI.

--- a/vizro-core/docs/pages/user-guides/pages.md
+++ b/vizro-core/docs/pages/user-guides/pages.md
@@ -1,3 +1,7 @@
+---
+description: "Structure a `Page` with `components`, `controls`, `layout`, `title`, and `description`, and set its URL via the `path` argument."
+---
+
 # How to make dashboard pages
 
 This guide shows you how to add pages to your dashboard and customize the URL paths if needed. A [`Page`][vizro.models.Page] model enables you to:

--- a/vizro-core/docs/pages/user-guides/parameters.md
+++ b/vizro-core/docs/pages/user-guides/parameters.md
@@ -1,3 +1,7 @@
+---
+description: "Basic, nested, and dynamic-data `Parameter`s that update non-data arguments of a component's `figure`, plus title, tooltip, and selector customization."
+---
+
 # How to use parameters
 
 This guide shows you how to add parameters to your dashboard. A parameter sets any argument other than `data_frame` in the `figure` function of a component. For example, a user could select using a dropdown which variable is plotted on the x-axis of a graph. Parameters can also be used to set [dynamic data parameters](parameters.md#dynamic-data-parameters). The following [components](components.md) are reactive to parameters:

--- a/vizro-core/docs/pages/user-guides/run-deploy.md
+++ b/vizro-core/docs/pages/user-guides/run-deploy.md
@@ -1,3 +1,7 @@
+---
+description: "Run Vizro from a script, notebook, or PyCafe with hot reload, then deploy via Hugging Face, Dash Enterprise, Gunicorn, or Docker."
+---
+
 # How to run and/or deploy your dashboard
 
 Typically when you create a dashboard, there are two distinct stages:

--- a/vizro-core/docs/pages/user-guides/selectors.md
+++ b/vizro-core/docs/pages/user-guides/selectors.md
@@ -1,3 +1,7 @@
+---
+description: "Categorical, numerical, temporal, boolean, and hierarchical selectors for `Filter` and `Parameter`, plus styled dropdowns, tooltips, and `extra`."
+---
+
 # How to use selectors
 
 This guide highlights different selectors that can be used in a dashboard. Selectors do not serve a purpose on their own, but they enable you to change how the input is given to other models, for example, the [`Filter`][vizro.models.Filter] or the [`Parameter`][vizro.models.Parameter] model.

--- a/vizro-core/docs/pages/user-guides/table.md
+++ b/vizro-core/docs/pages/user-guides/table.md
@@ -1,3 +1,7 @@
+---
+description: "Choose between `AgGrid` and Dash DataTable, format number, date, and string columns, disable pagination, resize columns, and apply sticky headers and styling."
+---
+
 # How to use tables
 
 This guide shows you how to visualize tables in Vizro.

--- a/vizro-core/docs/pages/user-guides/tabs.md
+++ b/vizro-core/docs/pages/user-guides/tabs.md
@@ -1,3 +1,7 @@
+---
+description: "Use `Tabs` to let users switch between multiple `Container`s that share the same screen space, and add a tooltip to the tab strip."
+---
+
 # How to use tabs
 
 This guide shows you how to use the [`Tabs`][vizro.models.Tabs] model, which organize and separate groups of related content in a dashboard, letting users switch between different sections or views.

--- a/vizro-core/docs/pages/user-guides/text.md
+++ b/vizro-core/docs/pages/user-guides/text.md
@@ -1,3 +1,7 @@
+---
+description: "Add Markdown paragraphs, notes, images, and links to a page with `Text`, and use the `extra` argument to pass options through to `dcc.Markdown`."
+---
+
 # How to add text to your page
 
 This guide shows you how to display text in your dashboard with the [`Text` component][vizro.models.Text] model.

--- a/vizro-core/docs/pages/user-guides/themes.md
+++ b/vizro-core/docs/pages/user-guides/themes.md
@@ -1,3 +1,7 @@
+---
+description: "Switch between Vizro's dark and light themes, use a custom Bootstrap theme, apply Vizro's Plotly templates and palettes, or reuse them in pure Dash."
+---
+
 # How to use themes and colors
 
 This guide shows you how to use themes. Themes are pre-designed collections of stylings that are applied to entire charts and dashboards. The themes provided by Vizro are infused with our design best practices that make charts and dashboards look visually consistent and professional.

--- a/vizro-core/docs/pages/user-guides/visual-formatting.md
+++ b/vizro-core/docs/pages/user-guides/visual-formatting.md
@@ -1,3 +1,7 @@
+---
+description: "Index of ways to restyle a Vizro dashboard: layout, themes and colors, static assets, custom CSS, and per-component `extra` overrides."
+---
+
 # How to customize the style of Vizro dashboards
 
 Vizro has a default styling to help users with no design experience get started. There are several options if you want to customize the style:

--- a/vizro-mcp/pyproject.toml
+++ b/vizro-mcp/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
   "mcp[cli]>=1.6.0",
   "vizro>=0.1.46",
   "click>=8.1.7",
-  "pandas[html,parquet,excel]"
+  "pandas[html,parquet,excel]",
+  "mcp<2"
 ]
 description = "MCP server to help create Vizro dashboards and charts"
 dynamic = ["version"]


### PR DESCRIPTION
## Description
Closes https://github.com/McK-Internal/vizro-internal/issues/2863

**[Built docs are here](https://vizro--1813.org.readthedocs.build/)**

Adds a `description:` field to the YAML front matter of every page under `vizro-core/docs/pages/` (54 pages) so agents and semantic search tools have per-page metadata to rank on. Zensical renders the field into `<meta name="description">` automatically, so there's no visible change to the built docs.

Follow-up to the agent-friendly docs work in #1797, which didn't include per-page metadata.

## Notes

- Each description is one sentence, ≤ 25 words, and distinct.
- Descriptions explain what the page actually covers (subheadings, features, sub-topics) rather than paraphrasing the H1.
- `docs/pages/explanation/faq.md` had existing front matter (`hide: - toc`) — the `description:` was added alongside it without disturbing other keys.
- `hatch run docs:build` is clean, `hatch run lint` is clean.
- Spot-checked the built HTML: every page emits the expected `<meta name="description" content="…">`.

## Not in scope

- `keywords:` metadata (separate follow-up if we want it).
- Any content rewrites or changes to visible rendering.

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
