### PR TITLE
Quality: Global logging configuration may cause conflicts

### DIFF
--- a/vizro-ai/src/vizro_ai/__init__.py
+++ b/vizro-ai/src/vizro_ai/__init__.py
@@ -3,5 +3,5 @@ import os
 
 __version__ = "0.4.2.dev0"
 
-# TODO: I think this collides with the VIZRO_LOG_LEVEL setting, as basicConfig can only be set once
-logging.basicConfig(level=os.getenv("VIZRO_AI_LOG_LEVEL", "INFO"))
+logger = logging.getLogger("vizro_ai")
+logger.setLevel(os.getenv("VIZRO_AI_LOG_LEVEL", "INFO"))


### PR DESCRIPTION
## Summary

Quality: Global logging configuration may cause conflicts

## Problem

**Severity**: `Medium` | **File**: `vizro-ai/src/vizro_ai/__init__.py:L1`

The `vizro_ai/__init__.py` file calls `logging.basicConfig` at the module level. As noted in the TODO comment, this can collide with the `VIZRO_LOG_LEVEL` setting and override logging configurations, since `basicConfig` is a no-op if the root logger already has handlers configured.

## Solution

Avoid calling `logging.basicConfig` at import time. Instead, provide a dedicated `setup_logging()` function for users to call, or use a custom logger configuration that doesn't affect the root logger globally.

## Changes

- `vizro-ai/src/vizro_ai/__init__.py` (modified)