### PR TITLE
[CI] Pin selenium>=4 and consolidate Dependabot action bumps

### DIFF
--- a/.github/workflows/build-vizro-whl.yml
+++ b/.github/workflows/build-vizro-whl.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install Hatch

--- a/.github/workflows/checks-vizro-ai.yml
+++ b/.github/workflows/checks-vizro-ai.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 2
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/checks-vizro-core.yml
+++ b/.github/workflows/checks-vizro-core.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 2
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/checks-vizro-dash-components.yml
+++ b/.github/workflows/checks-vizro-dash-components.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 2
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/checks-vizro-experimental.yml
+++ b/.github/workflows/checks-vizro-experimental.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 2
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/checks-vizro-mcp.yml
+++ b/.github/workflows/checks-vizro-mcp.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 2
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/checks-workflows.yml
+++ b/.github/workflows/checks-workflows.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/docs-link-checker.yml
+++ b/.github/workflows/docs-link-checker.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -18,4 +18,4 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/labeler@v6
+      - uses: actions/labeler@v7

--- a/.github/workflows/lint-vizro-all.yml
+++ b/.github/workflows/lint-vizro-all.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/pycafe-dashboards.yml
+++ b/.github/workflows/pycafe-dashboards.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install Hatch

--- a/.github/workflows/pycafe-docs-links.yml
+++ b/.github/workflows/pycafe-docs-links.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -36,7 +36,7 @@ jobs:
 
       - name: Send custom JSON data to Slack
         # used pinned commit hash for security reasons
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         if: failure()
         with:
           payload: |

--- a/.github/workflows/release-if-needed.yml
+++ b/.github/workflows/release-if-needed.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
@@ -48,7 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies
@@ -67,7 +67,7 @@ jobs:
           ${{needs.check-version.outputs.package_version}} release_body.txt
       - name: Set up Node.js for vizro-dash-components
         if: needs.check-version.outputs.package_name == 'vizro-dash-components'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 20
       - name: Generate Python components for vizro-dash-components
@@ -102,7 +102,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.VIZRO_SVC_PAT }}
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install dependencies

--- a/.github/workflows/release-vizro-e2e-flow.yml
+++ b/.github/workflows/release-vizro-e2e-flow.yml
@@ -29,7 +29,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/test-e2e-component-library-vizro-core.yml
+++ b/.github/workflows/test-e2e-component-library-vizro-core.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install Hatch

--- a/.github/workflows/test-e2e-plot-vizro-ai.yml
+++ b/.github/workflows/test-e2e-plot-vizro-ai.yml
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.config.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.config.python-version }}
       - name: Install Hatch
@@ -152,7 +152,7 @@ jobs:
       - name: Send custom JSON data to Slack
         id: slack
         # used pinned commit hash for security reasons
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         if: failure()
         with:
           payload: |

--- a/.github/workflows/test-e2e-vizro-dom-elements.yml
+++ b/.github/workflows/test-e2e-vizro-dom-elements.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test-e2e-vizro-http-requests.yml
+++ b/.github/workflows/test-e2e-vizro-http-requests.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install Hatch

--- a/.github/workflows/test-e2e-vizro-screenshots.yml
+++ b/.github/workflows/test-e2e-vizro-screenshots.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install Hatch

--- a/.github/workflows/test-integration-browser-vizro-chat-component.yml
+++ b/.github/workflows/test-integration-browser-vizro-chat-component.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/test-integration-vizro-chat-component.yml
+++ b/.github/workflows/test-integration-vizro-chat-component.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install Hatch

--- a/.github/workflows/test-integration-vizro-chat-popup.yml
+++ b/.github/workflows/test-integration-vizro-chat-popup.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install Hatch

--- a/.github/workflows/test-integration-vizro-core.yml
+++ b/.github/workflows/test-integration-vizro-core.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.config.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.config.python-version }}
       - name: Install Hatch

--- a/.github/workflows/test-unit-vizro-ai.yml
+++ b/.github/workflows/test-unit-vizro-ai.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.config.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.config.python-version }}
       - name: Install Hatch

--- a/.github/workflows/test-unit-vizro-chat-component.yml
+++ b/.github/workflows/test-unit-vizro-chat-component.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test-unit-vizro-core-js.yml
+++ b/.github/workflows/test-unit-vizro-core-js.yml
@@ -32,12 +32,12 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Hatch

--- a/.github/workflows/test-unit-vizro-core.yml
+++ b/.github/workflows/test-unit-vizro-core.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.config.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.config.python-version }}
       - name: Install Hatch

--- a/.github/workflows/test-unit-vizro-mcp.yml
+++ b/.github/workflows/test-unit-vizro-mcp.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.config.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.config.python-version }}
       - name: Install Hatch

--- a/.github/workflows/test-vizro-dash-components.yml
+++ b/.github/workflows/test-vizro-dash-components.yml
@@ -25,12 +25,12 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 20
 

--- a/.github/workflows/update-static-files.yml
+++ b/.github/workflows/update-static-files.yml
@@ -24,7 +24,7 @@ jobs:
           token: ${{ secrets.VIZRO_SVC_PAT }}
 
       - name: Set up Python ${{ matrix.config.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.config.python-version }}
       - name: Install Hatch

--- a/vizro-core/docs/pages/user-guides/data.md
+++ b/vizro-core/docs/pages/user-guides/data.md
@@ -216,7 +216,7 @@ The Vizro data manager has a server-side caching mechanism to help solve this. V
 
 <!-- vale off -->
 
-In a development environment the easiest way to enable caching is to use a [simple memory cache](https://cachelib.readthedocs.io/en/stable/simple/) with the default configuration options. This is achieved by adding one line to the [dynamic data example](#dynamic-data) to set `data_manager.cache`:
+In a development environment the easiest way to enable caching is to use a [simple memory cache](https://cachelib.readthedocs.io/en/stable/api/simple/) with the default configuration options. This is achieved by adding one line to the [dynamic data example](#dynamic-data) to set `data_manager.cache`:
 
 !!! example "Simple cache with default timeout of 5 minutes"
 
@@ -257,7 +257,7 @@ data_manager.cache = Cache(config={"CACHE_TYPE": "SimpleCache", "CACHE_DEFAULT_T
 
 !!! warning
 
-    Simple cache exists purely for single-process development purposes and is not intended to be used in production. If you deploy with multiple workers, [for example with Gunicorn](./run-deploy/#gunicorn), then you should use a production-ready cache backend. All of Flask-Caching's [built-in backends](https://flask-caching.readthedocs.io/en/latest/#built-in-cache-backends) other than `SimpleCache` are suitable for production. In particular, you might like to use [`FileSystemCache`](https://cachelib.readthedocs.io/en/stable/file/) or [`RedisCache`](https://cachelib.readthedocs.io/en/stable/redis/):
+    Simple cache exists purely for single-process development purposes and is not intended to be used in production. If you deploy with multiple workers, [for example with Gunicorn](./run-deploy/#gunicorn), then you should use a production-ready cache backend. All of Flask-Caching's [built-in backends](https://flask-caching.readthedocs.io/en/latest/#built-in-cache-backends) other than `SimpleCache` are suitable for production. In particular, you might like to use [`FileSystemCache`](https://cachelib.readthedocs.io/en/stable/api/file/) or [`RedisCache`](https://cachelib.readthedocs.io/en/stable/api/redis/):
 
     ```py title="Production-ready caches"
     # Store cached data in CACHE_DIR

--- a/vizro-dash-components/changelog.d/20260803_143649_petar_pejovic_fix_selenium_and_add_dep_bot_changes.md
+++ b/vizro-dash-components/changelog.d/20260803_143649_petar_pejovic_fix_selenium_and_add_dep_bot_changes.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Highlights ✨
+
+- A bullet item for the Highlights ✨ category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category with a link to the relevant PR at the end of your entry, e.g. Enable feature XXX. ([#1](https://github.com/mckinsey/vizro/pull/1))
+
+-->

--- a/vizro-dash-components/hatch.toml
+++ b/vizro-dash-components/hatch.toml
@@ -8,12 +8,7 @@ scripts = {add = "scriv create --add", collect = ["scriv collect --add", "- pre-
 dependencies = [
   "pre-commit",
   "dash[dev,testing]>=4,<5",  # provides dash-generate-components + dash_duo fixture
-  # dash[testing] constrains selenium to >=3.141.0,<=4.2.0. selenium 4.2.0 requires urllib3~=1.26,
-  # while the ancient 3.141.0 allows urllib3 2.x but is incompatible with it (its remote_connection
-  # raises "Timeout value connect was <object object>"). Once a transitive dep started preferring
-  # urllib3 2.x, the resolver backtracked off 4.2.0 down to the broken 3.141.0. Pinning selenium>=4
-  # forces 4.2.0, which pulls the compatible urllib3 1.26.x.
-  "selenium>=4",
+  "selenium>=4",  # Pinning selenium>=4 forces 4.2.0, which pulls the compatible urllib3 1.26.x.
   "chromedriver-autoinstaller>=0.6.4",
   "pytest"
 ]

--- a/vizro-dash-components/hatch.toml
+++ b/vizro-dash-components/hatch.toml
@@ -8,6 +8,12 @@ scripts = {add = "scriv create --add", collect = ["scriv collect --add", "- pre-
 dependencies = [
   "pre-commit",
   "dash[dev,testing]>=4,<5",  # provides dash-generate-components + dash_duo fixture
+  # dash[testing] constrains selenium to >=3.141.0,<=4.2.0. selenium 4.2.0 requires urllib3~=1.26,
+  # while the ancient 3.141.0 allows urllib3 2.x but is incompatible with it (its remote_connection
+  # raises "Timeout value connect was <object object>"). Once a transitive dep started preferring
+  # urllib3 2.x, the resolver backtracked off 4.2.0 down to the broken 3.141.0. Pinning selenium>=4
+  # forces 4.2.0, which pulls the compatible urllib3 1.26.x.
+  "selenium>=4",
   "chromedriver-autoinstaller>=0.6.4",
   "pytest"
 ]


### PR DESCRIPTION
## Description

Consolidates four Dependabot GitHub Actions bumps into one PR and fixes the **unrelated** CI failure they were surfacing.

### Dependabot bumps included (supersedes these PRs — close them)
- slackapi/slack-github-action 3.0.3 → 4.0.0 (#1819)
- actions/setup-python 6 → 7 (#1820)
- actions/setup-node 6 → 7 (#1821)
- actions/labeler 6 → 7 (#1822)

### The real fix: selenium pin

`test-vizro-dash-components` broke on `main` (and on every Dependabot PR) with 90 errors:

```
ValueError: Timeout value connect was <object object>, but it must be an int, float or None.
```

This is **not** caused by the action bumps — the identical failure appears on the `labeler` bump, which cannot touch Python tests, and `main` was green on 2026-07-30 with the same code.

Root cause: `dash[testing]` constrains `selenium>=3.141.0,<=4.2.0`. selenium 4.2.0 requires `urllib3~=1.26`; the ancient 3.141.0 allows urllib3 2.x but is incompatible with it (its `remote_connection` passes a timeout sentinel urllib3 2.x rejects). Once a transitive dep began preferring urllib3 2.x, the resolver backtracked off 4.2.0 down to the broken 3.141.0.

Pinning `selenium>=4` in `vizro-dash-components/hatch.toml` forces 4.2.0, which pulls the compatible urllib3 1.26.x — restoring the last-green combo. Verified with a fresh `uv pip compile --no-cache --python-version 3.13 --python-platform linux`.

### Note
The separate `link-check` failure (`https://stackoverflow.com/q/65877567` → 403 Forbidden, Stack Overflow blocking the bot) is pre-existing and unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
