### PR TITLE
[Docs] Remove decommissioned vizro.mckinsey.com link from examples README

### DIFF
--- a/vizro-core/examples/README.md
+++ b/vizro-core/examples/README.md
@@ -4,7 +4,7 @@ Please note that this folder contains only example dashboards that are still **i
 
 ### Vizro examples gallery
 
-To view a comprehensive list of available demos, browse the [Vizro Gallery on Hugging Face](https://huggingface.co/collections/vizro/vizro-official-gallery). There, you can explore a wide range of dashboards and applications created with Vizro.
+To view a comprehensive list of available demos, browse the [Vizro Gallery on Hugging Face](https://huggingface.co/collections/vizro/vizro-official-gallery), where you can explore a wide range of dashboards and applications created with Vizro.
 
 <a href="https://huggingface.co/collections/vizro/vizro-official-gallery">
 <img src="https://raw.githubusercontent.com/mckinsey/vizro/main/.github/images/huggingface_collection.png" alt="Vizro Gallery on Hugging Face" width="600"/>

--- a/vizro-core/examples/README.md
+++ b/vizro-core/examples/README.md
@@ -4,16 +4,8 @@ Please note that this folder contains only example dashboards that are still **i
 
 ### Vizro examples gallery
 
-To view a comprehensive list of available demos, please visit the [Vizro HuggingFace collection](https://huggingface.co/vizro). There, you can explore a wide range of dashboards and applications created with Vizro.
+To view a comprehensive list of available demos, browse the [Vizro Gallery on Hugging Face](https://huggingface.co/collections/vizro/vizro-official-gallery). There, you can explore a wide range of dashboards and applications created with Vizro.
 
-<a href="http://vizro.mckinsey.com/">
-<img src="https://raw.githubusercontent.com/mckinsey/vizro/main/.github/images/vizro_examples_gallery.png" width="600"/>
-</a>
-
-### Huggingface collection
-
-For a curated list of example dashboards, check out our [dashboard collection on Huggingface](https://huggingface.co/collections/vizro/vizro-official-gallery-66697d414646eeac61eae6de).
-
-<a href="https://huggingface.co/collections/vizro/vizro-official-gallery-66697d414646eeac61eae6de">
+<a href="https://huggingface.co/collections/vizro/vizro-official-gallery">
 <img src="https://raw.githubusercontent.com/mckinsey/vizro/main/.github/images/huggingface_collection.png" width="600"/>
 </a>

--- a/vizro-core/examples/README.md
+++ b/vizro-core/examples/README.md
@@ -7,5 +7,5 @@ Please note that this folder contains only example dashboards that are still **i
 To view a comprehensive list of available demos, browse the [Vizro Gallery on Hugging Face](https://huggingface.co/collections/vizro/vizro-official-gallery). There, you can explore a wide range of dashboards and applications created with Vizro.
 
 <a href="https://huggingface.co/collections/vizro/vizro-official-gallery">
-<img src="https://raw.githubusercontent.com/mckinsey/vizro/main/.github/images/huggingface_collection.png" width="600"/>
+<img src="https://raw.githubusercontent.com/mckinsey/vizro/main/.github/images/huggingface_collection.png" alt="Vizro Gallery on Hugging Face" width="600"/>
 </a>


### PR DESCRIPTION
## Description

`http://vizro.mckinsey.com/` is being decommissioned, so this removes the last reference to it in the repo (`vizro-core/examples/README.md`). All other `mckinsey.com` hits are contact/security email addresses, which are unaffected.

While removing it, the README is simplified. It had two sections that both pointed at the same Hugging Face gallery:

- **"Vizro examples gallery"** — the link text was already redirected to Hugging Face in #1388, but the screenshot below it was still wrapped in `<a href="http://vizro.mckinsey.com/">`. That screenshot (`.github/images/vizro_examples_gallery.png`) was deleted in #925, so the image itself was already rendering as a 404.
- **"Huggingface collection"** — same destination, using the long collection slug.

These are now a single section linking to `https://huggingface.co/collections/vizro/vizro-official-gallery`, the same short URL the root `README.md` uses. Verified both the collection URL and the remaining `huggingface_collection.png` image return 200.

No changelog fragment: docs-only change, and the check only fires on `src` changes.

## Screenshot

```markdown
## Examples

Please note that this folder contains only example dashboards that are still **in development**.

### Vizro examples gallery

To view a comprehensive list of available demos, browse the [Vizro Gallery on Hugging Face](https://huggingface.co/collections/vizro/vizro-official-gallery). There, you can explore a wide range of dashboards and applications created with Vizro.

<a href="https://huggingface.co/collections/vizro/vizro-official-gallery">
<img src="https://raw.githubusercontent.com/mckinsey/vizro/main/.github/images/huggingface_collection.png" width="600"/>
</a>
```

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)